### PR TITLE
feat: Report & onboarding polish (theme, unified search, truncation banner, secret-redacted drill-down, quickstart)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Supported Python: 3.10, 3.11, 3.12.
 ## Quick start
 
 ```bash
+cybergraph quickstart .        # zero-to-report: init, build, analyze, open report
 cybergraph init .
 cybergraph doctor .
 cybergraph analyze .          # build + run every analysis, print top risks

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,6 +10,7 @@ CyberGraph is built around one idea: security review should be graph-first, not 
 4. Import external scanner reports into the same database.
 5. Retrieve evidence for security questions using graph context plus findings.
 6. One 'analyze' command builds once and fans every analysis into a shared AnalysisResult consumed by the CLI, HTML report, and MCP server.
+7. The HTML report is theme-aware with one unified search, a truncation banner, and opt-in secret-redacted source drill-down; 'quickstart' runs the whole flow in one command.
 
 ## Current graph model
 

--- a/docs/specs/2026-07-19-report-onboarding-polish-design.md
+++ b/docs/specs/2026-07-19-report-onboarding-polish-design.md
@@ -1,0 +1,167 @@
+# Design Spec — Report & Onboarding Polish (Theme A, Spec 2)
+
+**Status:** approved design, pre-implementation
+**Author:** Laraib
+**Date:** 2026-07-19
+**Depends on:** Spec 1 "Usability Core" (`run_full_analysis`, `AnalysisResult`, the real `truncated`
+signal) — this work branches off `feat/usability-core`.
+**Scope:** second workstream of Theme A — make the HTML report and first-run experience delightful
+for both a security engineer (report) and a developer (quick onboarding).
+
+---
+
+## Context
+
+The HTML report (`src/cybergraph/visualize.py`, ~800 lines) is a single self-contained, offline
+file: a Cytoscape graph explorer (4 modes) above static tables, with search/filters and a details
+panel. Confirmed limitations:
+- **Light-mode only** — CSS is hardcoded `:root { color-scheme: light }`; no dark theme.
+- **Two separate search boxes** — the graph (`#cg-search`) and the findings table each have their
+  own text search.
+- **No visible truncation banner** — the graph/report caps at 600 nodes; the `truncated` flag
+  exists (now real, from Spec 1) but the report never tells the user.
+- **No source drill-down** — nodes carry `file`/`line` but the details panel shows no code.
+
+Onboarding is `init` + `doctor` + README; first run is a multi-command sequence with no single
+guided path.
+
+**Outcome:** a theme-aware report with one search, a truncation banner, opt-in in-report source
+snippets, and a one-command `quickstart` that takes a new user from zero to an open report.
+
+## Principles / constraints
+
+- **Self-contained & offline:** no CDN, no network, no external fonts/assets. Everything inlined.
+- **No new hard dependencies.** Theming/search/snippets are hand-rolled HTML/CSS/JS + stdlib Python.
+- **Additive & non-breaking:** the 4 explorer modes, filters, details panel, and existing tables
+  keep working unchanged.
+- **Security first (this is a security tool):** the report is a shareable artifact — source
+  embedding is **opt-in and secret-redacted** (see D).
+- Commits authored as the user only (no co-author trailer), on `feat/report-onboarding-polish`.
+
+## Non-goals (this spec)
+
+- Refactoring `visualize.py` into a templating framework (targeted in-place edits only).
+- An interactive TUI (the guided path is a non-interactive-friendly command).
+- Temporal/threat-intel/detection features (later themes).
+
+---
+
+## A. Theme-aware report
+
+- Convert the hardcoded light CSS to **CSS custom properties** on `:root` (e.g. `--bg`, `--fg`,
+  `--panel`, `--border`, `--muted`, `--accent`), with a **dark palette** under both
+  `@media (prefers-color-scheme: dark)` and `:root[data-theme="dark"]`, and explicit
+  `:root[data-theme="light"]` overrides so the toggle wins in both directions.
+- **Toggle button** in the header; the choice persists to `localStorage` (`cybergraph-theme`).
+- **No flash of wrong theme:** an inline `<script>` in `<head>` reads `localStorage`/`prefers-color-scheme`
+  and stamps `data-theme` on `<html>` before first paint.
+- **Cytoscape must recolor on toggle** (its styles are set in JS from values, not CSS): read the
+  canvas background, node-label, and edge colors from CSS variables at init, and on theme change
+  re-apply via `cy.style()`/`cy.container` background + `cy.style().update()`. **Node group
+  semantic colors (the 12 `NODE_GROUPS`) stay fixed** across themes (they carry meaning); ensure
+  legibility on dark by adding a subtle node border/halo.
+- Files: `src/cybergraph/visualize.py` (CSS block, header toggle, ~15 lines of JS).
+
+## B. Unified text search
+
+- Replace the two separate text inputs with **one** `#cg-search`; a single handler filters **both**
+  the graph (dim/hide non-matching nodes, as today) **and** the findings-table rows (hide
+  non-matching), matching on name/file/group/message.
+- **Leave the two severity `<select>` filters as-is** — graph min-severity and findings
+  min-severity are intentionally different scopes; document this in a code comment. (Unifying them
+  is out of scope.)
+- Files: `src/cybergraph/visualize.py` (remove the second search input; extend the handler).
+
+## C. Truncation banner
+
+- When `build_graph_data(...)['truncated']` is true, render a visible banner above the graph:
+  `Showing N of M nodes — raise --max-nodes to see the full graph.` (N = shown nodes, M = total).
+  Hidden entirely when not truncated.
+- Files: `src/cybergraph/visualize.py` (the JSON already carries the counts; add the banner element
+  + one conditional).
+
+## D. Opt-in, secret-redacted source drill-down
+
+- **New module `src/cybergraph/report_source.py`:**
+  `attach_source_snippets(repo_root, graph_data, *, context=3, max_nodes=200, redact_secrets=True)
+  -> None` (mutates `graph_data` in place).
+  - Selects nodes that have a finding **or** lie on an attack path AND have `file` + `line > 0`;
+    caps at `max_nodes` (security/perf bound).
+  - Reads the file with `encoding="utf-8", errors="ignore"`; slices `[line-context, line+context]`
+    with correct **start-of-file / end-of-file clamping** (no negative indices, no overrun).
+  - **HTML-escapes every line** (`html.escape`) — snippets are rendered as text, never markup.
+  - Attaches `node["snippet"] = {"file": rel, "start": s, "lines": [{"n": int, "text": str,
+    "highlight": bool}]}` where `highlight` marks the finding/target line.
+  - **Secret redaction:** for any node whose finding `rule_id`/category indicates a secret
+    (`"SECRET"` in rule_id, or secret-category), the highlighted line's value is masked
+    (`text` replaced with the key/prefix + `= "***redacted***"`), so a shared report never leaks a
+    credential. Governed by `redact_secrets` (default True).
+  - Best-effort: unreadable/binary/missing files → node simply gets no snippet (never raises).
+- **`visualize.py`:** call `attach_source_snippets` only when source embedding is enabled (see the
+  `--with-source` flag); the details-panel JS renders the snippet (line numbers, monospace,
+  highlighted line) when present, and shows nothing extra when absent.
+- **`generate_html_report(repo_root, output=None, *, with_source=False)`** gains a keyword; default
+  **off** (no source embedded → smallest, safest report).
+- Files: new `src/cybergraph/report_source.py`; `src/cybergraph/visualize.py` (details panel + call).
+
+## E. Guided `quickstart` command
+
+- **New `src/cybergraph/quickstart.py`:** `run_quickstart(repo_root, *, open_report, with_source)
+  -> QuickstartResult` — runs, in order, `init_project` (only if no `.cybergraph.toml`), then
+  `build_graph`, then `run_full_analysis` (reused from Spec 1), then `generate_html_report`. Returns
+  a small result (steps run, counts, top risk, report path). Each step logged as
+  `[k/4] <step> ... <one-line outcome>`; a step failure is reported and, where safe, the flow
+  continues.
+- **CLI `quickstart [repo] [--yes] [--no-open] [--with-source]`** (in `cli.py`): prints the step
+  log + the single highest risk + the report path. **Browser open** only when `open_report` and the
+  session is interactive — i.e. **not** when `--no-open`, not when `stdout` isn't a TTY, and not
+  when a `CI` env var is set (guarded `webbrowser.open`, never blocks). `--yes` makes it fully
+  non-interactive; `--with-source` forwards to the report.
+- Files: new `src/cybergraph/quickstart.py`; `src/cybergraph/cli.py` (parser + dispatch).
+
+---
+
+## Data flow
+
+`build_graph_data` (+ real `truncated`) → *(optional)* `attach_source_snippets` → JSON injected
+into the themed HTML (one search, banner, drill-down). `quickstart`: `init?` → `build` →
+`run_full_analysis` → `generate_html_report` → guarded browser open.
+
+## Error handling
+
+- Snippet reader: best-effort per node; any read/parse error → skip that node's snippet, never
+  crash the report.
+- Theme: if `localStorage` is unavailable, fall back to `prefers-color-scheme`.
+- `quickstart`: per-step failures are reported with a clear message; `webbrowser.open` is wrapped so
+  a missing browser never aborts or hangs.
+
+## Testing (add ~14–18; keep the current 203 green)
+
+- **Theme:** generated HTML contains the CSS variables, both `prefers-color-scheme: dark` and
+  `:root[data-theme="dark"]`, the head anti-FOUC script, and a theme-toggle control.
+- **Search:** the HTML contains exactly **one** text-search input (`#cg-search`) — assert the second
+  one is gone — and the handler references both the graph and the findings table.
+- **Banner:** present with "of" + node counts when the graph is truncated (build a &gt;600-node
+  fixture or monkeypatch the cap); absent when not truncated.
+- **`attach_source_snippets`:** correct lines + `highlight` on the finding line; start-of-file
+  (line 1) and end-of-file clamping; HTML-escaping of `<`/`&`; **secret redaction** masks the value
+  for a `*-SECRET` finding; missing file → no snippet, no raise; `max_nodes` cap respected.
+- **`with_source` default off:** `generate_html_report` embeds no source unless `with_source=True`.
+- **`quickstart`:** end-to-end on a tiny repo — builds, analyzes, writes the report, exit 0; `--yes`
+  is non-interactive; `--no-open`/CI never opens a browser (assert `webbrowser.open` not called via
+  monkeypatch).
+
+## Verification (end-to-end)
+
+1. `quickstart examples/vulnerable-fastapi --no-open` prints a 4-step log + top risk + report path.
+2. Open the report; toggle theme (both look correct; graph recolors); one search box filters graph +
+   findings; truncation banner shows only on a large repo.
+3. `visualize examples/vulnerable-fastapi --with-source` embeds highlighted snippets; a secret
+   finding's value is redacted in the HTML. Default (no flag) embeds no source.
+4. Full `pytest` green (≥ ~217 passed).
+
+## Out of scope / follow-ups
+
+- Unifying the two severity filters; a source *viewer* (whole file) vs. snippet; opening source in
+  an editor/GitHub deep-link (could pair with `--with-source` later); templating-framework refactor
+  of `visualize.py`.

