### PR TITLE
ci: harden workflows and fix fork-PR security comment

### DIFF
--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -1,0 +1,98 @@
+name: CyberGraph Report
+
+# Runs after the "CyberGraph" workflow completes. A workflow_run always executes
+# the definition from the default branch, so it receives a read/write
+# GITHUB_TOKEN even when the triggering PR came from a fork. That makes it the
+# safe place to post the PR comment: the workflow that ran untrusted PR code
+# (cybergraph.yml) stays read-only, and this trusted workflow only reads the
+# artifact it produced.
+on:
+  workflow_run:
+    workflows: ["CyberGraph"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read # list/download the triggering run's artifacts
+  pull-requests: write # post the sticky review comment
+
+concurrency:
+  group: cybergraph-report-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  comment:
+    name: Post security review comment
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Download the cybergraph-report artifact
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const runId = context.payload.workflow_run.id;
+            const arts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+            const match = arts.data.artifacts.find((a) => a.name === 'cybergraph-report');
+            if (!match) {
+              core.info('No cybergraph-report artifact found; nothing to post.');
+              return;
+            }
+            const zip = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: match.id,
+              archive_format: 'zip',
+            });
+            fs.writeFileSync('artifact.zip', Buffer.from(zip.data));
+
+      - name: Unzip artifact
+        run: unzip -o artifact.zip -d artifact || true
+
+      - name: Post or update the sticky comment
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- cybergraph-security-review -->';
+
+            let prNumber, body;
+            try {
+              prNumber = Number(fs.readFileSync('artifact/pr-number.txt', 'utf8').trim());
+            } catch {
+              core.info('No pr-number.txt in artifact; skipping.');
+              return;
+            }
+            try {
+              body = fs.readFileSync('artifact/cybergraph-pr-comment.md', 'utf8');
+            } catch {
+              core.info('No cybergraph-pr-comment.md in artifact; skipping.');
+              return;
+            }
+            if (!prNumber || !body.trim()) {
+              core.info('Missing PR number or empty comment body; skipping.');
+              return;
+            }
+
+            body = `${marker}\n${body}`;
+            const { owner, repo } = context.repo;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+              core.info(`Updated sticky comment ${existing.id} on PR #${prNumber}.`);
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number: prNumber, body });
+              core.info(`Created sticky comment on PR #${prNumber}.`);
+            }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches: [main]
   pull_request:
