### PR TITLE
docs: lead with no-keys/offline guarantee + fix docs-PR CI deadlock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    paths-ignore: ["**.md", "docs/**", "LICENSE"]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Security review for codebases, powered by knowledge graphs.
 
 CyberGraph maps a repository into a cybersecurity knowledge graph so developers can inspect security layers, risky code paths, scanner findings, and evidence-backed answers without reading the whole codebase by hand.
 
+> **🔒 No API keys. Fully offline. Your code never leaves your machine.**
+> `pip install cybergraph` and you get the complete toolkit — the interactive HTML report, attack-path graphs, cited findings, and SARIF export — with **zero API keys, zero signup, and zero network calls**. There are no runtime dependencies. An LLM is entirely optional and only rephrases answers the graph has already grounded in evidence; nothing about the analysis requires one.
+
 ## Why this exists
 
 Security scanners are useful, but their output is usually flat: a file, a line, a rule, and a warning. Developers still have to answer the hard questions:


### PR DESCRIPTION
Two commits:

1. **docs** — Adds a callout under the tagline: no API keys, fully offline, code never leaves the machine. Verified true end-to-end (clean venv, no LLM libs, all keys scrubbed → full graph + HTML report + SARIF all generated). A genuine trust differentiator for a security tool.

2. **ci** — Removes the `paths-ignore` on ci.yml's PR trigger. Because the matrix legs are *required* status checks, a path-skipped required check reports as 'Expected — waiting for status' and blocks the merge forever; docs-only PRs (like this one) would deadlock. Running the matrix on every PR avoids that; public-repo Actions minutes are free.

No product code changed.