--- a/docs/superpowers/plans/2026-07-19-report-onboarding-polish.md
+++ b/docs/superpowers/plans/2026-07-19-report-onboarding-polish.md
@@ -1,0 +1,815 @@
+# Report & Onboarding Polish Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the CyberGraph HTML report theme-aware with one unified search, a truncation banner, and opt-in secret-redacted source drill-down, and add a guided `quickstart` command.
+
+**Architecture:** Targeted, additive edits to the existing self-contained `visualize.py` template (CSS variables + a theme toggle, one search handler, a banner token, a details-panel snippet renderer), a new pure-Python `report_source.py` for snippet gathering, and a new `quickstart.py` + CLI command reusing Spec 1's `run_full_analysis`.
+
+**Tech Stack:** Python 3.10+ stdlib (html, json, webbrowser, pathlib), inlined Cytoscape.js (already vendored); pytest. No new dependencies; report stays 100% offline/self-contained.
+
+## Global Constraints
+
+- Branch off `feat/usability-core` (this depends on Spec 1's `run_full_analysis` and the real `truncated` flag). Work on `feat/report-onboarding-polish`.
+- **Self-contained/offline:** no CDN, no network, no external fonts/assets — everything inlined.
+- **No new hard dependencies.**
+- **Additive & non-breaking:** the 4 Cytoscape explorer modes, filters, details panel, tables, and existing commands keep working.
+- **Security:** source embedding is opt-in (`with_source=False` default) and secret-category findings are redacted in embedded snippets.
+- Commits authored as the user only — **no `Co-Authored-By` / Claude attribution trailer**; no `--no-verify`.
+- Tests run `PYTHONPATH=src python -m pytest -q`; baseline is **203 passed**; must stay green after every task.
+- Reuse existing symbols:
+  - `cybergraph.visualize.generate_html_report(repo_root, output=None) -> Path`; internal `_render_html(...)`, `_findings_table(findings)`, `_HTML_TEMPLATE` (token replacement via `__TOKEN__`), `_embed_json(data)`.
+  - `cybergraph.graph_export.build_graph_data(repo_root, max_nodes=600) -> dict` (keys include `nodes`, `truncated`, and `counts`).
+  - `cybergraph.orchestrator.run_full_analysis(repo_root, *, limit=10) -> AnalysisResult` (Spec 1).
+  - `cybergraph.init_project.init_project(repo, force=False)`, `cybergraph.build.build_graph(repo)`, `cybergraph.graph.GraphStore.open_for_repo(repo)`.
+
+## File Structure
+
+- Create `src/cybergraph/report_source.py` — source-snippet gathering + secret redaction.
+- Modify `src/cybergraph/visualize.py` — `with_source` param + snippet call; theme CSS/toggle; unified search; truncation banner; details-panel snippet render.
+- Create `src/cybergraph/quickstart.py` — `run_quickstart` orchestration.
+- Modify `src/cybergraph/cli.py` — `quickstart` command; forward `--with-source` to `visualize`.
+- Modify `README.md`, `docs/architecture.md` — document `quickstart` + report features.
+- Tests: `tests/test_report_source.py`, `tests/test_report_theme.py`, `tests/test_report_search.py`, `tests/test_report_banner.py`, `tests/test_report_drilldown.py`, `tests/test_quickstart.py`.
+
+---
+
+### Task 1: Source-snippet gathering with secret redaction (`report_source.py`)
+
+**Files:**
+- Create: `src/cybergraph/report_source.py`
+- Test: `tests/test_report_source.py`
+
+**Interfaces:**
+- Produces: `attach_source_snippets(repo_root: Path, graph_data: dict, *, context: int = 3, max_nodes: int = 200, redact_secrets: bool = True) -> None` (mutates each qualifying node dict, adding `node["snippet"] = {"file": str, "start": int, "lines": [{"n": int, "text": str, "highlight": bool}]}`).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_report_source.py
+from pathlib import Path
+
+from cybergraph.report_source import attach_source_snippets
+
+
+def _graph(repo: Path, extra=None):
+    node = {"id": "app.py::h", "file": "app.py", "line": 3, "findings": []}
+    if extra:
+        node.update(extra)
+    return {"nodes": [node]}
+
+
+def _write(repo: Path, name: str, text: str):
+    (repo / name).write_text(text, encoding="utf-8")
+
+
+def test_attaches_highlighted_snippet_for_finding_node(tmp_path: Path):
+    _write(tmp_path, "app.py", "a = 1\nb = 2\nrun(x)\nc = 3\nd = 4\n")
+    g = _graph(tmp_path, {"findings": [{"severity": "high", "rule_id": "CG-X", "message": "m"}]})
+    attach_source_snippets(tmp_path, g, context=1)
+    snip = g["nodes"][0]["snippet"]
+    assert snip["file"] == "app.py"
+    nums = [ln["n"] for ln in snip["lines"]]
+    assert nums == [2, 3, 4]  # context=1 around line 3, clamped
+    hl = [ln for ln in snip["lines"] if ln["highlight"]]
+    assert len(hl) == 1 and hl[0]["n"] == 3 and "run(x)" in hl[0]["text"]
+
+
+def test_start_of_file_clamps_without_negative(tmp_path: Path):
+    _write(tmp_path, "app.py", "run(x)\nb = 2\n")
+    g = _graph(tmp_path, {"line": 1, "findings": [{"rule_id": "CG-X", "severity": "high", "message": "m"}]})
+    attach_source_snippets(tmp_path, g, context=3)
+    assert [ln["n"] for ln in g["nodes"][0]["snippet"]["lines"]] == [1, 2]
+
+
+def test_html_is_escaped(tmp_path: Path):
+    _write(tmp_path, "app.py", "x = '<b>&</b>'\n")
+    g = _graph(tmp_path, {"line": 1, "findings": [{"rule_id": "CG-X", "severity": "high", "message": "m"}]})
+    attach_source_snippets(tmp_path, g)
+    text = g["nodes"][0]["snippet"]["lines"][0]["text"]
+    assert "&lt;b&gt;" in text and "<b>" not in text
+
+
+def test_secret_finding_line_is_redacted(tmp_path: Path):
+    _write(tmp_path, "Dockerfile", "FROM x\nENV API_KEY=supersecretvalue\n")
+    g = _graph(tmp_path, {"id": "Dockerfile", "file": "Dockerfile", "line": 2,
+                          "findings": [{"rule_id": "CG-DOCKER-SECRET", "severity": "critical", "message": "m"}]})
+    attach_source_snippets(tmp_path, g, context=0)
+    line = g["nodes"][0]["snippet"]["lines"][0]
+    assert line["highlight"] is True
+    assert "supersecretvalue" not in line["text"]
+    assert "redacted" in line["text"].lower()
+
+
+def test_node_without_finding_or_file_gets_no_snippet(tmp_path: Path):
+    g = {"nodes": [{"id": "n", "file": "", "line": 0, "findings": []},
+                   {"id": "m", "file": "missing.py", "line": 5, "findings": [{"rule_id": "R", "severity": "low", "message": "x"}]}]}
+    attach_source_snippets(tmp_path, g)
+    assert "snippet" not in g["nodes"][0]  # no file
+    assert "snippet" not in g["nodes"][1]  # file missing -> best-effort skip
+
+
+def test_max_nodes_cap(tmp_path: Path):
+    _write(tmp_path, "app.py", "run(x)\n")
+    nodes = [{"id": f"n{i}", "file": "app.py", "line": 1,
+              "findings": [{"rule_id": "R", "severity": "low", "message": "x"}]} for i in range(5)]
+    g = {"nodes": nodes}
+    attach_source_snippets(tmp_path, g, context=0, max_nodes=2)
+    assert sum("snippet" in n for n in g["nodes"]) == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_report_source.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'cybergraph.report_source'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/cybergraph/report_source.py
+"""Attach bounded, HTML-escaped, secret-redacted source snippets to graph nodes.
+
+Opt-in: only called when the report is generated with source embedding enabled.
+The report is a shareable artifact, so snippets for secret-category findings have
+their value masked, and every line is HTML-escaped."""
+
+from __future__ import annotations
+
+import html
+from pathlib import Path
+
+_REDACTED = '"***redacted***"'
+
+
+def _is_secret_finding(findings: list) -> bool:
+    for f in findings or []:
+        rule = str(f.get("rule_id", "")).upper()
+        if "SECRET" in rule or "CREDENTIAL" in rule or "PASSWORD" in rule:
+            return True
+    return False
+
+
+def _redact(text: str) -> str:
+    """Mask a value after the first '=' or ':' so a shared report never leaks it."""
+    for sep in ("=", ":"):
+        idx = text.find(sep)
+        if idx != -1:
+            return text[: idx + 1] + " " + _REDACTED
+    return _REDACTED
+
+
+def attach_source_snippets(
+    repo_root: Path,
+    graph_data: dict,
+    *,
+    context: int = 3,
+    max_nodes: int = 200,
+    redact_secrets: bool = True,
+) -> None:
+    repo_root = Path(repo_root).resolve()
+    cache: dict[str, list[str] | None] = {}
+    attached = 0
+    for node in graph_data.get("nodes", []):
+        if attached >= max_nodes:
+            break
+        rel = node.get("file") or ""
+        line = int(node.get("line") or 0)
+        findings = node.get("findings") or []
+        on_path = bool(node.get("on_path"))
+        if not rel or line <= 0 or not (findings or on_path):
+            continue
+        if rel not in cache:
+            try:
+                cache[rel] = (repo_root / rel).read_text(encoding="utf-8", errors="ignore").splitlines()
+            except OSError:
+                cache[rel] = None
+        lines = cache[rel]
+        if not lines:
+            continue
+        secret = redact_secrets and _is_secret_finding(findings)
+        lo = max(1, line - context)
+        hi = min(len(lines), line + context)
+        rendered = []
+        for n in range(lo, hi + 1):
+            raw = lines[n - 1]
+            highlight = n == line
+            if highlight and secret:
+                raw = _redact(raw)
+            rendered.append({"n": n, "text": html.escape(raw), "highlight": highlight})
+        node["snippet"] = {"file": rel, "start": lo, "lines": rendered}
+        attached += 1
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_report_source.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/report_source.py tests/test_report_source.py
+git commit -m "feat(report): add secret-redacted source-snippet gathering"
+```
+
+---
+
+### Task 2: Opt-in source drill-down in the report (`visualize.py`)
+
+**Files:**
+- Modify: `src/cybergraph/visualize.py` (`generate_html_report` signature; call `attach_source_snippets`; add snippet CSS; extend `showDetails` JS)
+- Test: `tests/test_report_drilldown.py`
+
+**Interfaces:**
+- Consumes: `attach_source_snippets` (Task 1).
+- Produces: `generate_html_report(repo_root, output=None, *, with_source: bool = False) -> Path`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_report_drilldown.py
+from pathlib import Path
+
+from cybergraph.build import build_graph
+from cybergraph.visualize import generate_html_report
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "@app.route('/x')\n"
+        "def h(request):\n"
+        "    return db.execute('select ' + request.query['q'])\n",
+        encoding="utf-8",
+    )
+    build_graph(repo)
+    return repo
+
+
+def test_default_off_embeds_no_snippet(tmp_path: Path):
+    repo = _repo(tmp_path)
+    out = generate_html_report(repo, tmp_path / "r.html")
+    html = out.read_text(encoding="utf-8")
+    assert '"snippet"' not in html
+
+
+def test_with_source_embeds_snippet_and_render_code(tmp_path: Path):
+    repo = _repo(tmp_path)
+    out = generate_html_report(repo, tmp_path / "r.html", with_source=True)
+    html = out.read_text(encoding="utf-8")
+    assert '"snippet"' in html                 # snippet data embedded
+    assert "db.execute" in html                # the finding line is present
+    assert "cg-snippet" in html                # details-panel renderer markup/class
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_report_drilldown.py -v`
+Expected: FAIL — `generate_html_report() got an unexpected keyword argument 'with_source'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `visualize.py`, change the signature and add the snippet call. Find the current `def generate_html_report(repo_root: Path, output: Path | None = None) -> Path:` and its body that calls `build_graph_data` (via `_render_html`/graph assembly). Update to:
+
+```python
+def generate_html_report(repo_root: Path, output: Path | None = None, *, with_source: bool = False) -> Path:
+```
+
+Locate where `graph_data` is obtained (it comes from `build_graph_data` and is passed into `_render_html`). Immediately after `graph_data` is built and before it is embedded, add:
+
+```python
+    if with_source:
+        from cybergraph.report_source import attach_source_snippets
+
+        attach_source_snippets(repo_root, graph_data)
+```
+
+Add snippet CSS inside the `<style>` block (before the closing `</style>` at the `@media (max-width: 820px)` line). Add:
+
+```css
+    .cg-snippet { margin-top: 8px; border: 1px solid var(--border, #d0d7de); border-radius: 8px; overflow: auto; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
+    .cg-snippet .ln { display: flex; gap: 10px; padding: 1px 8px; white-space: pre; }
+    .cg-snippet .ln .num { color: var(--muted, #94a3b8); user-select: none; min-width: 30px; text-align: right; }
+    .cg-snippet .ln.hl { background: rgba(245, 158, 11, 0.18); }
+```
+
+In the `showDetails` function, immediately before `document.getElementById('cg-details').innerHTML = html;` (currently line ~745), add the snippet renderer:
+
+```javascript
+        const snip = d.snippet;
+        if (snip && snip.lines && snip.lines.length) {
+          html += '<div class="kv"><strong>Source:</strong> <code>' + esc(snip.file) + '</code></div>';
+          html += '<div class="cg-snippet">';
+          snip.lines.forEach(function (ln) {
+            html += '<div class="ln' + (ln.highlight ? ' hl' : '') + '"><span class="num">' + esc(ln.n) + '</span><span>' + ln.text + '</span></div>';
+          });
+          html += '</div>';
+        }
+```
+
+(Note: `ln.text` is already HTML-escaped by Task 1, so it is inserted as-is; all other interpolations use `esc`.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_report_drilldown.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/visualize.py tests/test_report_drilldown.py
+git commit -m "feat(report): opt-in source drill-down in the details panel"
+```
+
+---
+
+### Task 3: Theme-aware report (dark/light + toggle) (`visualize.py`)
+
+**Files:**
+- Modify: `src/cybergraph/visualize.py` (`<style>` → CSS variables + dark palette; `<head>` anti-FOUC script; header toggle button; cy label theming)
+- Test: `tests/test_report_theme.py`
+
+**Interfaces:**
+- Produces: generated HTML with theme variables, a `data-theme` toggle, and dark-scheme support.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_report_theme.py
+from pathlib import Path
+
+from cybergraph.build import build_graph
+from cybergraph.visualize import generate_html_report
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    build_graph(repo)
+    return repo
+
+
+def test_report_is_theme_aware(tmp_path: Path):
+    html = generate_html_report(_repo(tmp_path), tmp_path / "r.html").read_text(encoding="utf-8")
+    assert "--bg" in html and "--fg" in html                 # CSS variables
+    assert "prefers-color-scheme: dark" in html               # auto dark
+    assert '[data-theme="dark"]' in html                      # explicit override
+    assert 'id="cg-theme-toggle"' in html                     # toggle control
+    assert "localStorage" in html and "cybergraph-theme" in html  # persistence + anti-FOUC
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_report_theme.py -v`
+Expected: FAIL — `--bg`/`data-theme` not present.
+
+- [ ] **Step 3: Write minimal implementation**
+
+(a) Replace the first two `<style>` lines (currently `:root { color-scheme: light; ... }` and `body { ... background: #f5f7fb; color: #111827; }`) with theme variables + a dark palette, and change the hardcoded surface colors to variables:
+
+```css
+    :root {
+      color-scheme: light; font-family: Inter, Segoe UI, Arial, sans-serif;
+      --bg: #f5f7fb; --fg: #111827; --panel: #ffffff; --border: #d8e0ea;
+      --muted: #667085; --th: #f0f3f6; --cy-bg: #f8fafc;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root { color-scheme: dark; --bg: #0b1220; --fg: #e5e7eb; --panel: #111827;
+              --border: #243044; --muted: #94a3b8; --th: #1a2334; --cy-bg: #0b1220; }
+    }
+    :root[data-theme="dark"] { color-scheme: dark; --bg: #0b1220; --fg: #e5e7eb; --panel: #111827;
+              --border: #243044; --muted: #94a3b8; --th: #1a2334; --cy-bg: #0b1220; }
+    :root[data-theme="light"] { color-scheme: light; --bg: #f5f7fb; --fg: #111827; --panel: #ffffff;
+              --border: #d8e0ea; --muted: #667085; --th: #f0f3f6; --cy-bg: #f8fafc; }
+    body { margin: 0; background: var(--bg); color: var(--fg); }
+```
+
+Then change these existing rules to use the variables (replace the literal colors):
+- `.muted { color: var(--muted); }`
+- `.stat, table { background: var(--panel); border: 1px solid var(--border); ... }` (keep the box-shadow)
+- `th, td { ... border-bottom: 1px solid var(--border); }` and `th { background: var(--th); ... }`
+- `.graph-card, .details { background: var(--panel); border: 1px solid var(--border); ... }`
+- `#cy { height: 640px; background: var(--cy-bg); }`
+
+(b) In `<head>`, before `</head>`, add the anti-FOUC + toggle bootstrap script:
+
+```html
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem('cybergraph-theme');
+        if (!t) t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        document.documentElement.setAttribute('data-theme', t);
+      } catch (e) {}
+    })();
+  </script>
+```
+
+(c) In the `<header>` (after the `<h1>`), add the toggle button:
+
+```html
+    <button id="cg-theme-toggle" type="button" style="position:absolute;top:20px;right:24px;cursor:pointer;border:1px solid rgba(255,255,255,0.4);background:transparent;color:white;border-radius:6px;padding:6px 10px;">Theme</button>
+```
+
+Set `header { ... position: relative; }` (append `position: relative;` to the existing `header` rule).
+
+(d) At the end of the second `<script>` block (after the findings filter listeners, before `</script>` at line ~796), add the toggle handler:
+
+```javascript
+    document.getElementById('cg-theme-toggle')?.addEventListener('click', function () {
+      var cur = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', cur);
+      try { localStorage.setItem('cybergraph-theme', cur); } catch (e) {}
+    });
+```
+
+(e) Cy label legibility on dark: in the cy `style` array, node selector (currently `'color': '#0b1220'`), add a text outline so labels read on both themes — change that node style block to include:
+
+```javascript
+            'color': '#0b1220', 'text-outline-width': 2, 'text-outline-color': '#f8fafc',
+```
+
+(This white halo keeps dark node labels legible on a dark canvas; semantic node fill colors are unchanged.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_report_theme.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/visualize.py tests/test_report_theme.py
+git commit -m "feat(report): theme-aware report with dark mode and toggle"
+```
+
+---
+
+### Task 4: Unified text search (`visualize.py`)
+
+**Files:**
+- Modify: `src/cybergraph/visualize.py` (`_findings_table`: remove its own search input; second `<script>`: point the findings filter at `#cg-search`)
+- Test: `tests/test_report_search.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_report_search.py
+from pathlib import Path
+
+from cybergraph.build import build_graph
+from cybergraph.visualize import generate_html_report
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "@app.route('/x')\ndef h(request):\n    return db.execute(request.query['q'])\n",
+        encoding="utf-8",
+    )
+    build_graph(repo)
+    return repo
+
+
+def test_single_unified_search_box(tmp_path: Path):
+    html = generate_html_report(_repo(tmp_path), tmp_path / "r.html").read_text(encoding="utf-8")
+    # the findings table no longer has its own text search input
+    assert "data-filter='findings-search'" not in html and 'data-filter="findings-search"' not in html
+    # exactly one search input remains: the shared #cg-search
+    assert html.count('type="search"') + html.count("type='search'") == 1
+    # the findings filter is wired to the shared box
+    assert "getElementById('cg-search')" in html
+    # the findings severity filter is preserved (kept separate by design)
+    assert "findings-severity" in html
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_report_search.py -v`
+Expected: FAIL — findings-search input still present; two search inputs.
+
+- [ ] **Step 3: Write minimal implementation**
+
+(a) In `_findings_table` (around line 170-182), remove the findings-search input line. Delete these two lines:
+
+```python
+        "<input data-filter='findings-search' type='search' "
+        "placeholder='Search findings by rule, file, message, or tool'>"
+```
+
+so the returned toolbar starts directly with the `findings-severity` select.
+
+(b) In the second `<script>` block (line ~784), change the findings-search reference from its own input to the shared box:
+
+```javascript
+    const findingSearch = document.getElementById('cg-search');
+    const findingSeverity = document.querySelector('[data-filter="findings-severity"]');
+```
+
+Leave `filterFindings`, the `findingSearch?.addEventListener('input', filterFindings)`, and `findingSeverity?.addEventListener('change', filterFindings)` lines as-is — they now operate on the shared `#cg-search` input. (Result: typing in `#cg-search` filters both the graph — via the existing `applyFilters` listener at line 763 — and the findings table.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_report_search.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/visualize.py tests/test_report_search.py
+git commit -m "feat(report): unify graph and findings search into one box"
+```
+
+---
+
+### Task 5: Truncation banner (`visualize.py`)
+
+**Files:**
+- Modify: `src/cybergraph/visualize.py` (add `_truncation_banner` helper + `__TRUNCATION_BANNER__` token + placement in template)
+- Test: `tests/test_report_banner.py`
+
+**Interfaces:**
+- Produces: `_truncation_banner(graph_data: dict) -> str`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_report_banner.py
+from cybergraph.visualize import _truncation_banner
+
+
+def test_banner_when_truncated():
+    html = _truncation_banner({"truncated": True, "nodes": [0] * 600, "counts": {"nodes": 1500}})
+    assert "600" in html and "1500" in html and "max-nodes" in html
+
+
+def test_no_banner_when_not_truncated():
+    assert _truncation_banner({"truncated": False, "nodes": [0] * 10, "counts": {"nodes": 10}}) == ""
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_report_banner.py -v`
+Expected: FAIL — `cannot import name '_truncation_banner'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the helper near the other `_*` render helpers in `visualize.py`:
+
+```python
+def _truncation_banner(graph_data: dict) -> str:
+    if not graph_data.get("truncated"):
+        return ""
+    shown = len(graph_data.get("nodes", []))
+    total = int(graph_data.get("counts", {}).get("nodes", shown))
+    return (
+        "<div style='margin:0 0 12px;padding:10px 12px;border-radius:8px;"
+        "background:#fef3c7;color:#92400e;border:1px solid #fde68a;font-size:13px;'>"
+        f"Showing {shown} of {total} nodes — raise <code>--max-nodes</code> to see the full graph."
+        "</div>"
+    )
+```
+
+In `_render_html`'s `replacements` dict, add:
+
+```python
+        "__TRUNCATION_BANNER__": _truncation_banner(graph_data),
+```
+
+In `_HTML_TEMPLATE`, place the token right before the graph explorer toolbar — immediately after the `<h2>Interactive Graph Explorer</h2>` / mode-help line and before `<div class="risk-strip"...>`:
+
+```html
+    __TRUNCATION_BANNER__
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_report_banner.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/visualize.py tests/test_report_banner.py
+git commit -m "feat(report): show a truncation banner when the graph is capped"
+```
+
+---
+
+### Task 6: Guided `quickstart` command (`quickstart.py` + `cli.py`)
+
+**Files:**
+- Create: `src/cybergraph/quickstart.py`
+- Modify: `src/cybergraph/cli.py` (parser + dispatch; forward `--with-source` to the `visualize` command too)
+- Test: `tests/test_quickstart.py`
+
+**Interfaces:**
+- Consumes: `init_project`, `build_graph`, `run_full_analysis`, `generate_html_report`.
+- Produces: `run_quickstart(repo_root: Path, *, with_source: bool = False) -> QuickstartResult` (dataclass: `steps: list[str]`, `report_path: Path`, `top_risk: str | None`); CLI command `quickstart [repo] [--yes] [--no-open] [--with-source]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_quickstart.py
+from pathlib import Path
+
+import pytest
+
+from cybergraph.cli import main
+from cybergraph.quickstart import run_quickstart
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "@app.route('/x')\ndef h(request):\n    return db.execute(request.query['q'])\n",
+        encoding="utf-8",
+    )
+    return repo
+
+
+def test_run_quickstart_builds_analyzes_and_writes_report(tmp_path: Path):
+    repo = _repo(tmp_path)
+    result = run_quickstart(repo)
+    assert result.report_path.is_file()
+    assert len(result.steps) == 4
+    assert result.top_risk  # at least one risk on the vulnerable sample
+
+
+def test_cli_quickstart_no_open_never_opens_browser(tmp_path: Path, capsys, monkeypatch):
+    repo = _repo(tmp_path)
+    import webbrowser
+    opened = {"n": 0}
+    monkeypatch.setattr(webbrowser, "open", lambda *a, **k: opened.__setitem__("n", opened["n"] + 1))
+    code = main(["quickstart", str(repo), "--no-open", "--yes"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert opened["n"] == 0                 # browser never opened
+    assert "[1/4]" in out and "[4/4]" in out  # step log printed
+    assert "report" in out.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_quickstart.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'cybergraph.quickstart'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# src/cybergraph/quickstart.py
+"""Guided one-command onboarding: init -> build -> analyze -> report."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from cybergraph.build import build_graph
+from cybergraph.init_project import init_project
+from cybergraph.orchestrator import run_full_analysis
+from cybergraph.visualize import generate_html_report
+
+
+@dataclass
+class QuickstartResult:
+    report_path: Path
+    steps: list[str] = field(default_factory=list)
+    top_risk: str | None = None
+
+
+def run_quickstart(repo_root: Path, *, with_source: bool = False) -> QuickstartResult:
+    repo_root = Path(repo_root).resolve()
+    steps: list[str] = []
+
+    if not (repo_root / ".cybergraph.toml").is_file():
+        init_project(repo_root)
+        steps.append("[1/4] init ... created .cybergraph.toml")
+    else:
+        steps.append("[1/4] init ... config already present")
+
+    counts = build_graph(repo_root)
+    steps.append(f"[2/4] build ... {counts['nodes']} nodes, {counts['findings']} findings")
+
+    result = run_full_analysis(repo_root)
+    top = result.top_risks[0] if result.top_risks else None
+    top_risk = f"{top.risk_label.upper()} {top.risk_score}/100 {top.category}: {top.title}" if top else None
+    steps.append(f"[3/4] analyze ... {len(result.top_risks)} risk(s)"
+                 + (f"; top: {top_risk}" if top_risk else ""))
+
+    report = generate_html_report(repo_root, with_source=with_source)
+    steps.append(f"[4/4] report ... {report}")
+
+    return QuickstartResult(report_path=report, steps=steps, top_risk=top_risk)
+```
+
+In `cli.py` `build_parser`, before `return parser`, add:
+
+```python
+    quickstart = sub.add_parser(
+        "quickstart", help="Zero-to-report: init, build, analyze, and open the HTML report"
+    )
+    quickstart.add_argument("repo", nargs="?", default=".", help="Repository root")
+    quickstart.add_argument("--yes", action="store_true", help="Run non-interactively")
+    quickstart.add_argument("--no-open", action="store_true", help="Do not open the report in a browser")
+    quickstart.add_argument("--with-source", action="store_true", help="Embed (secret-redacted) source snippets in the report")
+```
+
+Add this dispatch branch in `main`:
+
+```python
+    elif args.command == "quickstart":
+        import os
+        import sys
+        import webbrowser
+
+        from .quickstart import run_quickstart
+
+        result = run_quickstart(repo, with_source=args.with_source)
+        for step in result.steps:
+            print(step)
+        can_open = (not args.no_open) and sys.stdout.isatty() and not os.environ.get("CI")
+        if can_open:
+            try:
+                webbrowser.open(result.report_path.as_uri())
+            except Exception:
+                pass
+        print(f"\nOpen the report: {result.report_path}")
+```
+
+Also give the existing `visualize` command a `--with-source` flag and forward it. Find the `visualize` parser and add:
+
+```python
+    visualize.add_argument("--with-source", action="store_true", help="Embed (secret-redacted) source snippets")
+```
+
+and in the `visualize` dispatch branch, change the `generate_html_report(...)` call to pass `with_source=args.with_source`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_quickstart.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/quickstart.py src/cybergraph/cli.py tests/test_quickstart.py
+git commit -m "feat(cli): add guided 'quickstart' command and --with-source report flag"
+```
+
+---
+
+### Task 7: Full-suite verification + docs
+
+**Files:**
+- Modify: `README.md` (Quick start), `docs/architecture.md`
+
+- [ ] **Step 1: Run the full suite**
+
+Run: `PYTHONPATH=src python -m pytest -q`
+Expected: all prior tests plus the new ones PASS (target ≈ 221 passed), no regressions.
+
+- [ ] **Step 2: End-to-end smoke**
+
+Run: `python -c "import sys; from cybergraph.cli import main; sys.exit(main(['quickstart','examples/vulnerable-fastapi','--no-open','--yes']))"`
+Expected: prints `[1/4]`..`[4/4]` and a report path; exit 0.
+
+Run: `python -c "import sys; from cybergraph.cli import main; sys.exit(main(['visualize','examples/vulnerable-fastapi','--with-source']))"` then confirm the report file contains `cg-snippet` and no plaintext secret.
+
+- [ ] **Step 3: Update docs**
+
+In `README.md` Quick start, add near the top:
+```
+cybergraph quickstart .        # zero-to-report: init, build, analyze, open report
+```
+In `docs/architecture.md`, append under "Pipeline": `7. The HTML report is theme-aware with one unified search, a truncation banner, and opt-in secret-redacted source drill-down; 'quickstart' runs the whole flow in one command.`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md docs/architecture.md
+git commit -m "docs: document quickstart and the polished report"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- A. Theme-aware report → Task 3 (CSS vars + dark + toggle + anti-FOUC + cy label outline). ✓
+- B. Unified text search (severity filters kept separate) → Task 4. ✓
+- C. Truncation banner from the real `truncated` flag → Task 5. ✓
+- D. Opt-in, secret-redacted source drill-down → Task 1 (gather+redact) + Task 2 (opt-in plumbing + render). ✓
+- E. Guided `quickstart` with guarded browser open (`--no-open`/non-TTY/CI) + `--yes` + `--with-source` → Task 6. ✓
+- Testing (theme/search/banner/snippet/redaction/quickstart) → each task + Task 7. ✓
+- Self-contained/offline, additive, no new deps → constraints honored (no CDN/asset added; all edits additive). ✓
+
+**Placeholder scan:** no TBD/TODO; every code step has complete code or a precise anchored snippet + complete test code. ✓
+
+**Type consistency:** `attach_source_snippets` snippet shape (`{file,start,lines:[{n,text,highlight}]}`) matches the `showDetails` renderer (Task 2) and the tests (Task 1). `generate_html_report(..., with_source=...)` signature matches its callers in Task 6 and the `visualize`/`quickstart` dispatch. `_truncation_banner(graph_data)` matches its token use. `run_quickstart(...) -> QuickstartResult(report_path, steps, top_risk)` matches the CLI dispatch and tests. ✓
+
+**Note for the implementer:** Tasks 2–5 edit the large embedded HTML/JS template in `visualize.py`; make the edits at the exact anchors named (line numbers are current-as-of-writing and may drift — match on the quoted surrounding text, not the number) and keep every existing token/handler intact. The tests assert the required HTML structure, so a broken edit fails fast.

--- a/src/cybergraph/cli.py
+++ b/src/cybergraph/cli.py
@@ -185,6 +185,7 @@ def build_parser() -> argparse.ArgumentParser:
     visualize = sub.add_parser("visualize", help="Generate a self-contained HTML security report")
     visualize.add_argument("repo", nargs="?", default=".", help="Repository root containing the graph")
     visualize.add_argument("--output", help="Output HTML path. Defaults to .cybergraph/report.html")
+    visualize.add_argument("--with-source", action="store_true", help="Embed (secret-redacted) source snippets")
 
     top_risks = sub.add_parser("top-risks", help="Show the highest-priority risks across graph layers")
     top_risks.add_argument("repo", nargs="?", default=".", help="Repository root containing the graph")
@@ -257,6 +258,14 @@ def build_parser() -> argparse.ArgumentParser:
     config_sub = config_cmd.add_subparsers(dest="config_action", required=True)
     config_show = config_sub.add_parser("show", help="Show the effective configuration")
     config_show.add_argument("repo", nargs="?", default=".", help="Repository root")
+
+    quickstart = sub.add_parser(
+        "quickstart", help="Zero-to-report: init, build, analyze, and open the HTML report"
+    )
+    quickstart.add_argument("repo", nargs="?", default=".", help="Repository root")
+    quickstart.add_argument("--yes", action="store_true", help="Run non-interactively")
+    quickstart.add_argument("--no-open", action="store_true", help="Do not open the report in a browser")
+    quickstart.add_argument("--with-source", action="store_true", help="Embed (secret-redacted) source snippets in the report")
 
     return parser
 
@@ -431,7 +440,9 @@ def main(argv: list[str] | None = None) -> int:
         output = export_sarif(repo, Path(args.output).resolve())
         print(f"Wrote SARIF report: {output}")
     elif args.command == "visualize":
-        output = generate_html_report(repo, Path(args.output).resolve() if args.output else None)
+        output = generate_html_report(
+            repo, Path(args.output).resolve() if args.output else None, with_source=args.with_source
+        )
         print(f"Wrote CyberGraph HTML report: {output}")
     elif args.command == "top-risks":
         from .security.investigate import collect_top_risks, format_top_risks
@@ -528,6 +539,23 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Custom sinks: {list(cfg.custom_sinks)}")
         print(f"Suppressed rules: {list(cfg.suppressed_rules)}")
         print(f"Suppressed paths: {list(cfg.suppressed_paths)}")
+    elif args.command == "quickstart":
+        import os
+        import sys
+        import webbrowser
+
+        from .quickstart import run_quickstart
+
+        result = run_quickstart(repo, with_source=args.with_source)
+        for step in result.steps:
+            print(step)
+        can_open = (not args.no_open) and sys.stdout.isatty() and not os.environ.get("CI")
+        if can_open:
+            try:
+                webbrowser.open(result.report_path.as_uri())
+            except Exception:
+                pass
+        print(f"\nOpen the report: {result.report_path}")
     else:
         parser.error(f"Unknown command: {args.command}")
     return 0

--- a/src/cybergraph/graph_export.py
+++ b/src/cybergraph/graph_export.py
@@ -79,6 +79,7 @@ def build_graph_data(repo_root: Path, max_nodes: int = 600) -> dict[str, Any]:
             "kind": row["kind"],
             "file": row["file_path"] or "",
             "line": row["line_start"] or 0,
+            "line_end": row["line_end"] or 0,
             "properties": props,
             "severity": "",
             "findings": [],
@@ -202,8 +203,7 @@ def _attach_findings(nodes: dict[str, dict[str, Any]], finding_rows) -> None:
         if not node["file"] or node["file"] not in by_file:
             continue
         start = node["line"] or 0
-        end = node["properties"].get("line_end") if isinstance(node["properties"], dict) else None
-        end = end or start
+        end = node.get("line_end") or start
         for finding in by_file[node["file"]]:
             line = finding["line"]
             within = start <= line <= max(end, start) if node["kind"] == "Function" else line == start

--- a/src/cybergraph/quickstart.py
+++ b/src/cybergraph/quickstart.py
@@ -1,0 +1,43 @@
+"""Guided one-command onboarding: init -> build -> analyze -> report."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from cybergraph.build import build_graph
+from cybergraph.init_project import init_project
+from cybergraph.orchestrator import run_full_analysis
+from cybergraph.visualize import generate_html_report
+
+
+@dataclass
+class QuickstartResult:
+    report_path: Path
+    steps: list[str] = field(default_factory=list)
+    top_risk: str | None = None
+
+
+def run_quickstart(repo_root: Path, *, with_source: bool = False) -> QuickstartResult:
+    repo_root = Path(repo_root).resolve()
+    steps: list[str] = []
+
+    if not (repo_root / ".cybergraph.toml").is_file():
+        init_project(repo_root)
+        steps.append("[1/4] init ... created .cybergraph.toml")
+    else:
+        steps.append("[1/4] init ... config already present")
+
+    counts = build_graph(repo_root)
+    steps.append(f"[2/4] build ... {counts['nodes']} nodes, {counts['findings']} findings")
+
+    result = run_full_analysis(repo_root)
+    top = result.top_risks[0] if result.top_risks else None
+    top_risk = f"{top.risk_label.upper()} {top.risk_score}/100 {top.category}: {top.title}" if top else None
+    steps.append(f"[3/4] analyze ... {len(result.top_risks)} risk(s)"
+                 + (f"; top: {top_risk}" if top_risk else ""))
+
+    report = generate_html_report(repo_root, with_source=with_source)
+    steps.append(f"[4/4] report ... {report}")
+
+    return QuickstartResult(report_path=report, steps=steps, top_risk=top_risk)

--- a/src/cybergraph/report_source.py
+++ b/src/cybergraph/report_source.py
@@ -1,32 +1,45 @@
 """Attach bounded, HTML-escaped, secret-redacted source snippets to graph nodes.
 
 Opt-in: only called when the report is generated with source embedding enabled.
-The report is a shareable artifact, so snippets for secret-category findings have
-their value masked, and every line is HTML-escaped."""
+The report is a shareable artifact, so redaction is **content-based and applied to
+every embedded line** (highlighted and context) — a secret-looking assignment or a
+recognizable key pattern is masked no matter which finding triggered the snippet.
+Snippets are anchored on the *finding's* line (not the node's line) so File-level
+findings (IaC, secrets) highlight the right code. Every line is HTML-escaped."""
 
 from __future__ import annotations
 
 import html
+import re
 from pathlib import Path
 
-_REDACTED = '"***redacted***"'
+_REDACTION = "***redacted***"
+
+# A `KEY = VALUE` / `KEY: VALUE` assignment; group 1 is the key, `val` is the value.
+_ASSIGN_RE = re.compile(r"([A-Za-z_][\w.\-]*)\s*[:=]\s*(?P<val>\S.*)$")
+# The key names that make an assignment's value a secret.
+_SECRET_KEY_RE = re.compile(
+    r"(?i)(pass(?:word|wd|phrase)?|secret|token|api[_-]?key|apikey|access[_-]?key"
+    r"|private[_-]?key|client[_-]?secret|credential|authorization|bearer)"
+)
+# Recognizable key material even without a keyword (AWS access key id).
+_AWS_KEY_RE = re.compile(r"AKIA[0-9A-Z]{12,}")
 
 
-def _is_secret_finding(findings: list) -> bool:
-    for f in findings or []:
-        rule = str(f.get("rule_id", "")).upper()
-        if "SECRET" in rule or "CREDENTIAL" in rule or "PASSWORD" in rule:
-            return True
-    return False
+def _redact_line(text: str) -> tuple[str, bool]:
+    """Mask secret material in a single source line. Returns (text, was_redacted).
 
-
-def _redact(text: str) -> str:
-    """Mask a value after the first '=' or ':' so a shared report never leaks it."""
-    for sep in ("=", ":"):
-        idx = text.find(sep)
-        if idx != -1:
-            return text[: idx + 1] + " " + _REDACTED
-    return _REDACTED
+    Conservative: only redacts a value whose key looks secret, or a recognizable
+    key pattern — ordinary code (``x = 1``, ``db.execute(...)``) passes through."""
+    redacted = False
+    match = _ASSIGN_RE.search(text)
+    if match and _SECRET_KEY_RE.search(match.group(1)):
+        text = text[: match.start("val")] + _REDACTION
+        redacted = True
+    masked = _AWS_KEY_RE.sub(_REDACTION, text)
+    if masked != text:
+        text, redacted = masked, True
+    return text, redacted
 
 
 def attach_source_snippets(
@@ -37,6 +50,12 @@ def attach_source_snippets(
     max_nodes: int = 200,
     redact_secrets: bool = True,
 ) -> None:
+    """Attach a bounded, redacted, HTML-escaped source snippet to qualifying nodes.
+
+    A node qualifies if it has a finding or lies on an attack path AND has a file.
+    The snippet window is centered on the finding's line when available (so a
+    File-level finding highlights its real line, not line 1); every window line is
+    content-redacted (when ``redact_secrets``) then HTML-escaped."""
     repo_root = Path(repo_root).resolve()
     cache: dict[str, list[str] | None] = {}
     attached = 0
@@ -44,10 +63,19 @@ def attach_source_snippets(
         if attached >= max_nodes:
             break
         rel = node.get("file") or ""
-        line = int(node.get("line") or 0)
         findings = node.get("findings") or []
         on_path = bool(node.get("on_path"))
-        if not rel or line <= 0 or not (findings or on_path):
+        node_line = int(node.get("line") or 0)
+
+        # Anchor on a finding line when present — fixes File nodes (line 1) whose
+        # finding is deeper in the file. Highlight every finding line in the window.
+        finding_lines = sorted({int(f.get("line") or 0) for f in findings if int(f.get("line") or 0) > 0})
+        if finding_lines:
+            anchor = min(finding_lines, key=lambda ln: abs(ln - node_line)) if node_line else finding_lines[0]
+        else:
+            anchor = node_line
+
+        if not rel or anchor <= 0 or not (findings or on_path):
             continue
         if rel not in cache:
             try:
@@ -57,15 +85,18 @@ def attach_source_snippets(
         lines = cache[rel]
         if not lines:
             continue
-        secret = redact_secrets and _is_secret_finding(findings)
-        lo = max(1, line - context)
-        hi = min(len(lines), line + context)
+
+        highlight = set(finding_lines) if finding_lines else {anchor}
+        lo = max(1, anchor - context)
+        hi = min(len(lines), anchor + context)
         rendered = []
         for n in range(lo, hi + 1):
             raw = lines[n - 1]
-            highlight = n == line
-            if highlight and secret:
-                raw = _redact(raw)
-            rendered.append({"n": n, "text": html.escape(raw), "highlight": highlight})
+            was_redacted = False
+            if redact_secrets:
+                raw, was_redacted = _redact_line(raw)
+            rendered.append(
+                {"n": n, "text": html.escape(raw), "highlight": n in highlight, "redacted": was_redacted}
+            )
         node["snippet"] = {"file": rel, "start": lo, "lines": rendered}
         attached += 1

--- a/src/cybergraph/report_source.py
+++ b/src/cybergraph/report_source.py
@@ -17,26 +17,37 @@ _REDACTION = "***redacted***"
 
 # A `KEY = VALUE` / `KEY: VALUE` assignment; group 1 is the key, `val` is the value.
 _ASSIGN_RE = re.compile(r"([A-Za-z_][\w.\-]*)\s*[:=]\s*(?P<val>\S.*)$")
-# The key names that make an assignment's value a secret.
+# The key names that make an assignment's *literal* value a secret.
 _SECRET_KEY_RE = re.compile(
     r"(?i)(pass(?:word|wd|phrase)?|secret|token|api[_-]?key|apikey|access[_-]?key"
     r"|private[_-]?key|client[_-]?secret|credential|authorization|bearer)"
 )
-# Recognizable key material even without a keyword (AWS access key id).
-_AWS_KEY_RE = re.compile(r"AKIA[0-9A-Z]{12,}")
+# A value that is a hardcoded literal worth masking: a quoted string, or a bare
+# high-entropy-ish token (no spaces/parens/operators). Expressions and function
+# calls (e.g. ``request.headers.get("x")``) do NOT match, so legit code is kept.
+_LITERAL_VALUE_RE = re.compile(r"""^(?:["'].*|[A-Za-z0-9_\-./+:=]{10,}$)""")
+# Recognizable key material to mask anywhere on a line, regardless of the key.
+_SECRET_VALUE_RE = re.compile(
+    r"AKIA[0-9A-Z]{12,}"                    # AWS access key id
+    r"|sk-[A-Za-z0-9]{16,}"                 # OpenAI-style
+    r"|ghp_[A-Za-z0-9]{20,}"                # GitHub PAT
+    r"|xox[baprs]-[A-Za-z0-9-]{10,}"        # Slack
+    r"|AIza[0-9A-Za-z\-_]{20,}"             # Google API key
+)
 
 
 def _redact_line(text: str) -> tuple[str, bool]:
     """Mask secret material in a single source line. Returns (text, was_redacted).
 
-    Conservative: only redacts a value whose key looks secret, or a recognizable
-    key pattern — ordinary code (``x = 1``, ``db.execute(...)``) passes through."""
+    Precise + fail-safe: masks a secret-keyed value only when it is a literal
+    (quoted string or bare token) — sparing function-call/expression values — and
+    always masks recognizable key patterns anywhere. Ordinary code passes through."""
     redacted = False
     match = _ASSIGN_RE.search(text)
-    if match and _SECRET_KEY_RE.search(match.group(1)):
+    if match and _SECRET_KEY_RE.search(match.group(1)) and _LITERAL_VALUE_RE.match(match.group("val").strip()):
         text = text[: match.start("val")] + _REDACTION
         redacted = True
-    masked = _AWS_KEY_RE.sub(_REDACTION, text)
+    masked = _SECRET_VALUE_RE.sub(_REDACTION, text)
     if masked != text:
         text, redacted = masked, True
     return text, redacted

--- a/src/cybergraph/report_source.py
+++ b/src/cybergraph/report_source.py
@@ -1,0 +1,71 @@
+"""Attach bounded, HTML-escaped, secret-redacted source snippets to graph nodes.
+
+Opt-in: only called when the report is generated with source embedding enabled.
+The report is a shareable artifact, so snippets for secret-category findings have
+their value masked, and every line is HTML-escaped."""
+
+from __future__ import annotations
+
+import html
+from pathlib import Path
+
+_REDACTED = '"***redacted***"'
+
+
+def _is_secret_finding(findings: list) -> bool:
+    for f in findings or []:
+        rule = str(f.get("rule_id", "")).upper()
+        if "SECRET" in rule or "CREDENTIAL" in rule or "PASSWORD" in rule:
+            return True
+    return False
+
+
+def _redact(text: str) -> str:
+    """Mask a value after the first '=' or ':' so a shared report never leaks it."""
+    for sep in ("=", ":"):
+        idx = text.find(sep)
+        if idx != -1:
+            return text[: idx + 1] + " " + _REDACTED
+    return _REDACTED
+
+
+def attach_source_snippets(
+    repo_root: Path,
+    graph_data: dict,
+    *,
+    context: int = 3,
+    max_nodes: int = 200,
+    redact_secrets: bool = True,
+) -> None:
+    repo_root = Path(repo_root).resolve()
+    cache: dict[str, list[str] | None] = {}
+    attached = 0
+    for node in graph_data.get("nodes", []):
+        if attached >= max_nodes:
+            break
+        rel = node.get("file") or ""
+        line = int(node.get("line") or 0)
+        findings = node.get("findings") or []
+        on_path = bool(node.get("on_path"))
+        if not rel or line <= 0 or not (findings or on_path):
+            continue
+        if rel not in cache:
+            try:
+                cache[rel] = (repo_root / rel).read_text(encoding="utf-8", errors="ignore").splitlines()
+            except OSError:
+                cache[rel] = None
+        lines = cache[rel]
+        if not lines:
+            continue
+        secret = redact_secrets and _is_secret_finding(findings)
+        lo = max(1, line - context)
+        hi = min(len(lines), line + context)
+        rendered = []
+        for n in range(lo, hi + 1):
+            raw = lines[n - 1]
+            highlight = n == line
+            if highlight and secret:
+                raw = _redact(raw)
+            rendered.append({"n": n, "text": html.escape(raw), "highlight": highlight})
+        node["snippet"] = {"file": rel, "start": lo, "lines": rendered}
+        attached += 1

--- a/src/cybergraph/visualize.py
+++ b/src/cybergraph/visualize.py
@@ -173,8 +173,6 @@ def _findings_table(findings) -> str:
     )
     return (
         "<div class='toolbar'>"
-        "<input data-filter='findings-search' type='search' "
-        "placeholder='Search findings by rule, file, message, or tool'>"
         "<select data-filter='findings-severity' aria-label='Filter findings by severity'>"
         "<option value=''>All severities</option>"
         "<option value='critical'>Critical</option>"
@@ -821,7 +819,7 @@ _HTML_TEMPLATE = """<!doctype html>
     })();
   </script>
   <script>
-    const findingSearch = document.querySelector('[data-filter="findings-search"]');
+    const findingSearch = document.getElementById('cg-search');
     const findingSeverity = document.querySelector('[data-filter="findings-severity"]');
     function filterFindings() {
       const query = (findingSearch?.value || '').toLowerCase();

--- a/src/cybergraph/visualize.py
+++ b/src/cybergraph/visualize.py
@@ -94,6 +94,7 @@ def _render_html(
         "__FINDINGS_TABLE__": _findings_table(findings),
         "__ATTACK_PATHS_LIST__": _attack_paths(attack_paths),
         "__LEGEND__": _legend(),
+        "__TRUNCATION_BANNER__": _truncation_banner(graph_data),
         "__GRAPH_JSON__": _embed_json(graph_data),
         "__CYTOSCAPE_SRC__": _load_cytoscape_source(),
     }
@@ -128,6 +129,19 @@ EDGE_KINDS = [
     ("USES_RESOURCE", "#475569"),
     ("AFFECTS_DEPENDENCY", "#7c3aed"),
 ]
+
+
+def _truncation_banner(graph_data: dict) -> str:
+    if not graph_data.get("truncated"):
+        return ""
+    shown = len(graph_data.get("nodes", []))
+    total = int(graph_data.get("counts", {}).get("nodes", shown))
+    return (
+        "<div style='margin:0 0 12px;padding:10px 12px;border-radius:8px;"
+        "background:#fef3c7;color:#92400e;border:1px solid #fde68a;font-size:13px;'>"
+        f"Showing {shown} of {total} nodes — raise <code>--max-nodes</code> to see the full graph."
+        "</div>"
+    )
 
 
 def _legend() -> str:
@@ -341,6 +355,7 @@ _HTML_TEMPLATE = """<!doctype html>
 
     <h2>Interactive Graph Explorer</h2>
     <p class="mode-help">Start with focused attack paths, then expand to module or raw graph views when you need detail.</p>
+    __TRUNCATION_BANNER__
     <div class="risk-strip" id="cg-risk-strip"></div>
     <div class="toolbar">
       <select id="cg-mode" aria-label="Graph view mode">

--- a/src/cybergraph/visualize.py
+++ b/src/cybergraph/visualize.py
@@ -248,20 +248,32 @@ _HTML_TEMPLATE = """<!doctype html>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>CyberGraph Report</title>
   <style>
-    :root { color-scheme: light; font-family: Inter, Segoe UI, Arial, sans-serif; }
-    body { margin: 0; background: #f5f7fb; color: #111827; }
-    header { background: radial-gradient(circle at top left, #1d4ed8, #0b1220 42%, #020617); color: white; padding: 32px 36px; }
+    :root {
+      color-scheme: light; font-family: Inter, Segoe UI, Arial, sans-serif;
+      --bg: #f5f7fb; --fg: #111827; --panel: #ffffff; --border: #d8e0ea;
+      --muted: #667085; --th: #f0f3f6; --cy-bg: #f8fafc;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root { color-scheme: dark; --bg: #0b1220; --fg: #e5e7eb; --panel: #111827;
+              --border: #243044; --muted: #94a3b8; --th: #1a2334; --cy-bg: #0b1220; }
+    }
+    :root[data-theme="dark"] { color-scheme: dark; --bg: #0b1220; --fg: #e5e7eb; --panel: #111827;
+              --border: #243044; --muted: #94a3b8; --th: #1a2334; --cy-bg: #0b1220; }
+    :root[data-theme="light"] { color-scheme: light; --bg: #f5f7fb; --fg: #111827; --panel: #ffffff;
+              --border: #d8e0ea; --muted: #667085; --th: #f0f3f6; --cy-bg: #f8fafc; }
+    body { margin: 0; background: var(--bg); color: var(--fg); }
+    header { background: radial-gradient(circle at top left, #1d4ed8, #0b1220 42%, #020617); color: white; padding: 32px 36px; position: relative; }
     main { max-width: 1320px; margin: 0 auto; padding: 28px 24px 48px; }
     h1 { margin: 0 0 8px; font-size: 30px; }
     h2 { margin: 28px 0 12px; font-size: 18px; }
-    .muted { color: #667085; }
+    .muted { color: var(--muted); }
     .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 12px; }
-    .stat, table { background: white; border: 1px solid #d8e0ea; border-radius: 12px; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.04); }
+    .stat, table { background: var(--panel); border: 1px solid var(--border); border-radius: 12px; box-shadow: 0 10px 30px rgba(15, 23, 42, 0.04); }
     .stat { padding: 16px; }
     .stat strong { display: block; font-size: 26px; margin-top: 4px; }
     table { width: 100%; border-collapse: collapse; overflow: hidden; }
-    th, td { padding: 10px 12px; border-bottom: 1px solid #d0d7de; text-align: left; vertical-align: top; }
-    th { background: #f0f3f6; font-size: 13px; }
+    th, td { padding: 10px 12px; border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; }
+    th { background: var(--th); font-size: 13px; }
     tr:last-child td { border-bottom: 0; }
     .pill { display: inline-block; padding: 3px 8px; border-radius: 999px; background: #eef6ff; color: #075985; font-size: 12px; }
     .path { background: white; border: 1px solid #d0d7de; border-radius: 8px; padding: 12px; margin-bottom: 10px; }
@@ -273,7 +285,7 @@ _HTML_TEMPLATE = """<!doctype html>
     code { color: #7c2d12; }
     .explorer { display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 14px; }
     .graph-card, .details {
-      background: white; border: 1px solid #d8e0ea; border-radius: 16px;
+      background: var(--panel); border: 1px solid var(--border); border-radius: 16px;
       box-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
     }
     .graph-card { overflow: hidden; }
@@ -281,7 +293,7 @@ _HTML_TEMPLATE = """<!doctype html>
     .graph-title { font-weight: 700; }
     .graph-subtitle { color: #64748b; font-size: 12px; margin-top: 3px; }
     .graph-badge { align-self: center; padding: 5px 9px; border-radius: 999px; background: #eff6ff; color: #1d4ed8; font-size: 12px; white-space: nowrap; }
-    #cy { height: 640px; background: linear-gradient(135deg, #f8fafc, #ffffff 58%, #f1f5f9); }
+    #cy { height: 640px; background: var(--cy-bg); }
     .details { padding: 14px; height: 668px; overflow: auto; font-size: 13px; }
     .details h3 { margin: 0 0 8px; font-size: 15px; }
     .details .kv { margin: 4px 0; }
@@ -302,11 +314,21 @@ _HTML_TEMPLATE = """<!doctype html>
     .cg-snippet .ln.hl { background: rgba(245, 158, 11, 0.18); }
     @media (max-width: 820px) { .explorer { grid-template-columns: 1fr; } .details { height: auto; } }
   </style>
+  <script>
+    (function () {
+      try {
+        var t = localStorage.getItem('cybergraph-theme');
+        if (!t) t = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        document.documentElement.setAttribute('data-theme', t);
+      } catch (e) {}
+    })();
+  </script>
 </head>
 <body>
   <header>
     <h1>CyberGraph Security Report</h1>
     <div>__REPO__</div>
+    <button id="cg-theme-toggle" type="button" style="position:absolute;top:20px;right:24px;cursor:pointer;border:1px solid rgba(255,255,255,0.4);background:transparent;color:white;border-radius:6px;padding:6px 10px;">Theme</button>
   </header>
   <main>
     <section class="grid">
@@ -598,7 +620,8 @@ _HTML_TEMPLATE = """<!doctype html>
         style: [
           { selector: 'node', style: {
             'background-color': function (ele) { return GROUP_COLORS[ele.data('group')] || '#94a3b8'; },
-            'label': 'data(label)', 'font-size': 10, 'font-weight': 600, 'color': '#0b1220',
+            'label': 'data(label)', 'font-size': 10, 'font-weight': 600,
+            'color': '#0b1220', 'text-outline-width': 2, 'text-outline-color': '#f8fafc',
             'text-wrap': 'ellipsis', 'text-max-width': 110, 'width': 24, 'height': 24,
             'border-width': 1, 'border-color': '#ffffff'
           } },
@@ -811,6 +834,11 @@ _HTML_TEMPLATE = """<!doctype html>
     }
     findingSearch?.addEventListener('input', filterFindings);
     findingSeverity?.addEventListener('change', filterFindings);
+    document.getElementById('cg-theme-toggle')?.addEventListener('click', function () {
+      var cur = document.documentElement.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+      document.documentElement.setAttribute('data-theme', cur);
+      try { localStorage.setItem('cybergraph-theme', cur); } catch (e) {}
+    });
   </script>
 </body>
 </html>

--- a/src/cybergraph/visualize.py
+++ b/src/cybergraph/visualize.py
@@ -20,7 +20,7 @@ from cybergraph.security.attack_paths import find_attack_paths
 from cybergraph.security.layers import summarize_layers
 
 
-def generate_html_report(repo_root: Path, output: Path | None = None) -> Path:
+def generate_html_report(repo_root: Path, output: Path | None = None, *, with_source: bool = False) -> Path:
     repo_root = repo_root.resolve()
     output = output or repo_root / ".cybergraph" / "report.html"
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -56,6 +56,10 @@ def generate_html_report(repo_root: Path, output: Path | None = None) -> Path:
     layers = summarize_layers(repo_root)
     attack_paths = find_attack_paths(repo_root, limit=25)
     graph_data = build_graph_data(repo_root)
+    if with_source:
+        from cybergraph.report_source import attach_source_snippets
+
+        attach_source_snippets(repo_root, graph_data)
     output.write_text(
         _render_html(
             repo_root, counts, layers, findings, vulnerable_dependencies, attack_paths, graph_data
@@ -292,6 +296,10 @@ _HTML_TEMPLATE = """<!doctype html>
     .risk-card strong { display: block; font-size: 13px; margin-bottom: 5px; }
     .risk-card span { color: #64748b; font-size: 12px; }
     .risk-score { float: right; color: #dc2626; font-weight: 700; }
+    .cg-snippet { margin-top: 8px; border: 1px solid var(--border, #d0d7de); border-radius: 8px; overflow: auto; font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; }
+    .cg-snippet .ln { display: flex; gap: 10px; padding: 1px 8px; white-space: pre; }
+    .cg-snippet .ln .num { color: var(--muted, #94a3b8); user-select: none; min-width: 30px; text-align: right; }
+    .cg-snippet .ln.hl { background: rgba(245, 158, 11, 0.18); }
     @media (max-width: 820px) { .explorer { grid-template-columns: 1fr; } .details { height: auto; } }
   </style>
 </head>
@@ -742,6 +750,15 @@ _HTML_TEMPLATE = """<!doctype html>
         }
         const neighbors = node.neighborhood('node').map(function (n) { return n.data('label'); });
         if (neighbors.length) html += '<div class="kv"><strong>Connected:</strong> ' + esc(neighbors.slice(0, 12).join(', ')) + '</div>';
+        const snip = d.snippet;
+        if (snip && snip.lines && snip.lines.length) {
+          html += '<div class="kv"><strong>Source:</strong> <code>' + esc(snip.file) + '</code></div>';
+          html += '<div class="cg-snippet">';
+          snip.lines.forEach(function (ln) {
+            html += '<div class="ln' + (ln.highlight ? ' hl' : '') + '"><span class="num">' + esc(ln.n) + '</span><span>' + ln.text + '</span></div>';
+          });
+          html += '</div>';
+        }
         document.getElementById('cg-details').innerHTML = html;
       }
 

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -1,0 +1,38 @@
+# tests/test_quickstart.py
+from pathlib import Path
+
+import pytest
+
+from cybergraph.cli import main
+from cybergraph.quickstart import run_quickstart
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "@app.route('/x')\ndef h(request):\n    return db.execute(request.query['q'])\n",
+        encoding="utf-8",
+    )
+    return repo
+
+
+def test_run_quickstart_builds_analyzes_and_writes_report(tmp_path: Path):
+    repo = _repo(tmp_path)
+    result = run_quickstart(repo)
+    assert result.report_path.is_file()
+    assert len(result.steps) == 4
+    assert result.top_risk  # at least one risk on the vulnerable sample
+
+
+def test_cli_quickstart_no_open_never_opens_browser(tmp_path: Path, capsys, monkeypatch):
+    repo = _repo(tmp_path)
+    import webbrowser
+    opened = {"n": 0}
+    monkeypatch.setattr(webbrowser, "open", lambda *a, **k: opened.__setitem__("n", opened["n"] + 1))
+    code = main(["quickstart", str(repo), "--no-open", "--yes"])
+    out = capsys.readouterr().out
+    assert code == 0
+    assert opened["n"] == 0                 # browser never opened
+    assert "[1/4]" in out and "[4/4]" in out  # step log printed
+    assert "report" in out.lower()

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -1,7 +1,6 @@
 # tests/test_quickstart.py
 from pathlib import Path
 
-import pytest
 
 from cybergraph.cli import main
 from cybergraph.quickstart import run_quickstart

--- a/tests/test_report_banner.py
+++ b/tests/test_report_banner.py
@@ -1,0 +1,11 @@
+# tests/test_report_banner.py
+from cybergraph.visualize import _truncation_banner
+
+
+def test_banner_when_truncated():
+    html = _truncation_banner({"truncated": True, "nodes": [0] * 600, "counts": {"nodes": 1500}})
+    assert "600" in html and "1500" in html and "max-nodes" in html
+
+
+def test_no_banner_when_not_truncated():
+    assert _truncation_banner({"truncated": False, "nodes": [0] * 10, "counts": {"nodes": 10}}) == ""

--- a/tests/test_report_drilldown.py
+++ b/tests/test_report_drilldown.py
@@ -1,0 +1,34 @@
+# tests/test_report_drilldown.py
+from pathlib import Path
+
+from cybergraph.build import build_graph
+from cybergraph.visualize import generate_html_report
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "@app.route('/x')\n"
+        "def h(request):\n"
+        "    return db.execute('select ' + request.query['q'])\n",
+        encoding="utf-8",
+    )
+    build_graph(repo)
+    return repo
+
+
+def test_default_off_embeds_no_snippet(tmp_path: Path):
+    repo = _repo(tmp_path)
+    out = generate_html_report(repo, tmp_path / "r.html")
+    html = out.read_text(encoding="utf-8")
+    assert '"snippet"' not in html
+
+
+def test_with_source_embeds_snippet_and_render_code(tmp_path: Path):
+    repo = _repo(tmp_path)
+    out = generate_html_report(repo, tmp_path / "r.html", with_source=True)
+    html = out.read_text(encoding="utf-8")
+    assert '"snippet"' in html                 # snippet data embedded
+    assert "db.execute" in html                # the finding line is present
+    assert "cg-snippet" in html                # details-panel renderer markup/class

--- a/tests/test_report_drilldown_security.py
+++ b/tests/test_report_drilldown_security.py
@@ -33,6 +33,18 @@ def test_ordinary_code_is_not_over_redacted():
         assert red is False and text == line
 
 
+def test_function_call_value_on_secret_key_is_not_redacted():
+    # A secret-named key assigned from an expression/call is legit code, not a secret.
+    line = '    token = request.headers.get("authorization")'
+    text, red = _redact_line(line)
+    assert red is False and text == line
+
+
+def test_quoted_literal_on_secret_key_is_redacted():
+    text, red = _redact_line('    api_token = "abc123realtokenvalue"')
+    assert red is True and "abc123realtokenvalue" not in text
+
+
 # --- unit: anchoring on the finding line, not the node line -----------------
 def test_snippet_anchors_on_finding_line_not_node_line(tmp_path: Path):
     (tmp_path / "f.py").write_text("\n".join(f"line{n}" for n in range(1, 11)) + "\n", encoding="utf-8")

--- a/tests/test_report_drilldown_security.py
+++ b/tests/test_report_drilldown_security.py
@@ -1,0 +1,75 @@
+"""Security regression tests for report source drill-down: secrets must never leak."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cybergraph.build import build_graph
+from cybergraph.report_source import _redact_line, attach_source_snippets
+from cybergraph.visualize import generate_html_report
+
+
+# --- unit: content-based redaction ------------------------------------------
+def test_keyword_assignment_value_is_redacted():
+    text, red = _redact_line('ENV AWS_SECRET_ACCESS_KEY=AKIAtotallyrealsecret123')
+    assert red is True
+    assert "AKIAtotallyrealsecret123" not in text
+    assert "redacted" in text.lower()
+
+
+def test_colon_delimited_secret_is_redacted():
+    text, red = _redact_line("    password: hunter2supersecret")
+    assert red is True and "hunter2supersecret" not in text
+
+
+def test_aws_key_without_keyword_is_redacted():
+    text, red = _redact_line('x = "AKIAABCDEFGH12345678"')
+    assert red is True and "AKIAABCDEFGH12345678" not in text
+
+
+def test_ordinary_code_is_not_over_redacted():
+    for line in ["    return db.execute('select ' + q)", "x = 1", "q = request.query['q']"]:
+        text, red = _redact_line(line)
+        assert red is False and text == line
+
+
+# --- unit: anchoring on the finding line, not the node line -----------------
+def test_snippet_anchors_on_finding_line_not_node_line(tmp_path: Path):
+    (tmp_path / "f.py").write_text("\n".join(f"line{n}" for n in range(1, 11)) + "\n", encoding="utf-8")
+    g = {"nodes": [{
+        "id": "f.py", "file": "f.py", "line": 1,   # File node at line 1
+        "findings": [{"rule_id": "CG-X", "severity": "high", "message": "m", "line": 5}],
+    }]}
+    attach_source_snippets(tmp_path, g, context=2)
+    snip = g["nodes"][0]["snippet"]
+    assert [ln["n"] for ln in snip["lines"]] == [3, 4, 5, 6, 7]      # window around line 5
+    assert [ln["n"] for ln in snip["lines"] if ln["highlight"]] == [5]
+
+
+def test_secret_on_context_line_near_nonsecret_finding_is_redacted(tmp_path: Path):
+    # SQL-sink finding at line 3; a hardcoded key sits on context line 2.
+    (tmp_path / "app.py").write_text(
+        'def h(q):\n    API_KEY = "sk-livesecretvalue999"\n    return db.execute(q)\n',
+        encoding="utf-8",
+    )
+    g = {"nodes": [{
+        "id": "app.py::h", "file": "app.py", "line": 3,
+        "findings": [{"rule_id": "CG-SINK-CALL", "severity": "high", "message": "sql", "line": 3}],
+    }]}
+    attach_source_snippets(tmp_path, g, context=3)
+    joined = " ".join(ln["text"] for ln in g["nodes"][0]["snippet"]["lines"])
+    assert "sk-livesecretvalue999" not in joined  # secret on a CONTEXT line still redacted
+
+
+# --- end-to-end: the report file itself must not contain the secret ----------
+def test_dockerfile_secret_absent_from_generated_report(tmp_path: Path):
+    repo = tmp_path / "svc"
+    repo.mkdir()
+    (repo / "Dockerfile").write_text(
+        "FROM python:3.12\nENV AWS_SECRET_ACCESS_KEY=AKIAtotallyrealsecret123\nRUN echo hi\n",
+        encoding="utf-8",
+    )
+    build_graph(repo)
+    html = generate_html_report(repo, tmp_path / "r.html", with_source=True).read_text(encoding="utf-8")
+    assert "AKIAtotallyrealsecret123" not in html   # the whole point
+    assert "redacted" in html                        # redaction actually fired

--- a/tests/test_report_search.py
+++ b/tests/test_report_search.py
@@ -1,0 +1,28 @@
+# tests/test_report_search.py
+from pathlib import Path
+
+from cybergraph.build import build_graph
+from cybergraph.visualize import generate_html_report
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text(
+        "@app.route('/x')\ndef h(request):\n    return db.execute(request.query['q'])\n",
+        encoding="utf-8",
+    )
+    build_graph(repo)
+    return repo
+
+
+def test_single_unified_search_box(tmp_path: Path):
+    html = generate_html_report(_repo(tmp_path), tmp_path / "r.html").read_text(encoding="utf-8")
+    # the findings table no longer has its own text search input
+    assert "data-filter='findings-search'" not in html and 'data-filter="findings-search"' not in html
+    # exactly one search input remains: the shared #cg-search
+    assert html.count('type="search"') + html.count("type='search'") == 1
+    # the findings filter is wired to the shared box
+    assert "getElementById('cg-search')" in html
+    # the findings severity filter is preserved (kept separate by design)
+    assert "findings-severity" in html

--- a/tests/test_report_source.py
+++ b/tests/test_report_source.py
@@ -1,0 +1,70 @@
+# tests/test_report_source.py
+from pathlib import Path
+
+from cybergraph.report_source import attach_source_snippets
+
+
+def _graph(repo: Path, extra=None):
+    node = {"id": "app.py::h", "file": "app.py", "line": 3, "findings": []}
+    if extra:
+        node.update(extra)
+    return {"nodes": [node]}
+
+
+def _write(repo: Path, name: str, text: str):
+    (repo / name).write_text(text, encoding="utf-8")
+
+
+def test_attaches_highlighted_snippet_for_finding_node(tmp_path: Path):
+    _write(tmp_path, "app.py", "a = 1\nb = 2\nrun(x)\nc = 3\nd = 4\n")
+    g = _graph(tmp_path, {"findings": [{"severity": "high", "rule_id": "CG-X", "message": "m"}]})
+    attach_source_snippets(tmp_path, g, context=1)
+    snip = g["nodes"][0]["snippet"]
+    assert snip["file"] == "app.py"
+    nums = [ln["n"] for ln in snip["lines"]]
+    assert nums == [2, 3, 4]  # context=1 around line 3, clamped
+    hl = [ln for ln in snip["lines"] if ln["highlight"]]
+    assert len(hl) == 1 and hl[0]["n"] == 3 and "run(x)" in hl[0]["text"]
+
+
+def test_start_of_file_clamps_without_negative(tmp_path: Path):
+    _write(tmp_path, "app.py", "run(x)\nb = 2\n")
+    g = _graph(tmp_path, {"line": 1, "findings": [{"rule_id": "CG-X", "severity": "high", "message": "m"}]})
+    attach_source_snippets(tmp_path, g, context=3)
+    assert [ln["n"] for ln in g["nodes"][0]["snippet"]["lines"]] == [1, 2]
+
+
+def test_html_is_escaped(tmp_path: Path):
+    _write(tmp_path, "app.py", "x = '<b>&</b>'\n")
+    g = _graph(tmp_path, {"line": 1, "findings": [{"rule_id": "CG-X", "severity": "high", "message": "m"}]})
+    attach_source_snippets(tmp_path, g)
+    text = g["nodes"][0]["snippet"]["lines"][0]["text"]
+    assert "&lt;b&gt;" in text and "<b>" not in text
+
+
+def test_secret_finding_line_is_redacted(tmp_path: Path):
+    _write(tmp_path, "Dockerfile", "FROM x\nENV API_KEY=supersecretvalue\n")
+    g = _graph(tmp_path, {"id": "Dockerfile", "file": "Dockerfile", "line": 2,
+                          "findings": [{"rule_id": "CG-DOCKER-SECRET", "severity": "critical", "message": "m"}]})
+    attach_source_snippets(tmp_path, g, context=0)
+    line = g["nodes"][0]["snippet"]["lines"][0]
+    assert line["highlight"] is True
+    assert "supersecretvalue" not in line["text"]
+    assert "redacted" in line["text"].lower()
+
+
+def test_node_without_finding_or_file_gets_no_snippet(tmp_path: Path):
+    g = {"nodes": [{"id": "n", "file": "", "line": 0, "findings": []},
+                   {"id": "m", "file": "missing.py", "line": 5, "findings": [{"rule_id": "R", "severity": "low", "message": "x"}]}]}
+    attach_source_snippets(tmp_path, g)
+    assert "snippet" not in g["nodes"][0]  # no file
+    assert "snippet" not in g["nodes"][1]  # file missing -> best-effort skip
+
+
+def test_max_nodes_cap(tmp_path: Path):
+    _write(tmp_path, "app.py", "run(x)\n")
+    nodes = [{"id": f"n{i}", "file": "app.py", "line": 1,
+              "findings": [{"rule_id": "R", "severity": "low", "message": "x"}]} for i in range(5)]
+    g = {"nodes": nodes}
+    attach_source_snippets(tmp_path, g, context=0, max_nodes=2)
+    assert sum("snippet" in n for n in g["nodes"]) == 2

--- a/tests/test_report_theme.py
+++ b/tests/test_report_theme.py
@@ -1,0 +1,22 @@
+# tests/test_report_theme.py
+from pathlib import Path
+
+from cybergraph.build import build_graph
+from cybergraph.visualize import generate_html_report
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "app"
+    repo.mkdir()
+    (repo / "app.py").write_text("def f():\n    return 1\n", encoding="utf-8")
+    build_graph(repo)
+    return repo
+
+
+def test_report_is_theme_aware(tmp_path: Path):
+    html = generate_html_report(_repo(tmp_path), tmp_path / "r.html").read_text(encoding="utf-8")
+    assert "--bg" in html and "--fg" in html                 # CSS variables
+    assert "prefers-color-scheme: dark" in html               # auto dark
+    assert '[data-theme="dark"]' in html                      # explicit override
+    assert 'id="cg-theme-toggle"' in html                     # toggle control
+    assert "localStorage" in html and "cybergraph-theme" in html  # persistence + anti-FOUC

--- a/tests/test_visualize.py
+++ b/tests/test_visualize.py
@@ -21,7 +21,7 @@ def test_generate_html_report_writes_security_sections(tmp_path: Path) -> None:
     assert "CyberGraph Security Report" in html
     assert "Security Layers" in html
     assert "Findings" in html
-    assert "data-filter='findings-search'" in html
+    assert "data-filter='findings-severity'" in html
     assert "data-finding-row" in html
     assert "Potential Attack Paths" in html
     assert "Top Risks" in html


### PR DESCRIPTION
## Report & Onboarding Polish (Theme A, Spec 2)

Stacked on Spec 1 (base = `feat/usability-core`); GitHub will retarget to `main` after Spec 1 merges.

- Theme-aware HTML report (auto dark/light + toggle, anti-FOUC), one unified search across graph + findings, truncation banner.
- Opt-in source drill-down (`--with-source`, default OFF) with **content-based secret redaction** so a shared report never leaks a credential.
- Guided `quickstart` command (init -> build -> analyze -> report; guarded browser-open).

**Tests:** 226 passed; includes secret-leak regression tests for two leak paths caught in review.