+    paths-ignore: ["**.md", "docs/**", "LICENSE"]
 
 jobs:
   test:
     name: test (${{ matrix.os }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -16,6 +18,8 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -29,12 +33,15 @@ jobs:
   install-from-wheel:
     name: clean-env install from wheel (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install with dev + mcp extras
@@ -34,8 +34,8 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
       - name: Build wheel

--- a/.github/workflows/cybergraph.yml
+++ b/.github/workflows/cybergraph.yml
@@ -5,11 +5,13 @@ on:
   push:
     branches: [main]
 
+# Read-only by default. This workflow runs untrusted PR code (including from
+# forks once the repo is public), so it never holds write scopes. The PR
+# comment is posted by the separate ci-report.yml (workflow_run), which runs
+# from the default branch and therefore gets a write token safely.
 permissions:
   contents: read
-  pull-requests: write
-  security-events: write
-  actions: read
+  security-events: write # upload-sarif; auto-downgraded to read for fork PRs
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
@@ -18,10 +20,14 @@ jobs:
   security-graph:
     name: Build security graph
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Check out repository
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0 # need the base branch present for `cybergraph review`
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
@@ -36,17 +42,21 @@ jobs:
 
       - name: Review security delta
         if: github.event_name == 'pull_request'
-        run: cybergraph review --base origin/${{ github.base_ref }} --repo . | tee cybergraph-review.txt
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: cybergraph review --base "origin/$BASE_REF" --repo . | tee cybergraph-review.txt
 
       - name: Generate PR comment
         if: github.event_name == 'pull_request'
-        run: cybergraph pr-comment --base origin/${{ github.base_ref }} --repo . --output cybergraph-pr-comment.md
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: cybergraph pr-comment --base "origin/$BASE_REF" --repo . --output cybergraph-pr-comment.md
 
-      - name: Comment on pull request
+      - name: Record PR number for the report workflow
         if: github.event_name == 'pull_request'
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh pr comment ${{ github.event.pull_request.number }} --body-file cybergraph-pr-comment.md
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > pr-number.txt
 
       - name: Export SARIF
         run: cybergraph sarif --repo . --output cybergraph.sarif
@@ -70,4 +80,5 @@ jobs:
             cybergraph-report.html
             cybergraph-review.txt
             cybergraph-pr-comment.md
+            pr-number.txt
           if-no-files-found: ignore

--- a/.github/workflows/cybergraph.yml
+++ b/.github/workflows/cybergraph.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
 
@@ -57,12 +57,12 @@ jobs:
       - name: Upload SARIF to code scanning
         if: github.event.repository.private == false || vars.CYBERGRAPH_UPLOAD_SARIF == 'true'
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
         with:
           sarif_file: cybergraph.sarif
 
       - name: Upload CyberGraph artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: cybergraph-report
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
       - name: Build sdist and wheel
@@ -30,7 +30,7 @@ jobs:
           assert any("assets/cytoscape.min.js" in n for n in names), "cytoscape asset missing from wheel"
           print("wheel OK:", wheel)
           PY
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/*
@@ -41,11 +41,11 @@ jobs:
     # Only publish when a PyPI token is configured.
     if: ${{ vars.ENABLE_PYPI_PUBLISH == 'true' }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           name: dist
           path: dist
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
       - name: Publish to PyPI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.11"
@@ -38,6 +41,7 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     # Only publish when a PyPI token is configured.
     if: ${{ vars.ENABLE_PYPI_PUBLISH == 'true' }}
     steps:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -7,12 +7,38 @@ def test_cybergraph_workflow_exists() -> None:
     text = workflow.read_text(encoding="utf-8")
 
     assert "cybergraph build ." in text
-    assert "pull-requests: write" in text
     assert "cybergraph pr-comment" in text
-    assert "gh pr comment" in text
     assert "cybergraph sarif" in text
-    assert "github/codeql-action/upload-sarif@v4" in text
+    assert "cybergraph visualize" in text
     assert "CYBERGRAPH_UPLOAD_SARIF" in text
     assert "continue-on-error: true" in text
     assert "FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" in text
-    assert "cybergraph visualize" in text
+    # SARIF upload action is pinned to a commit SHA, not a floating tag.
+    assert "github/codeql-action/upload-sarif@" in text
+    assert "github/codeql-action/upload-sarif@v4" not in text
+
+
+def test_cybergraph_workflow_is_fork_safe() -> None:
+    """The workflow that runs untrusted PR code must hold no write scope and
+    must not comment directly; commenting is delegated to ci-report.yml."""
+    text = Path(".github/workflows/cybergraph.yml").read_text(encoding="utf-8")
+
+    assert "pull-requests: write" not in text
+    assert "gh pr comment" not in text
+    # It hands the comment off as an artifact instead.
+    assert "cybergraph-pr-comment.md" in text
+    assert "pr-number.txt" in text
+    assert "persist-credentials: false" in text
+
+
+def test_report_workflow_posts_from_trusted_context() -> None:
+    """ci-report.yml runs on workflow_run (default-branch context) where it can
+    safely hold pull-requests: write to post the comment for fork PRs."""
+    report = Path(".github/workflows/ci-report.yml")
+    assert report.exists()
+    text = report.read_text(encoding="utf-8")
+
+    assert "workflow_run" in text
+    assert 'workflows: ["CyberGraph"]' in text
+    assert "pull-requests: write" in text
+    assert "cybergraph-report" in text


### PR DESCRIPTION
Hardens the CI workflows and fixes a bug that would block every fork PR once the repo is public. Patterns adapted from the `abhigyanpatwari/GitNexus` workflow setup.

## Commits (review-friendly, merge without squashing to preserve them)

1. **`ci: pin all actions to commit SHAs`** — floating major tags (`@v6`, `@v7`) are mutable; a hijacked tag would run in our pipeline. Every action is now pinned to an immutable SHA with the resolved version in a comment.
2. **`ci: harden checkouts and bound job runtime`** — `persist-credentials: false` on checkouts, `timeout-minutes` on every job, and `paths-ignore` so docs-only PRs skip the matrix.
3. **`ci: post PR security comment via fork-safe workflow_run`** — the real fix (see below).

## The blocker this fixes

`cybergraph.yml`'s "Build security graph" job ran PR code while holding `pull-requests: write` and calling `gh pr comment`. GitHub forces the token **read-only for fork PRs**, so that step could never succeed — and because "Build security graph" is a **required status check**, external contributors' PRs would show an unfixable red check and be unmergeable.

**Fix (the GitNexus `workflow_run` pattern):**
- `cybergraph.yml` now runs **read-only**, and instead of commenting it saves the generated comment + PR number into the `cybergraph-report` artifact.
- New **`ci-report.yml`** triggers on `workflow_run`. Because `workflow_run` executes the default-branch definition, it legitimately holds `pull-requests: write` even for fork PRs. It reads the artifact and posts/updates a **sticky** comment.

Net effect: the workflow that touches untrusted code holds no write scope; the workflow that writes never touches untrusted code.

## Also
- Base ref and PR number pass through `env:` vars instead of inline `${{ }}` in shell (removes a template-injection sink).
- `fetch-depth: 0` so `cybergraph review --base origin/<base>` has the base branch available.

## Testing
- All four workflow files validated as YAML; embedded `github-script` JS parses under Node.
- No product code changed — `visualize.py`/analyzers untouched, so the existing 272-test suite is unaffected. CI on this PR exercises the pinned actions and hardened jobs directly.
