### PR TITLE
chore: correct project ownership (CODEOWNERS + SECURITY contact)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Hasan-Laraib
+* @khan-ARK

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@
 1. **Preferred:** use GitHub's private vulnerability reporting — go to the
    repository's **Security** tab → **Report a vulnerability**. Your report is
    visible only to the maintainers.
-2. **Fallback:** email `lxh417bham@gmail.com` with a description, reproduction
+2. **Fallback:** email `er.azizurrahman@gmail.com` with a description, reproduction
    steps, and the affected version/commit.
 
 ## What to expect

--- a/tests/test_workflow_hardening.py
+++ b/tests/test_workflow_hardening.py
@@ -70,5 +70,5 @@ def test_community_health_files_exist():
     ):
         assert (repo / rel).is_file(), f"missing {rel}"
     sec = (repo / "SECURITY.md").read_text(encoding="utf-8")
-    assert "lxh417bham@gmail.com" in sec
+    assert "er.azizurrahman@gmail.com" in sec
     assert "14 days" in sec


### PR DESCRIPTION
Follow-up to #17. That PR set `CODEOWNERS` to `* @Hasan-Laraib` and the `SECURITY.md` fallback contact to a contributor's email. This points both at the project owner:

- `CODEOWNERS` -> `* @khan-ARK`
- `SECURITY.md` fallback email -> `er.azizurrahman@gmail.com`

No other changes. (If you'd rather co-own, `CODEOWNERS` can be `* @khan-ARK @Hasan-Laraib` — one-word change.)