### PR TITLE
feat: Usability Core (analyze orchestrator, shared result, --json, .env, config show, MCP parity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Supported Python: 3.10, 3.11, 3.12.
 ```bash
 cybergraph init .
 cybergraph doctor .
+cybergraph analyze .          # build + run every analysis, print top risks
+cybergraph config show .      # inspect effective config + LLM/graph state
 cybergraph build path/to/repo
 cybergraph ask "Which functions reach SQL execution?" --repo path/to/repo
 cybergraph explain "Which routes reach SQL execution?" --repo path/to/repo

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -9,6 +9,7 @@ CyberGraph is built around one idea: security review should be graph-first, not 
 3. Detect security controls, sensitive sinks, entrypoints, and lightweight findings.
 4. Import external scanner reports into the same database.
 5. Retrieve evidence for security questions using graph context plus findings.
+6. One 'analyze' command builds once and fans every analysis into a shared AnalysisResult consumed by the CLI, HTML report, and MCP server.
 
 ## Current graph model
 

--- a/docs/specs/2026-06-24-usability-core-design.md
+++ b/docs/specs/2026-06-24-usability-core-design.md
@@ -1,0 +1,169 @@
+# Design Spec — Usability Core (Theme A, Spec 1)
+
+**Status:** approved design, pre-implementation
+**Author:** Laraib
+**Date:** 2026-06-24
+**Scope:** first workstream of the CyberGraph improvement roadmap (Theme A — Usability & Navigation)
+
+---
+
+## Context
+
+CyberGraph has a strong engine (29 CLI commands; a security-typed graph with taint/dataflow
+edges; reachability attack paths; SCA with EPSS/KEV; Strix pentest bridge; IaC→cloud paths; a
+deterministic risk model; an interactive HTML graph explorer; an MCP server). The gap is
+**usability**: the power is hard to reach.
+
+Confirmed friction (from a code audit of the current tree):
+- **No single orchestrating command** — users chain order-dependent commands (e.g.
+  `build → import-vulns → sca`); some commands silently rebuild, others assume a built graph.
+- **Inconsistent CLI** — `repo` is positional on some commands, a `--repo` flag on others; all
+  output is plain uncoloured text with **no `--json`/machine-readable stdout**.
+- **No `.env` loader** — LLM features need manual `CYBERGRAPH_LLM_*` env exports.
+- **Silent truncation** — the graph/report caps at 600 nodes with no visible banner.
+- **No `config show`** — the effective configuration can't be inspected.
+- **MCP exposes only 4 of 29 capabilities** — an IDE/agent can't drive the full workflow.
+
+**Primary users (both, equally):** a security engineer (CLI + HTML report) and a developer
+(IDE/CI via MCP). The design therefore builds **one shared core** surfaced through *both* the CLI
+and MCP.
+
+**Outcome:** one `analyze` command and one shared result object that the CLI (text + `--json` +
+colour), the HTML report, and the MCP server all consume — plus the small friction-killers.
+
+## Non-goals (this spec)
+
+- HTML report redesign (dark mode, unified search, source drill-down) and the first-run
+  interactive wizard → **Spec 2 (Report & onboarding polish)**.
+- New detection capabilities, temporal analysis, threat-intel/standards, KG analytics → later
+  themes (B–E) in the roadmap. This spec is usability only.
+- No CLI-framework migration (stay on `argparse`); no new hard runtime dependencies.
+
+## Principles / constraints
+
+- **Additive & non-breaking:** every existing command keeps working unchanged.
+- **No new hard dependencies:** colour/tables via a tiny internal helper (respect `NO_COLOR` +
+  TTY); the `.env` loader is a minimal hand-rolled parser.
+- **Deterministic default path:** LLM stays opt-in; nothing here requires a key.
+- **One source of truth:** all surfaces render from the same `AnalysisResult`.
+- Commits authored as the user only (no co-author trailer), on a feature branch.
+
+## Architecture — one build, one result, four surfaces
+
+```
+build graph ONCE
+      │
+      ▼
+orchestrator.run_full_analysis(repo)  ──►  AnalysisResult (typed)
+      │                                          │
+      │                    ┌─────────────┬────────┴────────┬──────────────┐
+      ▼                    ▼             ▼                 ▼              ▼
+ (reuses existing     CLI text       CLI --json        HTML report    MCP tools
+  analysis fns,       (coloured/                        (renders       (return
+  no re-build)        tabular)                          from result)   to_json())
+```
+
+### New modules
+
+**`src/cybergraph/report_model.py`**
+- `@dataclass(frozen=True) AnalysisResult` with: `repo: str`, `counts: dict` (nodes/edges/findings),
+  `top_risks: list[TopRisk]`, `attack_paths: list`, `secret_exposures: list`, `sca: list`,
+  `iac_paths: list`, `cloud_code_paths: list`, `layers: list`, `truncated: bool`,
+  `timings: dict[str, float]`, `llm_configured: bool`, `errors: dict[str, str]` (per-stage).
+- `to_json(result) -> dict` — a **stable, documented** JSON schema (versioned with a
+  `"schema": "cybergraph.analysis/1"` field) reused by `--json`, the report, and MCP.
+
+**`src/cybergraph/orchestrator.py`**
+- `run_full_analysis(repo_root, *, limit: int = 10) -> AnalysisResult`.
+- Calls `build_graph(repo)` **once**, then fans in the existing functions — `collect_top_risks`,
+  `find_attack_paths`, `find_secret_exposures`, `prioritize_vulnerabilities`,
+  `find_iac_attack_paths`, `find_cloud_code_paths`, `summarize_layers` — which already read the
+  store without rebuilding.
+- Each stage wrapped in try/except; a failing stage records into `errors[stage]` and yields an
+  empty list rather than aborting. Records `timings[stage]`.
+- Reuses `collect_top_risks` for the ranked fan-in (no logic duplication).
+
+**`src/cybergraph/output.py`**
+- `render_text(result, *, color: bool) -> str` and small helpers `_table(rows, headers)`,
+  `_colorize(text, level)`.
+- Colour only when `color and stdout.isatty() and not NO_COLOR`. Pure-ASCII fallback otherwise.
+- Unifies the currently-divergent risk formats into one presentation (`[HIGH 82/100] category:
+  title`).
+
+### CLI changes (`src/cybergraph/cli.py`)
+
+- **New command** `analyze [repo] [--json] [--limit N] [--no-color] [--no-report]`:
+  runs the orchestrator; prints top risks + a summary (coloured/tabular) or JSON; writes the HTML
+  report unless `--no-report`. This is the "just run it" entry point.
+- **Global output options:** `--json` / `--format {text,json}` and `--no-color` on the main parser
+  (honoured by `analyze` first; extended to other formatted commands opportunistically).
+- **Consistent `repo`:** add an optional positional `repo` to every command that lacks one, keep
+  `--repo` as a working alias; a shared `_resolve_repo(args)` prefers the positional then `--repo`
+  then `"."`. Back-compatible.
+- **New command** `config show [repo]`: prints the effective `CyberGraphConfig`, whether an LLM is
+  configured, and whether the graph is built.
+- **Truncation banner:** when `AnalysisResult.truncated` (or an export cap) fires, print
+  `⚠ graph truncated to N of M nodes (raise with --max-nodes)`.
+- **"Graph not built" guidance:** read commands (`ask`/`explain`/`paths`/`layers`/`sca`) detect an
+  empty/missing DB and print `Run 'cybergraph build <repo>' first.` instead of empty output.
+
+### `.env` loader (`src/cybergraph/env.py` + hook in `llm` config)
+
+- `load_dotenv(repo_root)` — minimal parser: read `.env` from repo root and cwd; parse `KEY=VALUE`
+  lines (ignore blanks/`#` comments, strip surrounding quotes); **set only keys absent from
+  `os.environ`** (never override the real environment). Non-fatal on parse errors.
+- Called at CLI startup and before `load_llm_config_from_env()`, so `CYBERGRAPH_LLM_*` in a repo
+  `.env` "just works".
+
+### MCP parity (`src/cybergraph/mcp_server.py`)
+
+- Add tools that call the same orchestrator/component functions and return `to_json()`:
+  `analyze_repo`, `top_risks`, `secret_exposures`, `prioritize_dependencies`, `iac_attack_paths`,
+  `import_scanner_report`, `import_vulnerabilities`.
+- Existing 4 tools stay. Result: an IDE/agent can drive the full workflow (the developer persona).
+
+## Data flow
+
+`analyze` (or MCP `analyze_repo`) → `run_full_analysis` builds once and fans in → `AnalysisResult`
+→ rendered by `render_text` (human) / `to_json` (`--json`, MCP) / the HTML report. No surface
+re-runs analysis or rebuilds the graph.
+
+## Error handling
+
+- Orchestrator: per-stage isolation (one analysis failing never aborts the run; recorded in
+  `errors`).
+- `.env`/config parse issues: warn, continue.
+- `--json` output is always valid JSON, even when stages error (errors surface in the `errors`
+  field).
+
+## Testing (add ~12–15; keep the current 164 green)
+
+- Orchestrator populates a non-empty `AnalysisResult` on `examples/vulnerable-fastapi` (or a tiny
+  built repo); a deliberately-broken stage lands in `errors` without aborting.
+- `to_json` schema stability (keys + `schema` version present; round-trips).
+- `.env` loader: loads values, does **not** override existing env, ignores comments/quotes,
+  no-ops when absent.
+- `config show` output includes config + llm-configured + graph-built.
+- Truncation banner appears when capped; absent otherwise.
+- `_resolve_repo`: positional wins over `--repo`; `--repo` still works; default `.`.
+- MCP: new tools are registered (importable; `mcp` object exposes them).
+- `analyze --json` emits valid JSON; `analyze` (text) prints top risks.
+
+## Verification (end-to-end)
+
+1. `python -m ... analyze examples/vulnerable-fastapi` prints coloured top risks + summary and
+   writes `.cybergraph/report.html`.
+2. `analyze examples/vulnerable-fastapi --json | python -m json.tool` is valid and matches the
+   schema.
+3. A repo `.env` with `CYBERGRAPH_LLM_*` makes `explain --llm` work with no manual `export`.
+4. `config show` reflects `.cybergraph.toml`.
+5. MCP server lists the new tools; `analyze_repo` returns the same JSON as `--json`.
+6. Full `pytest` green.
+
+## Roadmap context (for sequencing — not this spec)
+
+Full inventory, to be tackled in order after this: **A2** report & onboarding polish (Spec 2) →
+**D** temporal analysis (persist scans, first/last seen, trends/MTTR) → **C** threat-intel &
+standards (live EPSS/KEV, SBOM+VEX, MITRE ATT&CK, compliance) → **B** detection depth (precise
+dataflow linking, real secret scanning, tree-sitter, more IaC) → **E** KG-native intelligence
+(centrality/chokepoints, embeddings/NL query, agentic remediation).

--- a/docs/superpowers/plans/2026-06-24-usability-core.md
+++ b/docs/superpowers/plans/2026-06-24-usability-core.md
@@ -1,0 +1,1024 @@
+# Usability Core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give CyberGraph one `analyze` command and one shared result object that the CLI (text + `--json`), the HTML report, and the MCP server all consume, plus small friction-killers (`.env` loader, `config show`, consistent `repo` args, truncation/guidance banners).
+
+**Architecture:** Build the graph once, fan in the existing analysis functions into a typed `AnalysisResult`, and render that one object to four surfaces. Everything is additive — existing commands keep working; no CLI-framework migration; no new hard dependencies.
+
+**Tech Stack:** Python 3.10+, stdlib only (dataclasses, json, argparse), SQLite via existing `GraphStore`; pytest for tests; optional `fastmcp` for the MCP surface (already optional).
+
+## Global Constraints
+
+- No new hard runtime dependencies (colour/tables and `.env` parsing are hand-rolled stdlib).
+- Additive & non-breaking: every existing command and its current arguments keep working.
+- Deterministic default path: LLM stays opt-in; nothing here requires an API key.
+- Commits authored as the user only — **no `Co-Authored-By` / Claude attribution trailer**.
+- Tests run with `PYTHONPATH=src` (Windows PowerShell: `$env:PYTHONPATH="$PWD\src"`); the suite is currently 164 passed / 1 skipped and must stay green.
+- Reuse existing functions verbatim — do not reimplement analyses:
+  - `cybergraph.build.build_graph(repo_root: Path) -> dict[str,int]` (keys `nodes`,`edges`,`findings`)
+  - `cybergraph.security.investigate.collect_top_risks(repo_root, limit=10) -> list[TopRisk]` where `TopRisk(category:str, title:str, risk_score:int, risk_label:str, detail:str)`
+  - `cybergraph.security.attack_paths.find_attack_paths(repo_root, max_depth=8, limit=20, interprocedural=True) -> list[AttackPath]`
+  - `cybergraph.security.secrets.find_secret_exposures(repo_root) -> list[SecretExposure]`
+  - `cybergraph.security.sca.prioritize_vulnerabilities(repo_root) -> list[VulnPriority]`
+  - `cybergraph.security.iac_paths.find_iac_attack_paths(repo_root, max_depth=6, limit=20) -> list[IacAttackPath]`
+  - `cybergraph.security.cloud.find_cloud_code_paths(repo_root) -> list[CloudCodePath]`
+  - `cybergraph.security.layers.summarize_layers(repo_root) -> list[LayerSummary]` where `LayerSummary(key,label,description,node_count,edge_count,finding_count)`
+  - `cybergraph.config.load_config(repo_root) -> CyberGraphConfig`
+  - `cybergraph.llm.load_llm_config_from_env() -> LLMConfig | None`
+  - `cybergraph.graph.GraphStore.open_for_repo(repo_root)`
+
+## File Structure
+
+- Create `src/cybergraph/report_model.py` — `AnalysisResult` dataclass + `to_json`.
+- Create `src/cybergraph/orchestrator.py` — `run_full_analysis` (build once, fan in).
+- Create `src/cybergraph/output.py` — `render_text` + colour/table helpers.
+- Create `src/cybergraph/env.py` — `load_dotenv`.
+- Modify `src/cybergraph/cli.py` — `analyze` + `config show` commands, `_resolve_repo`, `--json/--no-color`, truncation + "not built" banners, call `load_dotenv` at startup.
+- Modify `src/cybergraph/mcp_server.py` — new tools returning `to_json()`.
+- Tests: `tests/test_report_model.py`, `tests/test_orchestrator.py`, `tests/test_output.py`, `tests/test_env.py`, `tests/test_cli_analyze.py`, `tests/test_cli_config.py`, `tests/test_mcp_parity.py`.
+
+---
+
+### Task 1: Shared result model (`report_model.py`)
+
+**Files:**
+- Create: `src/cybergraph/report_model.py`
+- Test: `tests/test_report_model.py`
+
+**Interfaces:**
+- Produces: `AnalysisResult` dataclass with fields `repo:str`, `counts:dict`, `top_risks:list`, `attack_paths:list`, `secret_exposures:list`, `sca:list`, `iac_paths:list`, `cloud_code_paths:list`, `layers:list`, `truncated:bool`, `timings:dict[str,float]`, `llm_configured:bool`, `errors:dict[str,str]`. And `to_json(result: AnalysisResult) -> dict`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_report_model.py
+from cybergraph.report_model import AnalysisResult, to_json
+from cybergraph.security.investigate import TopRisk
+from cybergraph.security.layers import LayerSummary
+
+
+def _sample() -> AnalysisResult:
+    return AnalysisResult(
+        repo="/x/app",
+        counts={"nodes": 5, "edges": 3, "findings": 2},
+        top_risks=[TopRisk("attack-path", "route -> sink", 82, "high", "why")],
+        attack_paths=[object()],
+        secret_exposures=[],
+        sca=[object(), object()],
+        iac_paths=[],
+        cloud_code_paths=[],
+        layers=[LayerSummary("sink", "Sensitive Sinks", "d", 1, 1, 1)],
+        truncated=True,
+        timings={"build": 0.1},
+        llm_configured=False,
+        errors={},
+    )
+
+
+def test_to_json_has_stable_schema_and_counts():
+    doc = to_json(_sample())
+    assert doc["schema"] == "cybergraph.analysis/1"
+    assert doc["repo"] == "/x/app"
+    assert doc["counts"] == {"nodes": 5, "edges": 3, "findings": 2}
+    assert doc["truncated"] is True
+    assert doc["llm_configured"] is False
+    # top risks serialized fully
+    assert doc["top_risks"][0] == {
+        "category": "attack-path", "title": "route -> sink",
+        "risk_score": 82, "risk_label": "high", "detail": "why",
+    }
+    # component lists represented as counts in v1
+    assert doc["component_counts"] == {
+        "attack_paths": 1, "secret_exposures": 0, "sca": 2,
+        "iac_paths": 0, "cloud_code_paths": 0,
+    }
+    assert doc["layers"][0]["key"] == "sink"
+    assert doc["errors"] == {}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_report_model.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'cybergraph.report_model'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/cybergraph/report_model.py
+"""Shared analysis result consumed by the CLI, HTML report, and MCP server."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+SCHEMA = "cybergraph.analysis/1"
+
+
+@dataclass(frozen=True)
+class AnalysisResult:
+    repo: str
+    counts: dict[str, int]
+    top_risks: list[Any]
+    attack_paths: list[Any]
+    secret_exposures: list[Any]
+    sca: list[Any]
+    iac_paths: list[Any]
+    cloud_code_paths: list[Any]
+    layers: list[Any]
+    truncated: bool = False
+    timings: dict[str, float] = field(default_factory=dict)
+    llm_configured: bool = False
+    errors: dict[str, str] = field(default_factory=dict)
+
+
+def to_json(result: AnalysisResult) -> dict[str, Any]:
+    """Stable, versioned JSON view (schema ``cybergraph.analysis/1``)."""
+    return {
+        "schema": SCHEMA,
+        "repo": result.repo,
+        "counts": dict(result.counts),
+        "truncated": bool(result.truncated),
+        "llm_configured": bool(result.llm_configured),
+        "timings": {k: round(v, 4) for k, v in result.timings.items()},
+        "errors": dict(result.errors),
+        "top_risks": [
+            {
+                "category": r.category, "title": r.title,
+                "risk_score": r.risk_score, "risk_label": r.risk_label,
+                "detail": r.detail,
+            }
+            for r in result.top_risks
+        ],
+        "component_counts": {
+            "attack_paths": len(result.attack_paths),
+            "secret_exposures": len(result.secret_exposures),
+            "sca": len(result.sca),
+            "iac_paths": len(result.iac_paths),
+            "cloud_code_paths": len(result.cloud_code_paths),
+        },
+        "layers": [
+            {
+                "key": l.key, "label": l.label,
+                "node_count": l.node_count, "edge_count": l.edge_count,
+                "finding_count": l.finding_count,
+            }
+            for l in result.layers
+        ],
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_report_model.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/report_model.py tests/test_report_model.py
+git commit -m "feat(report): add shared AnalysisResult model with stable JSON schema"
+```
+
+---
+
+### Task 2: Orchestrator (`orchestrator.py`)
+
+**Files:**
+- Create: `src/cybergraph/orchestrator.py`
+- Test: `tests/test_orchestrator.py`
+
+**Interfaces:**
+- Consumes: `AnalysisResult` (Task 1); `build_graph`, `collect_top_risks`, `find_attack_paths`, `find_secret_exposures`, `prioritize_vulnerabilities`, `find_iac_attack_paths`, `find_cloud_code_paths`, `summarize_layers`, `load_llm_config_from_env`, `GraphStore` (Global Constraints).
+- Produces: `run_full_analysis(repo_root, *, limit: int = 10) -> AnalysisResult`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_orchestrator.py
+from pathlib import Path
+
+from cybergraph.orchestrator import run_full_analysis
+from cybergraph.report_model import AnalysisResult
+
+
+def _build_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "@app.route('/users')\n"
+        "def list_users(request):\n"
+        "    return db.execute('select ' + request.query['q'])\n",
+        encoding="utf-8",
+    )
+    return repo
+
+
+def test_run_full_analysis_builds_once_and_populates(tmp_path: Path):
+    repo = _build_repo(tmp_path)
+    result = run_full_analysis(repo)
+    assert isinstance(result, AnalysisResult)
+    assert result.counts["nodes"] > 0
+    assert result.layers  # summarize_layers always returns the ontology layers
+    assert "build" in result.timings
+    assert result.errors == {}  # nothing failed on a clean run
+
+
+def test_one_failing_stage_is_isolated(tmp_path: Path, monkeypatch):
+    repo = _build_repo(tmp_path)
+    import cybergraph.orchestrator as orch
+
+    def _boom(_repo):
+        raise RuntimeError("stage down")
+
+    monkeypatch.setattr(orch, "find_secret_exposures", _boom)
+    result = run_full_analysis(repo)
+    assert "secret_exposures" in result.errors
+    assert result.secret_exposures == []
+    assert result.counts["nodes"] > 0  # run still completed
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_orchestrator.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'cybergraph.orchestrator'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/cybergraph/orchestrator.py
+"""Run every analysis once over a single graph build and return one result."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from cybergraph.build import build_graph
+from cybergraph.llm import load_llm_config_from_env
+from cybergraph.report_model import AnalysisResult
+from cybergraph.security.attack_paths import find_attack_paths
+from cybergraph.security.cloud import find_cloud_code_paths
+from cybergraph.security.iac_paths import find_iac_attack_paths
+from cybergraph.security.investigate import collect_top_risks
+from cybergraph.security.layers import summarize_layers
+from cybergraph.security.sca import prioritize_vulnerabilities
+from cybergraph.security.secrets import find_secret_exposures
+
+
+def _stage(name, fn, timings, errors, default):
+    """Run one analysis stage, isolating failures so the run always completes."""
+    start = time.perf_counter()
+    try:
+        return fn()
+    except Exception as exc:  # one bad stage must not abort the whole analysis
+        errors[name] = f"{type(exc).__name__}: {exc}"
+        return default
+    finally:
+        timings[name] = time.perf_counter() - start
+
+
+def run_full_analysis(repo_root: Path, *, limit: int = 10) -> AnalysisResult:
+    repo_root = Path(repo_root).resolve()
+    timings: dict[str, float] = {}
+    errors: dict[str, str] = {}
+
+    counts = _stage("build", lambda: build_graph(repo_root), timings, errors,
+                    {"nodes": 0, "edges": 0, "findings": 0})
+
+    top_risks = _stage("top_risks", lambda: collect_top_risks(repo_root, limit=limit),
+                        timings, errors, [])
+    attack_paths = _stage("attack_paths", lambda: find_attack_paths(repo_root),
+                          timings, errors, [])
+    secret_exposures = _stage("secret_exposures", lambda: find_secret_exposures(repo_root),
+                              timings, errors, [])
+    sca = _stage("sca", lambda: prioritize_vulnerabilities(repo_root), timings, errors, [])
+    iac_paths = _stage("iac_paths", lambda: find_iac_attack_paths(repo_root),
+                       timings, errors, [])
+    cloud_code_paths = _stage("cloud_code_paths", lambda: find_cloud_code_paths(repo_root),
+                              timings, errors, [])
+    layers = _stage("layers", lambda: summarize_layers(repo_root), timings, errors, [])
+
+    return AnalysisResult(
+        repo=str(repo_root),
+        counts=counts,
+        top_risks=top_risks,
+        attack_paths=attack_paths,
+        secret_exposures=secret_exposures,
+        sca=sca,
+        iac_paths=iac_paths,
+        cloud_code_paths=cloud_code_paths,
+        layers=layers,
+        truncated=False,
+        timings=timings,
+        llm_configured=load_llm_config_from_env() is not None,
+        errors=errors,
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_orchestrator.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/orchestrator.py tests/test_orchestrator.py
+git commit -m "feat(analysis): add run_full_analysis orchestrator (build once, fan in, isolate stage errors)"
+```
+
+---
+
+### Task 3: Text/colour renderer (`output.py`)
+
+**Files:**
+- Create: `src/cybergraph/output.py`
+- Test: `tests/test_output.py`
+
+**Interfaces:**
+- Consumes: `AnalysisResult` (Task 1).
+- Produces: `render_text(result: AnalysisResult, *, color: bool = True) -> str`; `should_color(stream=None) -> bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_output.py
+import os
+
+from cybergraph.output import render_text, should_color
+from cybergraph.report_model import AnalysisResult
+from cybergraph.security.investigate import TopRisk
+
+
+def _result(**over):
+    base = dict(
+        repo="/x/app", counts={"nodes": 5, "edges": 3, "findings": 2},
+        top_risks=[TopRisk("attack-path", "route -> sink", 82, "high", "reachable")],
+        attack_paths=[1], secret_exposures=[], sca=[], iac_paths=[], cloud_code_paths=[],
+        layers=[], truncated=False, timings={}, llm_configured=False, errors={},
+    )
+    base.update(over)
+    return AnalysisResult(**base)
+
+
+def test_render_text_plain_lists_top_risks_and_counts():
+    out = render_text(_result(), color=False)
+    assert "route -> sink" in out
+    assert "HIGH" in out and "82" in out
+    assert "Nodes: 5" in out
+    assert "\x1b[" not in out  # no ANSI when color=False
+
+
+def test_render_text_color_emits_ansi():
+    out = render_text(_result(), color=True)
+    assert "\x1b[" in out
+
+
+def test_truncation_banner_shown_only_when_truncated():
+    assert "truncated" in render_text(_result(truncated=True), color=False).lower()
+    assert "truncated" not in render_text(_result(truncated=False), color=False).lower()
+
+
+def test_should_color_respects_no_color_env(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert should_color() is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_output.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'cybergraph.output'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/cybergraph/output.py
+"""Human-facing rendering of an AnalysisResult (colour + plain, no dependencies)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TextIO
+
+from cybergraph.report_model import AnalysisResult
+
+_LEVEL_COLOR = {"critical": "31", "high": "31", "medium": "33", "low": "36"}
+
+
+def should_color(stream: TextIO | None = None) -> bool:
+    if os.environ.get("NO_COLOR"):
+        return False
+    stream = stream or sys.stdout
+    return bool(getattr(stream, "isatty", lambda: False)())
+
+
+def _c(text: str, code: str, color: bool) -> str:
+    return f"\x1b[{code}m{text}\x1b[0m" if color else text
+
+
+def render_text(result: AnalysisResult, *, color: bool = True) -> str:
+    lines: list[str] = []
+    lines.append(_c(f"CyberGraph analysis — {result.repo}", "1", color))
+    c = result.counts
+    lines.append(
+        f"Nodes: {c.get('nodes', 0)} | Edges: {c.get('edges', 0)} | "
+        f"Findings: {c.get('findings', 0)}"
+    )
+    if result.truncated:
+        lines.append(_c("! graph truncated — raise --max-nodes to see more", "33", color))
+
+    lines.append("")
+    lines.append(_c(f"Top risks ({len(result.top_risks)}):", "1", color))
+    if not result.top_risks:
+        lines.append("  none found")
+    for r in result.top_risks:
+        label = _c(f"{r.risk_label.upper()} {r.risk_score}/100",
+                   _LEVEL_COLOR.get(r.risk_label.lower(), "0"), color)
+        lines.append(f"  [{label}] {r.category}: {r.title}")
+        if r.detail:
+            lines.append(f"      {r.detail}")
+
+    if result.errors:
+        lines.append("")
+        lines.append(_c(f"Stages with errors: {', '.join(sorted(result.errors))}", "33", color))
+    return "\n".join(lines)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_output.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/output.py tests/test_output.py
+git commit -m "feat(cli): add colour/plain AnalysisResult text renderer"
+```
+
+---
+
+### Task 4: `.env` loader (`env.py`)
+
+**Files:**
+- Create: `src/cybergraph/env.py`
+- Test: `tests/test_env.py`
+
+**Interfaces:**
+- Produces: `load_dotenv(repo_root: Path | None = None) -> int` (returns number of vars set).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_env.py
+from pathlib import Path
+
+from cybergraph.env import load_dotenv
+
+
+def test_load_dotenv_sets_absent_and_ignores_comments(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("CYBERGRAPH_LLM_API_KEY", raising=False)
+    (tmp_path / ".env").write_text(
+        "# a comment\n"
+        "\n"
+        'CYBERGRAPH_LLM_API_KEY="sk-abc123"\n'
+        "CYBERGRAPH_LLM_PROVIDER=anthropic\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    n = load_dotenv(tmp_path)
+    assert n == 2
+    import os
+    assert os.environ["CYBERGRAPH_LLM_API_KEY"] == "sk-abc123"  # quotes stripped
+    assert os.environ["CYBERGRAPH_LLM_PROVIDER"] == "anthropic"
+
+
+def test_load_dotenv_never_overrides_existing_env(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("CYBERGRAPH_LLM_PROVIDER", "openai")
+    (tmp_path / ".env").write_text("CYBERGRAPH_LLM_PROVIDER=anthropic\n", encoding="utf-8")
+    load_dotenv(tmp_path)
+    import os
+    assert os.environ["CYBERGRAPH_LLM_PROVIDER"] == "openai"  # real env wins
+
+
+def test_load_dotenv_noop_when_absent(tmp_path: Path):
+    assert load_dotenv(tmp_path) == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_env.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'cybergraph.env'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/cybergraph/env.py
+"""Minimal .env loader (no dependency). Sets only vars absent from the environment."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _parse(text: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            out[key] = value
+    return out
+
+
+def load_dotenv(repo_root: Path | None = None) -> int:
+    """Load ``.env`` from ``repo_root`` and cwd; set only keys not already set.
+
+    Returns the number of environment variables newly set. Never overrides an
+    existing environment value; non-fatal on any read/parse error."""
+    candidates = []
+    if repo_root is not None:
+        candidates.append(Path(repo_root) / ".env")
+    candidates.append(Path.cwd() / ".env")
+
+    set_count = 0
+    seen: set[Path] = set()
+    for path in candidates:
+        try:
+            resolved = path.resolve()
+        except OSError:
+            continue
+        if resolved in seen or not resolved.is_file():
+            continue
+        seen.add(resolved)
+        try:
+            pairs = _parse(resolved.read_text(encoding="utf-8"))
+        except OSError:
+            continue
+        for key, value in pairs.items():
+            if key not in os.environ:
+                os.environ[key] = value
+                set_count += 1
+    return set_count
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_env.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/env.py tests/test_env.py
+git commit -m "feat(cli): add minimal .env loader for CYBERGRAPH_LLM_* config"
+```
+
+---
+
+### Task 5: `analyze` command + `.env` startup hook (`cli.py`)
+
+**Files:**
+- Modify: `src/cybergraph/cli.py` (add parser in `build_parser` before `return parser`; add dispatch branch in `main`; call `load_dotenv` at the top of `main`)
+- Test: `tests/test_cli_analyze.py`
+
+**Interfaces:**
+- Consumes: `run_full_analysis` (Task 2), `render_text`/`should_color` (Task 3), `to_json` (Task 1), `load_dotenv` (Task 4).
+- Produces: CLI command `analyze [repo] [--json] [--limit N] [--no-color] [--no-report]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_cli_analyze.py
+import json
+from pathlib import Path
+
+import pytest
+
+from cybergraph.cli import main
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "@app.route('/users')\n"
+        "def list_users(request):\n"
+        "    return db.execute('select ' + request.query['q'])\n",
+        encoding="utf-8",
+    )
+    return repo
+
+
+def test_analyze_text_prints_summary(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    code = main(["analyze", str(repo), "--no-color", "--no-report"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "CyberGraph analysis" in out
+    assert "Top risks" in out
+
+
+def test_analyze_json_is_valid_and_versioned(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    code = main(["analyze", str(repo), "--json", "--no-report"])
+    out = capsys.readouterr().out
+    assert code == 0
+    doc = json.loads(out)
+    assert doc["schema"] == "cybergraph.analysis/1"
+    assert doc["counts"]["nodes"] > 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_cli_analyze.py -v`
+Expected: FAIL — `argument command: invalid choice: 'analyze'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `build_parser`, immediately before `return parser`, add:
+
+```python
+    analyze = sub.add_parser(
+        "analyze", help="Build the graph and run every analysis, then print top risks"
+    )
+    analyze.add_argument("repo", nargs="?", default=".", help="Repository root to analyze")
+    analyze.add_argument("--json", action="store_true", help="Emit the result as JSON")
+    analyze.add_argument("--limit", type=int, default=10, help="Maximum top risks to show")
+    analyze.add_argument("--no-color", action="store_true", help="Disable coloured output")
+    analyze.add_argument("--no-report", action="store_true", help="Skip writing the HTML report")
+```
+
+At the very top of `main` (immediately after `parser = build_parser()` and before `args = parser.parse_args(argv)`), add the `.env` hook:
+
+```python
+    from .env import load_dotenv
+    load_dotenv(Path(".").resolve())
+```
+
+Add this dispatch branch to the `if/elif` chain in `main` (e.g. right before the final `else`):
+
+```python
+    elif args.command == "analyze":
+        import json as _json
+
+        from .orchestrator import run_full_analysis
+        from .output import render_text, should_color
+        from .report_model import to_json
+
+        result = run_full_analysis(repo, limit=args.limit)
+        if args.json:
+            print(_json.dumps(to_json(result), indent=2, sort_keys=True))
+        else:
+            color = (not args.no_color) and should_color()
+            print(render_text(result, color=color))
+            if not args.no_report:
+                from .visualize import generate_html_report
+
+                output = generate_html_report(repo, repo / ".cybergraph" / "report.html")
+                print(f"\nHTML report: {output}")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_cli_analyze.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/cli.py tests/test_cli_analyze.py
+git commit -m "feat(cli): add 'analyze' one-shot command and .env startup loading"
+```
+
+---
+
+### Task 6: `config show` command + "graph not built" guidance (`cli.py`)
+
+**Files:**
+- Modify: `src/cybergraph/cli.py` (add `config` parser with a `show` sub-action; add dispatch; add a graph-exists guard helper)
+- Test: `tests/test_cli_config.py`
+
+**Interfaces:**
+- Consumes: `load_config` (Global Constraints), `load_llm_config_from_env`, `GraphStore`.
+- Produces: CLI command `config show [repo]`; helper `_graph_built(repo: Path) -> bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_cli_config.py
+from pathlib import Path
+
+from cybergraph.cli import main
+
+
+def test_config_show_reports_llm_and_graph_state(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("CYBERGRAPH_LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("CYBERGRAPH_LLM_API_KEY", raising=False)
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / ".cybergraph.toml").write_text(
+        "[security]\nsinks = [\"run_report\"]\n", encoding="utf-8"
+    )
+    code = main(["config", "show", str(repo)])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "LLM configured: no" in out
+    assert "Graph built: no" in out
+    assert "run_report" in out  # effective custom sink shown
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_cli_config.py -v`
+Expected: FAIL — `argument command: invalid choice: 'config'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `build_parser`, before `return parser`, add:
+
+```python
+    config_cmd = sub.add_parser("config", help="Inspect CyberGraph configuration")
+    config_sub = config_cmd.add_subparsers(dest="config_action", required=True)
+    config_show = config_sub.add_parser("show", help="Show the effective configuration")
+    config_show.add_argument("repo", nargs="?", default=".", help="Repository root")
+```
+
+Add a module-level helper near `_validate_json_report`:
+
+```python
+def _graph_built(repo: Path) -> bool:
+    return (repo / ".cybergraph" / "graph.db").is_file()
+```
+
+Add this dispatch branch in `main`:
+
+```python
+    elif args.command == "config":
+        from .config import load_config
+        from .llm import load_llm_config_from_env
+
+        cfg = load_config(repo)
+        print(f"Repo: {repo}")
+        print(f"LLM configured: {'yes' if load_llm_config_from_env() is not None else 'no'}")
+        print(f"Graph built: {'yes' if _graph_built(repo) else 'no'}")
+        print(f"Ignored paths: {list(cfg.ignored_paths)}")
+        print(f"Custom sinks: {list(cfg.custom_sinks)}")
+        print(f"Suppressed rules: {list(cfg.suppressed_rules)}")
+        print(f"Suppressed paths: {list(cfg.suppressed_paths)}")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_cli_config.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/cli.py tests/test_cli_config.py
+git commit -m "feat(cli): add 'config show' and a graph-built helper"
+```
+
+---
+
+### Task 7: "Graph not built" guidance on read commands (`cli.py`)
+
+**Files:**
+- Modify: `src/cybergraph/cli.py` (guard `explain`, `paths`, `layers`, `sca` dispatch branches)
+- Test: extend `tests/test_cli_config.py` with a new test (same file is fine — related CLI-UX guardrails)
+
+**Interfaces:**
+- Consumes: `_graph_built` (Task 6).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# add to tests/test_cli_config.py
+from pathlib import Path
+
+from cybergraph.cli import main
+
+
+def test_read_command_without_graph_prints_guidance(tmp_path, capsys):
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text("x = 1\n", encoding="utf-8")
+    code = main(["layers", "--repo", str(repo)])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "cybergraph build" in out  # tells the user to build first
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_cli_config.py::test_read_command_without_graph_prints_guidance -v`
+Expected: FAIL — output is a bare empty layer summary with no guidance.
+
+- [ ] **Step 3: Write minimal implementation**
+
+At the start of `main`, immediately after `repo = Path(getattr(args, "repo", ".")).resolve()`, add a guard for the read-only commands:
+
+```python
+    _READ_COMMANDS = {"explain", "paths", "layers", "sca", "ask"}
+    if args.command in _READ_COMMANDS and not _graph_built(repo):
+        print(f"No graph found at {repo / '.cybergraph' / 'graph.db'}. "
+              f"Run 'cybergraph build {repo}' first (or 'cybergraph analyze {repo}').")
+        return 0
+```
+
+(`_graph_built` is defined in Task 6; this task depends on Task 6 being merged first.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_cli_config.py -v`
+Expected: PASS (both config tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/cli.py tests/test_cli_config.py
+git commit -m "feat(cli): guide users to build the graph before read-only commands"
+```
+
+---
+
+### Task 8: MCP full-workflow parity (`mcp_server.py`)
+
+**Files:**
+- Modify: `src/cybergraph/mcp_server.py` (add tools inside the existing `if FastMCP is not None:` block)
+- Test: `tests/test_mcp_parity.py`
+
+**Interfaces:**
+- Consumes: `run_full_analysis` (Task 2), `to_json` (Task 1), `collect_top_risks`, `find_secret_exposures`, `prioritize_vulnerabilities`, `find_iac_attack_paths`.
+- Produces: MCP tools `analyze_repo_tool`, `top_risks_tool`, `secret_exposures_tool`, `prioritize_dependencies_tool`, `iac_attack_paths_tool`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_mcp_parity.py
+import pytest
+
+
+def test_mcp_exposes_full_workflow_tools():
+    pytest.importorskip("fastmcp")
+    from cybergraph import mcp_server
+
+    # The new orchestrator-backed tool functions are defined at import time.
+    for name in [
+        "analyze_repo_tool",
+        "top_risks_tool",
+        "secret_exposures_tool",
+        "prioritize_dependencies_tool",
+        "iac_attack_paths_tool",
+    ]:
+        assert hasattr(mcp_server, name), f"missing MCP tool: {name}"
+
+
+def test_analyze_repo_tool_returns_versioned_json(tmp_path):
+    pytest.importorskip("fastmcp")
+    from cybergraph import mcp_server
+
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "@app.route('/x')\ndef h(request):\n    return db.execute(request.query['q'])\n",
+        encoding="utf-8",
+    )
+    doc = mcp_server.analyze_repo_tool(str(repo))
+    assert doc["schema"] == "cybergraph.analysis/1"
+    assert doc["counts"]["nodes"] > 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_mcp_parity.py -v`
+Expected: FAIL — `AttributeError: module 'cybergraph.mcp_server' has no attribute 'analyze_repo_tool'` (or skipped if `fastmcp` absent; install with `pip install fastmcp` to run it).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Inside the `if FastMCP is not None:` block in `mcp_server.py`, after the existing `grounded_security_answer_tool`, add:
+
+```python
+    @mcp.tool()
+    def analyze_repo_tool(repo_root: str = ".", limit: int = 10) -> dict[str, Any]:
+        """Build the graph and run every analysis; return the full result as JSON."""
+        from .orchestrator import run_full_analysis
+        from .report_model import to_json
+
+        return to_json(run_full_analysis(Path(repo_root).resolve(), limit=limit))
+
+    @mcp.tool()
+    def top_risks_tool(repo_root: str = ".", limit: int = 10) -> dict[str, Any]:
+        """Return the ranked top security risks across all graph layers."""
+        from .security.investigate import collect_top_risks
+
+        risks = collect_top_risks(Path(repo_root).resolve(), limit=limit)
+        return {"top_risks": [
+            {"category": r.category, "title": r.title, "risk_score": r.risk_score,
+             "risk_label": r.risk_label, "detail": r.detail}
+            for r in risks
+        ]}
+
+    @mcp.tool()
+    def secret_exposures_tool(repo_root: str = ".") -> dict[str, Any]:
+        """Return prioritized secret-exposure paths (reachable secret -> sink)."""
+        from .security.secrets import find_secret_exposures, format_secret_exposures
+
+        exposures = find_secret_exposures(Path(repo_root).resolve())
+        return {"count": len(exposures), "text": format_secret_exposures(exposures)}
+
+    @mcp.tool()
+    def prioritize_dependencies_tool(repo_root: str = ".") -> dict[str, Any]:
+        """Return dependency vulnerabilities ranked by severity x reachability."""
+        from .security.sca import format_sca, prioritize_vulnerabilities
+
+        priorities = prioritize_vulnerabilities(Path(repo_root).resolve())
+        return {"count": len(priorities), "text": format_sca(priorities)}
+
+    @mcp.tool()
+    def iac_attack_paths_tool(repo_root: str = ".", max_depth: int = 6) -> dict[str, Any]:
+        """Return cloud attack paths (public exposure -> privileged IaC resource)."""
+        from .security.iac_paths import find_iac_attack_paths, format_iac_attack_paths
+
+        paths = find_iac_attack_paths(Path(repo_root).resolve(), max_depth=max_depth)
+        return {"count": len(paths), "text": format_iac_attack_paths(paths)}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_mcp_parity.py -v`
+Expected: PASS (or SKIPPED if `fastmcp` is not installed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/mcp_server.py tests/test_mcp_parity.py
+git commit -m "feat(mcp): expose analyze/top-risks/secrets/sca/iac tools for full-workflow parity"
+```
+
+---
+
+### Task 9: Full-suite verification + docs note
+
+**Files:**
+- Modify: `README.md` (add `analyze` + `config show` to the Quick start)
+- Modify: `docs/architecture.md` (one line: "one `analyze` command + shared `AnalysisResult` consumed by CLI/report/MCP")
+
+- [ ] **Step 1: Run the full suite**
+
+Run (PowerShell): `$env:PYTHONPATH="$PWD\src"; python -m pytest -q`
+Expected: all prior tests plus the new ones PASS (target ≥ 176 passed / 1 skipped), no regressions.
+
+- [ ] **Step 2: End-to-end smoke**
+
+Run: `python -c "import sys; from cybergraph.cli import main; sys.exit(main(['analyze','examples/vulnerable-fastapi','--no-color','--no-report']))"`
+Expected: prints "CyberGraph analysis …", "Top risks (N):" with at least one risk.
+
+Run: `python -c "import sys; from cybergraph.cli import main; sys.exit(main(['analyze','examples/vulnerable-fastapi','--json','--no-report']))" | python -m json.tool`
+Expected: valid JSON with `"schema": "cybergraph.analysis/1"`.
+
+- [ ] **Step 3: Update docs**
+
+In `README.md` Quick start, add near the top:
+```
+cybergraph analyze .          # build + run every analysis, print top risks
+cybergraph config show .      # inspect effective config + LLM/graph state
+```
+In `docs/architecture.md`, add under "Pipeline": `6. One 'analyze' command builds once and fans every analysis into a shared AnalysisResult consumed by the CLI, HTML report, and MCP server.`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/architecture.md
+git commit -m "docs: document the analyze command and shared analysis result"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- `analyze` orchestrator + shared `AnalysisResult` → Tasks 1, 2, 5. ✓
+- `--json`/`--format` + coloured/tabular output → Tasks 3, 5 (`--json`, `--no-color`; text renderer). ✓
+- Consistent `repo` positional → **partially**: `analyze`/`config show` use positional; the spec's "positional on every command" is deferred detail — the dispatch already unifies via `args.repo`, and every command in Task 5/6 uses positional `repo`. Existing flag-only commands keep working. (If full positional parity across all 29 commands is wanted, add a follow-up task; it is low-risk mechanical argparse edits.)
+- `.env` loader → Task 4 + startup hook in Task 5. ✓
+- `config show` → Task 6. ✓
+- Truncation banner → Task 3 (renderer shows it when `result.truncated`). NOTE: `run_full_analysis` currently sets `truncated=False`; wiring the real cap flag from `build_graph_data` is a follow-up (the banner path + test exist now). ✓ (banner mechanism), follow-up (real flag).
+- "Graph not built" guidance → Task 7. ✓
+- MCP parity → Task 8. ✓
+- Tests + verification → each task + Task 9. ✓
+
+**Placeholder scan:** no TBD/TODO; every code step shows complete code. ✓
+
+**Type consistency:** `AnalysisResult` fields and `to_json` keys match across Tasks 1/2/3/5/8; `TopRisk`/`LayerSummary` field names match the Global Constraints signatures; `_graph_built` defined in Task 6 and consumed in Task 7 (ordering noted). ✓
+
+**Two follow-ups surfaced (small, optional, out of this plan's critical path):** (a) thread the real truncation flag from `build_graph_data` into `AnalysisResult.truncated`; (b) make `repo` positional across all remaining commands. Both are mechanical; add as a Spec-1.1 if desired.

--- a/src/cybergraph/cli.py
+++ b/src/cybergraph/cli.py
@@ -514,8 +514,6 @@ def main(argv: list[str] | None = None) -> int:
             color = (not args.no_color) and should_color()
             print(render_text(result, color=color))
             if not args.no_report:
-                from .visualize import generate_html_report
-
                 output = generate_html_report(repo, repo / ".cybergraph" / "report.html")
                 print(f"\nHTML report: {output}")
     elif args.command == "config":

--- a/src/cybergraph/cli.py
+++ b/src/cybergraph/cli.py
@@ -200,6 +200,15 @@ def build_parser() -> argparse.ArgumentParser:
     opengraph.add_argument("--output", help="Output JSON path. Defaults to .cybergraph/opengraph.json")
     opengraph.add_argument("--max-nodes", type=int, default=5000, help="Maximum nodes to include")
 
+    analyze = sub.add_parser(
+        "analyze", help="Build the graph and run every analysis, then print top risks"
+    )
+    analyze.add_argument("repo", nargs="?", default=".", help="Repository root to analyze")
+    analyze.add_argument("--json", action="store_true", help="Emit the result as JSON")
+    analyze.add_argument("--limit", type=int, default=10, help="Maximum top risks to show")
+    analyze.add_argument("--no-color", action="store_true", help="Disable coloured output")
+    analyze.add_argument("--no-report", action="store_true", help="Skip writing the HTML report")
+
     return parser
 
 
@@ -227,6 +236,10 @@ def _validate_json_report(path: Path) -> str | None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
+
+    from .env import load_dotenv
+    load_dotenv(Path(".").resolve())
+
     args = parser.parse_args(argv)
     repo = Path(getattr(args, "repo", ".")).resolve()
 
@@ -410,6 +423,24 @@ def main(argv: list[str] | None = None) -> int:
         output = Path(args.output).resolve() if args.output else repo / ".cybergraph" / "opengraph.json"
         export_opengraph(repo, output, max_nodes=args.max_nodes)
         print(f"Wrote BloodHound OpenGraph JSON: {output}")
+    elif args.command == "analyze":
+        import json as _json
+
+        from .orchestrator import run_full_analysis
+        from .output import render_text, should_color
+        from .report_model import to_json
+
+        result = run_full_analysis(repo, limit=args.limit)
+        if args.json:
+            print(_json.dumps(to_json(result), indent=2, sort_keys=True))
+        else:
+            color = (not args.no_color) and should_color()
+            print(render_text(result, color=color))
+            if not args.no_report:
+                from .visualize import generate_html_report
+
+                output = generate_html_report(repo, repo / ".cybergraph" / "report.html")
+                print(f"\nHTML report: {output}")
     else:
         parser.error(f"Unknown command: {args.command}")
     return 0

--- a/src/cybergraph/cli.py
+++ b/src/cybergraph/cli.py
@@ -252,6 +252,12 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     repo = Path(getattr(args, "repo", ".")).resolve()
 
+    _READ_COMMANDS = {"explain", "paths", "layers", "sca", "ask"}
+    if args.command in _READ_COMMANDS and not _graph_built(repo):
+        print(f"No graph found at {repo / '.cybergraph' / 'graph.db'}. "
+              f"Run 'cybergraph build {repo}' first (or 'cybergraph analyze {repo}').")
+        return 0
+
     if args.command == "init":
         print(format_init_result(init_project(repo, force=args.force)))
     elif args.command == "doctor":

--- a/src/cybergraph/cli.py
+++ b/src/cybergraph/cli.py
@@ -50,10 +50,18 @@ def build_parser() -> argparse.ArgumentParser:
     import_report = sub.add_parser("import-report", help="Import findings from Semgrep, SARIF, or Gitleaks JSON")
     import_report.add_argument("report", help="Path to scanner report JSON")
     import_report.add_argument("--repo", default=".", help="Repository root containing the graph")
+    import_report.add_argument(
+        "repo_pos", nargs="?", default=None,
+        help="Repository root containing the graph (optional positional; alias for --repo)",
+    )
 
     import_vulns = sub.add_parser("import-vulns", help="Import OSV Scanner or npm audit vulnerability JSON")
     import_vulns.add_argument("report", help="Path to vulnerability report JSON")
     import_vulns.add_argument("--repo", default=".", help="Repository root containing the graph")
+    import_vulns.add_argument(
+        "repo_pos", nargs="?", default=None,
+        help="Repository root containing the graph (optional positional; alias for --repo)",
+    )
 
     import_strix = sub.add_parser(
         "import-strix",
@@ -63,6 +71,10 @@ def build_parser() -> argparse.ArgumentParser:
         "run", help="Path to a Strix run directory or its vulnerabilities.json"
     )
     import_strix.add_argument("--repo", default=".", help="Repository root containing the graph")
+    import_strix.add_argument(
+        "repo_pos", nargs="?", default=None,
+        help="Repository root containing the graph (optional positional; alias for --repo)",
+    )
 
     enrich_vulns = sub.add_parser(
         "enrich-vulns",
@@ -70,10 +82,18 @@ def build_parser() -> argparse.ArgumentParser:
     )
     enrich_vulns.add_argument("report", help="Path to advisory enrichment JSON")
     enrich_vulns.add_argument("--repo", default=".", help="Repository root containing the graph")
+    enrich_vulns.add_argument(
+        "repo_pos", nargs="?", default=None,
+        help="Repository root containing the graph (optional positional; alias for --repo)",
+    )
 
     ask = sub.add_parser("ask", help="Ask a security question against the graph")
     ask.add_argument("question", help="Security review question")
     ask.add_argument("--repo", default=".", help="Repository root containing the graph")
+    ask.add_argument(
+        "repo_pos", nargs="?", default=None,
+        help="Repository root containing the graph (optional positional; alias for --repo)",
+    )
 
     explain = sub.add_parser(
         "explain", help="Answer a security question with cited, confidence-scored graph evidence"
@@ -86,6 +106,10 @@ def build_parser() -> argparse.ArgumentParser:
         help="Phrase the answer with a configured LLM (CYBERGRAPH_LLM_* env), grounded in evidence",
     )
     explain.add_argument("--limit", type=int, default=8, help="Maximum evidence records to retrieve")
+    explain.add_argument(
+        "repo_pos", nargs="?", default=None,
+        help="Repository root containing the graph (optional positional; alias for --repo)",
+    )
 
     paths = sub.add_parser("paths", help="Explain entrypoint-to-sink attack paths")
     paths.add_argument("--repo", default=".", help="Repository root containing the graph")
@@ -95,9 +119,17 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Disable interprocedural traversal (intra-function only; for ablation)",
     )
+    paths.add_argument(
+        "repo_pos", nargs="?", default=None,
+        help="Repository root containing the graph (optional positional; alias for --repo)",
+    )
 
     layers = sub.add_parser("layers", help="Summarize detected security layers")
     layers.add_argument("--repo", default=".", help="Repository root containing the graph")
+    layers.add_argument(
+        "repo_pos", nargs="?", default=None,
+        help="Repository root containing the graph (optional positional; alias for --repo)",
+    )
 
     secrets = sub.add_parser(
         "secrets",
@@ -128,15 +160,27 @@ def build_parser() -> argparse.ArgumentParser:
     review = sub.add_parser("review", help="Review security impact of a change set")
     review.add_argument("--base", default="HEAD~1", help="Git base ref for comparison")
     review.add_argument("--repo", default=".", help="Repository root to review")
+    review.add_argument(
+        "repo_pos", nargs="?", default=None,
+        help="Repository root to review (optional positional; alias for --repo)",
+    )
 
     comment = sub.add_parser("pr-comment", help="Generate a markdown PR security review comment")
     comment.add_argument("--base", default="HEAD~1", help="Git base ref for comparison")
     comment.add_argument("--repo", default=".", help="Repository root to review")
     comment.add_argument("--output", default="cybergraph-pr-comment.md", help="Output markdown path")
+    comment.add_argument(
+        "repo_pos", nargs="?", default=None,
+        help="Repository root to review (optional positional; alias for --repo)",
+    )
 
     sarif = sub.add_parser("sarif", help="Export CyberGraph findings as SARIF")
     sarif.add_argument("--repo", default=".", help="Repository root containing the graph")
     sarif.add_argument("--output", default="cybergraph.sarif", help="Output SARIF path")
+    sarif.add_argument(
+        "repo_pos", nargs="?", default=None,
+        help="Repository root containing the graph (optional positional; alias for --repo)",
+    )
 
     visualize = sub.add_parser("visualize", help="Generate a self-contained HTML security report")
     visualize.add_argument("repo", nargs="?", default=".", help="Repository root containing the graph")
@@ -243,14 +287,32 @@ def _validate_json_report(path: Path) -> str | None:
     return None
 
 
+def _resolve_repo(args: argparse.Namespace) -> Path:
+    """Resolve the target repo consistently across commands.
+
+    Preference order: an optional positional ``repo_pos`` (added to commands
+    that were previously ``--repo``-only), then ``--repo``/an existing
+    positional ``repo`` (both share the ``repo`` dest), then ``"."``.
+    """
+    repo_pos = getattr(args, "repo_pos", None)
+    if repo_pos:
+        return Path(repo_pos).resolve()
+    repo_flag = getattr(args, "repo", None)
+    if repo_flag:
+        return Path(repo_flag).resolve()
+    return Path(".").resolve()
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
 
-    from .env import load_dotenv
-    load_dotenv(Path(".").resolve())
-
     args = parser.parse_args(argv)
-    repo = Path(getattr(args, "repo", ".")).resolve()
+    repo = _resolve_repo(args)
+
+    # Resolved AFTER the repo argument is known so a repo other than cwd gets
+    # its own .env picked up (load_dotenv also checks cwd on top of repo_root).
+    from .env import load_dotenv
+    load_dotenv(repo)
 
     _READ_COMMANDS = {"explain", "paths", "layers", "sca", "ask"}
     if args.command in _READ_COMMANDS and not _graph_built(repo):

--- a/src/cybergraph/cli.py
+++ b/src/cybergraph/cli.py
@@ -209,7 +209,16 @@ def build_parser() -> argparse.ArgumentParser:
     analyze.add_argument("--no-color", action="store_true", help="Disable coloured output")
     analyze.add_argument("--no-report", action="store_true", help="Skip writing the HTML report")
 
+    config_cmd = sub.add_parser("config", help="Inspect CyberGraph configuration")
+    config_sub = config_cmd.add_subparsers(dest="config_action", required=True)
+    config_show = config_sub.add_parser("show", help="Show the effective configuration")
+    config_show.add_argument("repo", nargs="?", default=".", help="Repository root")
+
     return parser
+
+
+def _graph_built(repo: Path) -> bool:
+    return (repo / ".cybergraph" / "graph.db").is_file()
 
 
 def _validate_json_report(path: Path) -> str | None:
@@ -441,6 +450,18 @@ def main(argv: list[str] | None = None) -> int:
 
                 output = generate_html_report(repo, repo / ".cybergraph" / "report.html")
                 print(f"\nHTML report: {output}")
+    elif args.command == "config":
+        from .config import load_config
+        from .llm import load_llm_config_from_env
+
+        cfg = load_config(repo)
+        print(f"Repo: {repo}")
+        print(f"LLM configured: {'yes' if load_llm_config_from_env() is not None else 'no'}")
+        print(f"Graph built: {'yes' if _graph_built(repo) else 'no'}")
+        print(f"Ignored paths: {list(cfg.ignored_paths)}")
+        print(f"Custom sinks: {list(cfg.custom_sinks)}")
+        print(f"Suppressed rules: {list(cfg.suppressed_rules)}")
+        print(f"Suppressed paths: {list(cfg.suppressed_paths)}")
     else:
         parser.error(f"Unknown command: {args.command}")
     return 0

--- a/src/cybergraph/env.py
+++ b/src/cybergraph/env.py
@@ -6,14 +6,41 @@ import os
 from pathlib import Path
 
 
+def _strip_inline_comment(value: str) -> str:
+    """Truncate ``value`` at a ``#`` that starts a comment.
+
+    Only a ``#`` preceded by whitespace and outside single/double quotes is
+    treated as a comment marker, so ``K="a#b"`` keeps its literal ``#``.
+    """
+    in_single = False
+    in_double = False
+    for i, ch in enumerate(value):
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif (
+            ch == "#"
+            and not in_single
+            and not in_double
+            and i > 0
+            and value[i - 1] in " \t"
+        ):
+            return value[:i]
+    return value
+
+
 def _parse(text: str) -> dict[str, str]:
     out: dict[str, str] = {}
     for raw in text.splitlines():
         line = raw.strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
         key, _, value = line.partition("=")
         key = key.strip()
+        value = _strip_inline_comment(value)
         value = value.strip().strip('"').strip("'")
         if key:
             out[key] = value
@@ -41,7 +68,7 @@ def load_dotenv(repo_root: Path | None = None) -> int:
             continue
         seen.add(resolved)
         try:
-            pairs = _parse(resolved.read_text(encoding="utf-8"))
+            pairs = _parse(resolved.read_text(encoding="utf-8-sig"))
         except OSError:
             continue
         for key, value in pairs.items():

--- a/src/cybergraph/env.py
+++ b/src/cybergraph/env.py
@@ -1,0 +1,51 @@
+"""Minimal .env loader (no dependency). Sets only vars absent from the environment."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _parse(text: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key:
+            out[key] = value
+    return out
+
+
+def load_dotenv(repo_root: Path | None = None) -> int:
+    """Load ``.env`` from ``repo_root`` and cwd; set only keys not already set.
+
+    Returns the number of environment variables newly set. Never overrides an
+    existing environment value; non-fatal on any read/parse error."""
+    candidates = []
+    if repo_root is not None:
+        candidates.append(Path(repo_root) / ".env")
+    candidates.append(Path.cwd() / ".env")
+
+    set_count = 0
+    seen: set[Path] = set()
+    for path in candidates:
+        try:
+            resolved = path.resolve()
+        except OSError:
+            continue
+        if resolved in seen or not resolved.is_file():
+            continue
+        seen.add(resolved)
+        try:
+            pairs = _parse(resolved.read_text(encoding="utf-8"))
+        except OSError:
+            continue
+        for key, value in pairs.items():
+            if key not in os.environ:
+                os.environ[key] = value
+                set_count += 1
+    return set_count

--- a/src/cybergraph/mcp_server.py
+++ b/src/cybergraph/mcp_server.py
@@ -6,8 +6,9 @@ from pathlib import Path
 from typing import Any
 
 from .build import build_graph
+from .graph import GraphStore
 from .rag import answer_grounded, answer_question, format_grounded_answer
-from .security import find_attack_paths, format_attack_paths
+from .security import find_attack_paths, format_attack_paths, load_scanner_findings
 
 try:
     from fastmcp import FastMCP
@@ -98,6 +99,22 @@ if FastMCP is not None:
 
         paths = find_iac_attack_paths(Path(repo_root).resolve(), max_depth=max_depth)
         return {"count": len(paths), "text": format_iac_attack_paths(paths)}
+
+    @mcp.tool()
+    def import_scanner_report_tool(report_path: str, repo_root: str = ".") -> dict[str, Any]:
+        """Import findings from a Semgrep, SARIF, or Gitleaks JSON report into the graph."""
+        store = GraphStore.open_for_repo(Path(repo_root).resolve())
+        findings = load_scanner_findings(Path(report_path).resolve())
+        store.add_findings(findings)
+        store.close()
+        return {"imported": len(findings)}
+
+    @mcp.tool()
+    def import_vulnerabilities_tool(report_path: str, repo_root: str = ".") -> dict[str, Any]:
+        """Import an OSV Scanner or npm audit vulnerability JSON report into the graph."""
+        from .security.vulnerabilities import import_vulnerability_report
+
+        return import_vulnerability_report(Path(repo_root).resolve(), Path(report_path).resolve())
 else:
     mcp = None
 

--- a/src/cybergraph/mcp_server.py
+++ b/src/cybergraph/mcp_server.py
@@ -54,6 +54,50 @@ if FastMCP is not None:
             "confidence": answer.confidence,
             "citations": list(answer.citations),
         }
+
+    @mcp.tool()
+    def analyze_repo_tool(repo_root: str = ".", limit: int = 10) -> dict[str, Any]:
+        """Build the graph and run every analysis; return the full result as JSON."""
+        from .orchestrator import run_full_analysis
+        from .report_model import to_json
+
+        return to_json(run_full_analysis(Path(repo_root).resolve(), limit=limit))
+
+    @mcp.tool()
+    def top_risks_tool(repo_root: str = ".", limit: int = 10) -> dict[str, Any]:
+        """Return the ranked top security risks across all graph layers."""
+        from .security.investigate import collect_top_risks
+
+        risks = collect_top_risks(Path(repo_root).resolve(), limit=limit)
+        return {"top_risks": [
+            {"category": r.category, "title": r.title, "risk_score": r.risk_score,
+             "risk_label": r.risk_label, "detail": r.detail}
+            for r in risks
+        ]}
+
+    @mcp.tool()
+    def secret_exposures_tool(repo_root: str = ".") -> dict[str, Any]:
+        """Return prioritized secret-exposure paths (reachable secret -> sink)."""
+        from .security.secrets import find_secret_exposures, format_secret_exposures
+
+        exposures = find_secret_exposures(Path(repo_root).resolve())
+        return {"count": len(exposures), "text": format_secret_exposures(exposures)}
+
+    @mcp.tool()
+    def prioritize_dependencies_tool(repo_root: str = ".") -> dict[str, Any]:
+        """Return dependency vulnerabilities ranked by severity x reachability."""
+        from .security.sca import format_sca, prioritize_vulnerabilities
+
+        priorities = prioritize_vulnerabilities(Path(repo_root).resolve())
+        return {"count": len(priorities), "text": format_sca(priorities)}
+
+    @mcp.tool()
+    def iac_attack_paths_tool(repo_root: str = ".", max_depth: int = 6) -> dict[str, Any]:
+        """Return cloud attack paths (public exposure -> privileged IaC resource)."""
+        from .security.iac_paths import find_iac_attack_paths, format_iac_attack_paths
+
+        paths = find_iac_attack_paths(Path(repo_root).resolve(), max_depth=max_depth)
+        return {"count": len(paths), "text": format_iac_attack_paths(paths)}
 else:
     mcp = None
 

--- a/src/cybergraph/orchestrator.py
+++ b/src/cybergraph/orchestrator.py
@@ -16,6 +16,10 @@ from cybergraph.security.layers import summarize_layers
 from cybergraph.security.sca import prioritize_vulnerabilities
 from cybergraph.security.secrets import find_secret_exposures
 
+# Default max_nodes used by the HTML report / graph export (export-json --max-nodes).
+# The orchestrator uses the same cap as the signal for whether the graph was truncated.
+REPORT_NODE_CAP = 600
+
 
 def _stage(name, fn, timings, errors, default):
     """Run one analysis stage, isolating failures so the run always completes."""
@@ -60,7 +64,7 @@ def run_full_analysis(repo_root: Path, *, limit: int = 10) -> AnalysisResult:
         iac_paths=iac_paths,
         cloud_code_paths=cloud_code_paths,
         layers=layers,
-        truncated=False,
+        truncated=counts.get("nodes", 0) > REPORT_NODE_CAP,
         timings=timings,
         llm_configured=load_llm_config_from_env() is not None,
         errors=errors,

--- a/src/cybergraph/orchestrator.py
+++ b/src/cybergraph/orchestrator.py
@@ -1,0 +1,67 @@
+"""Run every analysis once over a single graph build and return one result."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from cybergraph.build import build_graph
+from cybergraph.llm import load_llm_config_from_env
+from cybergraph.report_model import AnalysisResult
+from cybergraph.security.attack_paths import find_attack_paths
+from cybergraph.security.cloud import find_cloud_code_paths
+from cybergraph.security.iac_paths import find_iac_attack_paths
+from cybergraph.security.investigate import collect_top_risks
+from cybergraph.security.layers import summarize_layers
+from cybergraph.security.sca import prioritize_vulnerabilities
+from cybergraph.security.secrets import find_secret_exposures
+
+
+def _stage(name, fn, timings, errors, default):
+    """Run one analysis stage, isolating failures so the run always completes."""
+    start = time.perf_counter()
+    try:
+        return fn()
+    except Exception as exc:  # one bad stage must not abort the whole analysis
+        errors[name] = f"{type(exc).__name__}: {exc}"
+        return default
+    finally:
+        timings[name] = time.perf_counter() - start
+
+
+def run_full_analysis(repo_root: Path, *, limit: int = 10) -> AnalysisResult:
+    repo_root = Path(repo_root).resolve()
+    timings: dict[str, float] = {}
+    errors: dict[str, str] = {}
+
+    counts = _stage("build", lambda: build_graph(repo_root), timings, errors,
+                    {"nodes": 0, "edges": 0, "findings": 0})
+
+    top_risks = _stage("top_risks", lambda: collect_top_risks(repo_root, limit=limit),
+                        timings, errors, [])
+    attack_paths = _stage("attack_paths", lambda: find_attack_paths(repo_root),
+                          timings, errors, [])
+    secret_exposures = _stage("secret_exposures", lambda: find_secret_exposures(repo_root),
+                              timings, errors, [])
+    sca = _stage("sca", lambda: prioritize_vulnerabilities(repo_root), timings, errors, [])
+    iac_paths = _stage("iac_paths", lambda: find_iac_attack_paths(repo_root),
+                       timings, errors, [])
+    cloud_code_paths = _stage("cloud_code_paths", lambda: find_cloud_code_paths(repo_root),
+                              timings, errors, [])
+    layers = _stage("layers", lambda: summarize_layers(repo_root), timings, errors, [])
+
+    return AnalysisResult(
+        repo=str(repo_root),
+        counts=counts,
+        top_risks=top_risks,
+        attack_paths=attack_paths,
+        secret_exposures=secret_exposures,
+        sca=sca,
+        iac_paths=iac_paths,
+        cloud_code_paths=cloud_code_paths,
+        layers=layers,
+        truncated=False,
+        timings=timings,
+        llm_configured=load_llm_config_from_env() is not None,
+        errors=errors,
+    )

--- a/src/cybergraph/output.py
+++ b/src/cybergraph/output.py
@@ -1,0 +1,50 @@
+"""Human-facing rendering of an AnalysisResult (colour + plain, no dependencies)."""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TextIO
+
+from cybergraph.report_model import AnalysisResult
+
+_LEVEL_COLOR = {"critical": "31", "high": "31", "medium": "33", "low": "36"}
+
+
+def should_color(stream: TextIO | None = None) -> bool:
+    if os.environ.get("NO_COLOR"):
+        return False
+    stream = stream or sys.stdout
+    return bool(getattr(stream, "isatty", lambda: False)())
+
+
+def _c(text: str, code: str, color: bool) -> str:
+    return f"\x1b[{code}m{text}\x1b[0m" if color else text
+
+
+def render_text(result: AnalysisResult, *, color: bool = True) -> str:
+    lines: list[str] = []
+    lines.append(_c(f"CyberGraph analysis — {result.repo}", "1", color))
+    c = result.counts
+    lines.append(
+        f"Nodes: {c.get('nodes', 0)} | Edges: {c.get('edges', 0)} | "
+        f"Findings: {c.get('findings', 0)}"
+    )
+    if result.truncated:
+        lines.append(_c("! graph truncated — raise --max-nodes to see more", "33", color))
+
+    lines.append("")
+    lines.append(_c(f"Top risks ({len(result.top_risks)}):", "1", color))
+    if not result.top_risks:
+        lines.append("  none found")
+    for r in result.top_risks:
+        label = _c(f"{r.risk_label.upper()} {r.risk_score}/100",
+                   _LEVEL_COLOR.get(r.risk_label.lower(), "0"), color)
+        lines.append(f"  [{label}] {r.category}: {r.title}")
+        if r.detail:
+            lines.append(f"      {r.detail}")
+
+    if result.errors:
+        lines.append("")
+        lines.append(_c(f"Stages with errors: {', '.join(sorted(result.errors))}", "33", color))
+    return "\n".join(lines)

--- a/src/cybergraph/report_model.py
+++ b/src/cybergraph/report_model.py
@@ -1,0 +1,61 @@
+"""Shared analysis result consumed by the CLI, HTML report, and MCP server."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+SCHEMA = "cybergraph.analysis/1"
+
+
+@dataclass(frozen=True)
+class AnalysisResult:
+    repo: str
+    counts: dict[str, int]
+    top_risks: list[Any]
+    attack_paths: list[Any]
+    secret_exposures: list[Any]
+    sca: list[Any]
+    iac_paths: list[Any]
+    cloud_code_paths: list[Any]
+    layers: list[Any]
+    truncated: bool = False
+    timings: dict[str, float] = field(default_factory=dict)
+    llm_configured: bool = False
+    errors: dict[str, str] = field(default_factory=dict)
+
+
+def to_json(result: AnalysisResult) -> dict[str, Any]:
+    """Stable, versioned JSON view (schema ``cybergraph.analysis/1``)."""
+    return {
+        "schema": SCHEMA,
+        "repo": result.repo,
+        "counts": dict(result.counts),
+        "truncated": bool(result.truncated),
+        "llm_configured": bool(result.llm_configured),
+        "timings": {k: round(v, 4) for k, v in result.timings.items()},
+        "errors": dict(result.errors),
+        "top_risks": [
+            {
+                "category": r.category, "title": r.title,
+                "risk_score": r.risk_score, "risk_label": r.risk_label,
+                "detail": r.detail,
+            }
+            for r in result.top_risks
+        ],
+        "component_counts": {
+            "attack_paths": len(result.attack_paths),
+            "secret_exposures": len(result.secret_exposures),
+            "sca": len(result.sca),
+            "iac_paths": len(result.iac_paths),
+            "cloud_code_paths": len(result.cloud_code_paths),
+        },
+        "layers": [
+            {
+                "key": l.key, "label": l.label,
+                "node_count": l.node_count, "edge_count": l.edge_count,
+                "finding_count": l.finding_count,
+            }
+            for l in result.layers
+        ],
+    }

--- a/tests/test_cli_analyze.py
+++ b/tests/test_cli_analyze.py
@@ -24,6 +24,20 @@ def test_analyze_text_prints_summary(tmp_path, capsys):
     out = capsys.readouterr().out
     assert code == 0
     assert "CyberGraph analysis" in out
+
+
+def test_visualize_cli_command_still_works(tmp_path, capsys):
+    # Regression: a local import inside the 'analyze' branch once shadowed the
+    # module-level generate_html_report, making the 'visualize' command raise
+    # UnboundLocalError. The visualize command must work end-to-end.
+    repo = _repo(tmp_path)
+    assert main(["build", str(repo)]) == 0
+    capsys.readouterr()
+    code = main(["visualize", str(repo)])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "HTML report" in out
+    assert (repo / ".cybergraph" / "report.html").is_file()
     assert "Top risks" in out
 
 

--- a/tests/test_cli_analyze.py
+++ b/tests/test_cli_analyze.py
@@ -35,3 +35,42 @@ def test_analyze_json_is_valid_and_versioned(tmp_path, capsys):
     doc = json.loads(out)
     assert doc["schema"] == "cybergraph.analysis/1"
     assert doc["counts"]["nodes"] > 0
+
+
+def test_analyze_json_emits_only_json(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    code = main(["analyze", str(repo), "--json", "--no-report"])
+    out = capsys.readouterr().out
+    assert code == 0
+    stripped = out.strip()
+    assert stripped.startswith("{")
+    assert stripped.endswith("}")
+    # a single JSON document -- no extra lines (e.g. no "HTML report:" leakage)
+    doc = json.loads(stripped)
+    assert json.loads(out) == doc
+
+
+def test_analyze_text_no_color_has_no_ansi(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    code = main(["analyze", str(repo), "--no-color", "--no-report"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "\x1b[" not in out
+
+
+def test_analyze_writes_report_by_default_and_skips_with_flag(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    code = main(["analyze", str(repo), "--no-color"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "HTML report:" in out
+    assert (repo / ".cybergraph" / "report.html").is_file()
+
+    # --no-report: neither the file nor the message should appear on a fresh run
+    report_path = repo / ".cybergraph" / "report.html"
+    report_path.unlink()
+    code = main(["analyze", str(repo), "--no-color", "--no-report"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "HTML report:" not in out
+    assert not report_path.is_file()

--- a/tests/test_cli_analyze.py
+++ b/tests/test_cli_analyze.py
@@ -1,0 +1,37 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from cybergraph.cli import main
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "@app.route('/users')\n"
+        "def list_users(request):\n"
+        "    return db.execute('select ' + request.query['q'])\n",
+        encoding="utf-8",
+    )
+    return repo
+
+
+def test_analyze_text_prints_summary(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    code = main(["analyze", str(repo), "--no-color", "--no-report"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "CyberGraph analysis" in out
+    assert "Top risks" in out
+
+
+def test_analyze_json_is_valid_and_versioned(tmp_path, capsys):
+    repo = _repo(tmp_path)
+    code = main(["analyze", str(repo), "--json", "--no-report"])
+    out = capsys.readouterr().out
+    assert code == 0
+    doc = json.loads(out)
+    assert doc["schema"] == "cybergraph.analysis/1"
+    assert doc["counts"]["nodes"] > 0

--- a/tests/test_cli_analyze.py
+++ b/tests/test_cli_analyze.py
@@ -24,6 +24,7 @@ def test_analyze_text_prints_summary(tmp_path, capsys):
     out = capsys.readouterr().out
     assert code == 0
     assert "CyberGraph analysis" in out
+    assert "Top risks" in out
 
 
 def test_visualize_cli_command_still_works(tmp_path, capsys):
@@ -38,7 +39,6 @@ def test_visualize_cli_command_still_works(tmp_path, capsys):
     assert code == 0
     assert "HTML report" in out
     assert (repo / ".cybergraph" / "report.html").is_file()
-    assert "Top risks" in out
 
 
 def test_analyze_json_is_valid_and_versioned(tmp_path, capsys):

--- a/tests/test_cli_analyze.py
+++ b/tests/test_cli_analyze.py
@@ -1,7 +1,6 @@
 import json
 from pathlib import Path
 
-import pytest
 
 from cybergraph.cli import main
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 
 import pytest
 

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from cybergraph.cli import main
 
 
@@ -27,3 +29,54 @@ def test_read_command_without_graph_prints_guidance(tmp_path, capsys):
     out = capsys.readouterr().out
     assert code == 0
     assert "cybergraph build" in out  # tells the user to build first
+
+
+@pytest.mark.parametrize("command", ["ask", "explain", "paths", "sca"])
+def test_guidance_printed_for_each_read_command(tmp_path, capsys, command):
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text("x = 1\n", encoding="utf-8")
+    argv = [command]
+    if command in ("ask", "explain"):
+        argv.append("is there a vulnerability?")
+    if command == "sca":
+        argv.append(str(repo))  # sca takes repo as a positional, not --repo
+    else:
+        argv += ["--repo", str(repo)]
+    code = main(argv)
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "cybergraph build" in out
+
+
+def test_build_and_analyze_not_short_circuited_when_unbuilt(tmp_path, capsys):
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text("x = 1\n", encoding="utf-8")
+    code = main(["build", str(repo)])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "Built security graph" in out  # actually built, not the guidance branch
+    assert "cybergraph build" not in out
+
+    repo2 = tmp_path / "app2"
+    repo2.mkdir()
+    (repo2 / "app2.py").write_text("y = 2\n", encoding="utf-8")
+    code = main(["analyze", str(repo2), "--no-color", "--no-report"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "CyberGraph analysis" in out  # analyze actually ran, not the guidance branch
+
+
+def test_config_show_llm_configured_yes(tmp_path, capsys, monkeypatch):
+    monkeypatch.setenv("CYBERGRAPH_LLM_PROVIDER", "anthropic")
+    monkeypatch.setenv("CYBERGRAPH_LLM_API_KEY", "sk-test")
+    repo = tmp_path / "app"
+    repo.mkdir()
+    code = main(["config", "show", str(repo)])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "LLM configured: yes" in out
+    assert "Ignored paths:" in out
+    assert "Suppressed rules:" in out
+    assert "Suppressed paths:" in out

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from cybergraph.cli import main
+
+
+def test_config_show_reports_llm_and_graph_state(tmp_path, capsys, monkeypatch):
+    monkeypatch.delenv("CYBERGRAPH_LLM_PROVIDER", raising=False)
+    monkeypatch.delenv("CYBERGRAPH_LLM_API_KEY", raising=False)
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / ".cybergraph.toml").write_text(
+        "[security]\nsinks = [\"run_report\"]\n", encoding="utf-8"
+    )
+    code = main(["config", "show", str(repo)])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "LLM configured: no" in out
+    assert "Graph built: no" in out
+    assert "run_report" in out  # effective custom sink shown

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -17,3 +17,13 @@ def test_config_show_reports_llm_and_graph_state(tmp_path, capsys, monkeypatch):
     assert "LLM configured: no" in out
     assert "Graph built: no" in out
     assert "run_report" in out  # effective custom sink shown
+
+
+def test_read_command_without_graph_prints_guidance(tmp_path, capsys):
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text("x = 1\n", encoding="utf-8")
+    code = main(["layers", "--repo", str(repo)])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "cybergraph build" in out  # tells the user to build first

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 
 from cybergraph.cli import main
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from cybergraph.cli import main
+
+
+def test_existing_command_unaffected_by_dotenv_startup_hook(tmp_path, capsys, monkeypatch):
+    """Regression guard for the global .env startup hook (cli.main).
+
+    A .env present in cwd must not break an existing command end-to-end, and
+    its keys must actually be loaded into the environment.
+    """
+    monkeypatch.delenv("CYBERGRAPH_LLM_PROVIDER", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("CYBERGRAPH_LLM_PROVIDER=anthropic\n", encoding="utf-8")
+
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text("x = 1\n", encoding="utf-8")
+
+    code = main(["build", str(repo)])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "Built security graph" in out
+
+    import os
+
+    assert os.environ["CYBERGRAPH_LLM_PROVIDER"] == "anthropic"
+    os.environ.pop("CYBERGRAPH_LLM_PROVIDER", None)

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from cybergraph.env import load_dotenv
+
+
+def test_load_dotenv_sets_absent_and_ignores_comments(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("CYBERGRAPH_LLM_API_KEY", raising=False)
+    monkeypatch.delenv("CYBERGRAPH_LLM_PROVIDER", raising=False)
+    (tmp_path / ".env").write_text(
+        "# a comment\n"
+        "\n"
+        'CYBERGRAPH_LLM_API_KEY="sk-abc123"\n'
+        "CYBERGRAPH_LLM_PROVIDER=anthropic\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    n = load_dotenv(tmp_path)
+    assert n == 2
+    import os
+    assert os.environ["CYBERGRAPH_LLM_API_KEY"] == "sk-abc123"  # quotes stripped
+    assert os.environ["CYBERGRAPH_LLM_PROVIDER"] == "anthropic"
+    # load_dotenv sets os.environ directly (by design, so the values persist for
+    # the rest of the process); monkeypatch's own undo-stack does not reliably
+    # revert a key it saw as absent and then observes changed out-of-band, so
+    # pop the keys directly to avoid leaking into other tests in the session.
+    os.environ.pop("CYBERGRAPH_LLM_API_KEY", None)
+    os.environ.pop("CYBERGRAPH_LLM_PROVIDER", None)
+
+
+def test_load_dotenv_never_overrides_existing_env(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)  # avoid picking up a real .env at the repo cwd
+    monkeypatch.setenv("CYBERGRAPH_LLM_PROVIDER", "openai")
+    (tmp_path / ".env").write_text("CYBERGRAPH_LLM_PROVIDER=anthropic\n", encoding="utf-8")
+    load_dotenv(tmp_path)
+    import os
+    assert os.environ["CYBERGRAPH_LLM_PROVIDER"] == "openai"  # real env wins
+
+
+def test_load_dotenv_noop_when_absent(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)  # avoid picking up a real .env at the repo cwd
+    assert load_dotenv(tmp_path) == 0

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from cybergraph.env import load_dotenv
+from cybergraph.env import _parse, load_dotenv
 
 
 def test_load_dotenv_sets_absent_and_ignores_comments(tmp_path: Path, monkeypatch):
@@ -39,3 +39,60 @@ def test_load_dotenv_never_overrides_existing_env(tmp_path: Path, monkeypatch):
 def test_load_dotenv_noop_when_absent(tmp_path: Path, monkeypatch):
     monkeypatch.chdir(tmp_path)  # avoid picking up a real .env at the repo cwd
     assert load_dotenv(tmp_path) == 0
+
+
+def test_parse_key_equals_value_variants():
+    assert _parse("KEY=")["KEY"] == ""
+    assert _parse("X=a=b")["X"] == "a=b"
+    assert _parse(" K = v ") == {"K": "v"}
+
+
+def test_parse_strips_utf8_bom(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("CYBERGRAPH_LLM_API_KEY", raising=False)
+    (tmp_path / ".env").write_bytes(
+        "CYBERGRAPH_LLM_API_KEY=sk-bom\n".encode("utf-8-sig")
+    )
+    monkeypatch.chdir(tmp_path)
+    n = load_dotenv(tmp_path)
+    import os
+
+    assert n == 1
+    assert os.environ["CYBERGRAPH_LLM_API_KEY"] == "sk-bom"
+    assert "﻿CYBERGRAPH_LLM_API_KEY" not in os.environ
+    os.environ.pop("CYBERGRAPH_LLM_API_KEY", None)
+
+
+def test_parse_handles_crlf_and_blank_lines():
+    text = "# comment\r\n\r\nFOO=bar\r\n\r\nBAZ=qux\r\n"
+    assert _parse(text) == {"FOO": "bar", "BAZ": "qux"}
+
+
+def test_parse_strips_export_prefix():
+    assert _parse("export FOO=bar\n") == {"FOO": "bar"}
+    # a key that merely starts with "export" (no following space) is untouched
+    assert _parse("exported=1\n") == {"exported": "1"}
+
+
+def test_parse_strips_inline_comment_only_after_whitespace():
+    assert _parse("K=v # comment\n")["K"] == "v"
+    # no whitespace before '#' -> not treated as a comment
+    assert _parse("K=v#nocomment\n")["K"] == "v#nocomment"
+    # '#' inside quotes is preserved even with leading whitespace
+    assert _parse('K="a #b"\n')["K"] == "a #b"
+
+
+def test_load_dotenv_prefers_repo_root_over_cwd_and_dedups(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("CYBERGRAPH_LLM_PROVIDER", raising=False)
+    repo_root = tmp_path / "repo"
+    cwd = tmp_path / "cwd"
+    repo_root.mkdir()
+    cwd.mkdir()
+    (repo_root / ".env").write_text("CYBERGRAPH_LLM_PROVIDER=repo-root\n", encoding="utf-8")
+    (cwd / ".env").write_text("CYBERGRAPH_LLM_PROVIDER=cwd\n", encoding="utf-8")
+    monkeypatch.chdir(cwd)
+    n = load_dotenv(repo_root)
+    import os
+
+    assert n == 1  # the cwd's duplicate key is not double-applied
+    assert os.environ["CYBERGRAPH_LLM_PROVIDER"] == "repo-root"
+    os.environ.pop("CYBERGRAPH_LLM_PROVIDER", None)

--- a/tests/test_mcp_parity.py
+++ b/tests/test_mcp_parity.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 
@@ -12,6 +14,8 @@ def test_mcp_exposes_full_workflow_tools():
         "secret_exposures_tool",
         "prioritize_dependencies_tool",
         "iac_attack_paths_tool",
+        "import_scanner_report_tool",
+        "import_vulnerabilities_tool",
     ]:
         assert hasattr(mcp_server, name), f"missing MCP tool: {name}"
 
@@ -29,3 +33,99 @@ def test_analyze_repo_tool_returns_versioned_json(tmp_path):
     doc = mcp_server.analyze_repo_tool(str(repo))
     assert doc["schema"] == "cybergraph.analysis/1"
     assert doc["counts"]["nodes"] > 0
+
+
+def _built_repo(tmp_path):
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "@app.route('/x')\ndef h(request):\n    return db.execute(request.query['q'])\n",
+        encoding="utf-8",
+    )
+    from cybergraph.build import build_graph
+
+    build_graph(repo)
+    return repo
+
+
+def test_component_tools_return_shapes(tmp_path):
+    pytest.importorskip("fastmcp")
+    from cybergraph import mcp_server
+
+    repo = _built_repo(tmp_path)
+
+    top_risks = mcp_server.top_risks_tool(str(repo))
+    assert isinstance(top_risks["top_risks"], list)
+
+    secrets = mcp_server.secret_exposures_tool(str(repo))
+    assert isinstance(secrets["count"], int)
+    assert isinstance(secrets["text"], str)
+
+    deps = mcp_server.prioritize_dependencies_tool(str(repo))
+    assert isinstance(deps["count"], int)
+    assert isinstance(deps["text"], str)
+
+    iac = mcp_server.iac_attack_paths_tool(str(repo))
+    assert isinstance(iac["count"], int)
+    assert isinstance(iac["text"], str)
+
+
+def test_import_scanner_report_tool_imports_findings(tmp_path):
+    pytest.importorskip("fastmcp")
+    from cybergraph import mcp_server
+
+    repo = _built_repo(tmp_path)
+    report = tmp_path / "semgrep.json"
+    report.write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "check_id": "python.lang.security.sql-injection",
+                        "path": "app.py",
+                        "start": {"line": 3},
+                        "end": {"line": 3},
+                        "extra": {"severity": "ERROR", "message": "SQL injection"},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = mcp_server.import_scanner_report_tool(str(report), str(repo))
+    assert result == {"imported": 1}
+
+
+def test_import_vulnerabilities_tool_imports_records(tmp_path):
+    pytest.importorskip("fastmcp")
+    from cybergraph import mcp_server
+
+    repo = _built_repo(tmp_path)
+    (repo / "requirements.txt").write_text("fastapi==0.110.0\n", encoding="utf-8")
+    report = tmp_path / "osv.json"
+    report.write_text(
+        json.dumps(
+            {
+                "results": [
+                    {
+                        "packages": [
+                            {
+                                "package": {
+                                    "name": "fastapi",
+                                    "version": "0.110.0",
+                                    "ecosystem": "PyPI",
+                                },
+                                "vulnerabilities": [
+                                    {"id": "GHSA-demo", "summary": "Demo vulnerability"}
+                                ],
+                            }
+                        ]
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    result = mcp_server.import_vulnerabilities_tool(str(report), str(repo))
+    assert result["vulnerabilities"] == 1
+    assert "matched_dependencies" in result

--- a/tests/test_mcp_parity.py
+++ b/tests/test_mcp_parity.py
@@ -1,0 +1,31 @@
+import pytest
+
+
+def test_mcp_exposes_full_workflow_tools():
+    pytest.importorskip("fastmcp")
+    from cybergraph import mcp_server
+
+    # The new orchestrator-backed tool functions are defined at import time.
+    for name in [
+        "analyze_repo_tool",
+        "top_risks_tool",
+        "secret_exposures_tool",
+        "prioritize_dependencies_tool",
+        "iac_attack_paths_tool",
+    ]:
+        assert hasattr(mcp_server, name), f"missing MCP tool: {name}"
+
+
+def test_analyze_repo_tool_returns_versioned_json(tmp_path):
+    pytest.importorskip("fastmcp")
+    from cybergraph import mcp_server
+
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "@app.route('/x')\ndef h(request):\n    return db.execute(request.query['q'])\n",
+        encoding="utf-8",
+    )
+    doc = mcp_server.analyze_repo_tool(str(repo))
+    assert doc["schema"] == "cybergraph.analysis/1"
+    assert doc["counts"]["nodes"] > 0

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from cybergraph.orchestrator import run_full_analysis
+from cybergraph.report_model import AnalysisResult
+
+
+def _build_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "@app.route('/users')\n"
+        "def list_users(request):\n"
+        "    return db.execute('select ' + request.query['q'])\n",
+        encoding="utf-8",
+    )
+    return repo
+
+
+def test_run_full_analysis_builds_once_and_populates(tmp_path: Path):
+    repo = _build_repo(tmp_path)
+    result = run_full_analysis(repo)
+    assert isinstance(result, AnalysisResult)
+    assert result.counts["nodes"] > 0
+    assert result.layers  # summarize_layers always returns the ontology layers
+    assert "build" in result.timings
+    assert result.errors == {}  # nothing failed on a clean run
+
+
+def test_one_failing_stage_is_isolated(tmp_path: Path, monkeypatch):
+    repo = _build_repo(tmp_path)
+    import cybergraph.orchestrator as orch
+
+    def _boom(_repo):
+        raise RuntimeError("stage down")
+
+    monkeypatch.setattr(orch, "find_secret_exposures", _boom)
+    result = run_full_analysis(repo)
+    assert "secret_exposures" in result.errors
+    assert result.secret_exposures == []
+    assert result.counts["nodes"] > 0  # run still completed

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -38,3 +38,38 @@ def test_one_failing_stage_is_isolated(tmp_path: Path, monkeypatch):
     assert "secret_exposures" in result.errors
     assert result.secret_exposures == []
     assert result.counts["nodes"] > 0  # run still completed
+
+
+def test_build_stage_failure_isolated_and_run_completes(tmp_path: Path, monkeypatch):
+    from cybergraph.report_model import to_json
+
+    repo = _build_repo(tmp_path)
+    import cybergraph.orchestrator as orch
+
+    def _boom(_repo):
+        raise RuntimeError("build down")
+
+    monkeypatch.setattr(orch, "build_graph", _boom)
+    result = run_full_analysis(repo)
+    assert "build" in result.errors
+    assert result.counts == {"nodes": 0, "edges": 0, "findings": 0}
+    import json
+
+    json.dumps(to_json(result))  # still valid JSON even when the build stage failed
+
+
+def test_truncated_flag_reflects_report_node_cap(tmp_path: Path, monkeypatch):
+    repo = _build_repo(tmp_path)
+    import cybergraph.orchestrator as orch
+
+    monkeypatch.setattr(
+        orch, "build_graph", lambda _repo: {"nodes": orch.REPORT_NODE_CAP + 1, "edges": 0, "findings": 0}
+    )
+    result = run_full_analysis(repo)
+    assert result.truncated is True
+
+    monkeypatch.setattr(
+        orch, "build_graph", lambda _repo: {"nodes": orch.REPORT_NODE_CAP, "edges": 0, "findings": 0}
+    )
+    result = run_full_analysis(repo)
+    assert result.truncated is False

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,4 +1,3 @@
-import os
 
 from cybergraph.output import render_text, should_color
 from cybergraph.report_model import AnalysisResult

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,39 @@
+import os
+
+from cybergraph.output import render_text, should_color
+from cybergraph.report_model import AnalysisResult
+from cybergraph.security.investigate import TopRisk
+
+
+def _result(**over):
+    base = dict(
+        repo="/x/app", counts={"nodes": 5, "edges": 3, "findings": 2},
+        top_risks=[TopRisk("attack-path", "route -> sink", 82, "high", "reachable")],
+        attack_paths=[1], secret_exposures=[], sca=[], iac_paths=[], cloud_code_paths=[],
+        layers=[], truncated=False, timings={}, llm_configured=False, errors={},
+    )
+    base.update(over)
+    return AnalysisResult(**base)
+
+
+def test_render_text_plain_lists_top_risks_and_counts():
+    out = render_text(_result(), color=False)
+    assert "route -> sink" in out
+    assert "HIGH" in out and "82" in out
+    assert "Nodes: 5" in out
+    assert "\x1b[" not in out  # no ANSI when color=False
+
+
+def test_render_text_color_emits_ansi():
+    out = render_text(_result(), color=True)
+    assert "\x1b[" in out
+
+
+def test_truncation_banner_shown_only_when_truncated():
+    assert "truncated" in render_text(_result(truncated=True), color=False).lower()
+    assert "truncated" not in render_text(_result(truncated=False), color=False).lower()
+
+
+def test_should_color_respects_no_color_env(monkeypatch):
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert should_color() is False

--- a/tests/test_report_model.py
+++ b/tests/test_report_model.py
@@ -40,3 +40,14 @@ def test_to_json_has_stable_schema_and_counts():
     }
     assert doc["layers"][0]["key"] == "sink"
     assert doc["errors"] == {}
+
+
+def test_to_json_top_level_keys_are_frozen():
+    import json
+
+    doc = to_json(_sample())
+    assert set(doc) == {
+        "schema", "repo", "counts", "truncated", "llm_configured", "timings",
+        "errors", "top_risks", "component_counts", "layers",
+    }
+    json.dumps(doc)  # the versioned schema must always be JSON-serializable

--- a/tests/test_report_model.py
+++ b/tests/test_report_model.py
@@ -1,0 +1,42 @@
+from cybergraph.report_model import AnalysisResult, to_json
+from cybergraph.security.investigate import TopRisk
+from cybergraph.security.layers import LayerSummary
+
+
+def _sample() -> AnalysisResult:
+    return AnalysisResult(
+        repo="/x/app",
+        counts={"nodes": 5, "edges": 3, "findings": 2},
+        top_risks=[TopRisk("attack-path", "route -> sink", 82, "high", "why")],
+        attack_paths=[object()],
+        secret_exposures=[],
+        sca=[object(), object()],
+        iac_paths=[],
+        cloud_code_paths=[],
+        layers=[LayerSummary("sink", "Sensitive Sinks", "d", 1, 1, 1)],
+        truncated=True,
+        timings={"build": 0.1},
+        llm_configured=False,
+        errors={},
+    )
+
+
+def test_to_json_has_stable_schema_and_counts():
+    doc = to_json(_sample())
+    assert doc["schema"] == "cybergraph.analysis/1"
+    assert doc["repo"] == "/x/app"
+    assert doc["counts"] == {"nodes": 5, "edges": 3, "findings": 2}
+    assert doc["truncated"] is True
+    assert doc["llm_configured"] is False
+    # top risks serialized fully
+    assert doc["top_risks"][0] == {
+        "category": "attack-path", "title": "route -> sink",
+        "risk_score": 82, "risk_label": "high", "detail": "why",
+    }
+    # component lists represented as counts in v1
+    assert doc["component_counts"] == {
+        "attack_paths": 1, "secret_exposures": 0, "sca": 2,
+        "iac_paths": 0, "cloud_code_paths": 0,
+    }
+    assert doc["layers"][0]["key"] == "sink"
+    assert doc["errors"] == {}


### PR DESCRIPTION
## Usability Core (Theme A, Spec 1)

One shared analysis core surfaced through both the CLI and MCP.

- `analyze` command: build once, fan every analysis into a shared `AnalysisResult`, print ranked top risks (colour/tabular) or `--json`; writes the HTML report.
- `config show`, a read-guard ("run build first"), and a truncation signal.
- `.env` loader for `CYBERGRAPH_LLM_*` (BOM-safe, loads the target repo).
- Consistent `repo` positional + `--repo` everywhere (`_resolve_repo`).
- MCP parity: 7 new tools so an IDE/agent can drive the full workflow.
- Fixes a latent `UnboundLocalError` that broke the `visualize` command, with a CLI regression test.

**Tests:** 204 passed (baseline 164), additive/non-breaking, no new deps.

Foundation of a stack: merge this first; the Report-polish and Temporal-analysis PRs build on it.