### PR TITLE
chore: add Hasan-Laraib as CODEOWNERS co-owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @khan-ARK
+* @khan-ARK @Hasan-Laraib


### PR DESCRIPTION
Laraib is co-maintaining the repo, so add him alongside `@khan-ARK` in CODEOWNERS for review auto-assignment.

Review-routing only — no permission change. He remains a Write collaborator; admin/secrets/branch-protection stay owner-only.