### PR TITLE
Code scanning hygiene: suppress fixture noise, keep real signal

### DIFF
--- a/.cybergraph.toml
+++ b/.cybergraph.toml
@@ -1,0 +1,13 @@
+# CyberGraph self-scan configuration (used by .github/workflows/cybergraph.yml,
+# which runs `cybergraph build .` on this repository).
+#
+# The paths below contain DELIBERATELY vulnerable fixture code (test fixtures,
+# benchmark cases, and example apps). Findings there are the tool working as
+# intended, not repository vulnerabilities — suppress them so the GitHub code
+# scanning tab reflects the real posture of src/.
+#
+# Note: keep the array on ONE line — the Python 3.10 fallback TOML parser in
+# cybergraph.config is line-based and does not support multi-line arrays.
+
+[suppressions]
+paths = ["tests/*", "benchmark/*", "examples/*"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,4 +26,11 @@ jobs:
       - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
         with:
           languages: python
+          # Fixture/example code is deliberately vulnerable — scanning it only
+          # produces noise in the code scanning tab. Product code stays covered.
+          config: |
+            paths-ignore:
+              - tests/fixtures
+              - benchmark
+              - examples
       - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3

--- a/.github/workflows/cybergraph.yml
+++ b/.github/workflows/cybergraph.yml
@@ -61,6 +61,15 @@ jobs:
       - name: Export SARIF
         run: cybergraph sarif --repo . --output cybergraph.sarif
 
+      - name: Drop informational sink-inventory findings from the self-scan SARIF
+        # CG-*-SINK-CALL marks "a sensitive sink is used here" — useful inventory
+        # for downstream analysis, but not actionable on CyberGraph's own
+        # parameterized sqlite calls. Keep the code scanning tab signal-only.
+        run: |
+          jq '.runs[].results |= map(select(.ruleId | test("SINK-CALL$") | not))' \
+            cybergraph.sarif > cybergraph.filtered.sarif
+          mv cybergraph.filtered.sarif cybergraph.sarif
+
       - name: Generate HTML report
         run: cybergraph visualize . --output cybergraph-report.html
 

--- a/.github/workflows/cybergraph.yml
+++ b/.github/workflows/cybergraph.yml
@@ -66,7 +66,7 @@ jobs:
         # for downstream analysis, but not actionable on CyberGraph's own
         # parameterized sqlite calls. Keep the code scanning tab signal-only.
         run: |
-          jq '.runs[].results |= map(select(.ruleId | test("SINK-CALL$") | not))' \
+          jq '.runs[].results |= map(select(.ruleId | test("^CG-.*SINK-CALL$") | not))' \
             cybergraph.sarif > cybergraph.filtered.sarif
           mv cybergraph.filtered.sarif cybergraph.sarif
 


### PR DESCRIPTION
## Why

The public repo's code scanning tab shows ~405 alerts, but 97% are noise from CyberGraph scanning its own deliberately-vulnerable fixtures, plus informational sink-inventory notes on our own parameterized sqlite calls. Only 2 alerts touch product code, and both are CodeQL false positives (the `secrets` command prints locations/rationale, never secret values) — dismissed via the API with comments.

## What

- **`.cybergraph.toml`** — suppress `tests/*`, `benchmark/*`, `examples/*` in the self-scan (fixture code is vulnerable by design). Note: single-line array required by the Python 3.10 fallback TOML parser — a real portability gotcha caught during verification.
- **`cybergraph.yml`** — filter `^CG-.*SINK-CALL$` results out of the uploaded SARIF: sink *inventory* isn't actionable on our own codebase. Future non-sink findings in `src/` still surface; the CG namespace anchor prevents ever filtering a third-party rule.
- **`codeql.yml`** — `paths-ignore` for `tests/fixtures`, `benchmark`, `examples`. `src/` and real test code stay fully scanned.

On the next `main` run both scanners upload without the fixture results, and GitHub auto-closes the ~397 stale alerts. Remaining open items are the honest Scorecard posture scores (Maintained/SAST/CodeReview improve with time; Fuzzing deferred; Best-Practices badge is a runbook step).

## Verification
- Self-build with the toml: findings 394 → 151, zero in fixture dirs; SARIF filter verified against real output (151 → 0 sink-inventory results).
- Full suite 279 passed; `ruff --select F` clean; workflow guard tests green.
- Reviewed: suppression globs cannot match `src/`; CodeQL keeps product coverage.

Merge with a merge commit or rebase (not squash).