### PR TITLE
fix(report): make --max-nodes available on visualize and fix the truncation banner

### DIFF
--- a/src/cybergraph/cli.py
+++ b/src/cybergraph/cli.py
@@ -203,6 +203,12 @@ def build_parser() -> argparse.ArgumentParser:
     visualize.add_argument(
         "--with-source", action="store_true", help="Embed (secret-redacted) source snippets"
     )
+    visualize.add_argument(
+        "--max-nodes",
+        type=int,
+        default=600,
+        help="Maximum nodes to include in the graph explorer (default: 600)",
+    )
 
     top_risks = sub.add_parser(
         "top-risks", help="Show the highest-priority risks across graph layers"
@@ -516,7 +522,10 @@ def main(argv: list[str] | None = None) -> int:
         print(f"Wrote SARIF report: {output}")
     elif args.command == "visualize":
         output = generate_html_report(
-            repo, Path(args.output).resolve() if args.output else None, with_source=args.with_source
+            repo,
+            Path(args.output).resolve() if args.output else None,
+            with_source=args.with_source,
+            max_nodes=args.max_nodes,
         )
         print(f"Wrote CyberGraph HTML report: {output}")
     elif args.command == "top-risks":

--- a/src/cybergraph/graph_export.py
+++ b/src/cybergraph/graph_export.py
@@ -155,6 +155,11 @@ def build_graph_data(repo_root: Path, max_nodes: int = 600) -> dict[str, Any]:
         "attack_paths": attack_paths,
         "top_risks": top_risks,
         "truncated": len(node_list) < len(nodes),
+        # Pre-cap size of the exported graph. This is larger than
+        # ``counts["nodes"]`` because the export synthesises nodes for edge
+        # endpoints that have no row of their own, so it is the only correct
+        # denominator when reporting how much of the graph was truncated.
+        "graph_nodes_total": len(nodes),
     }
 
 

--- a/src/cybergraph/visualize.py
+++ b/src/cybergraph/visualize.py
@@ -21,7 +21,11 @@ from cybergraph.security.layers import summarize_layers
 
 
 def generate_html_report(
-    repo_root: Path, output: Path | None = None, *, with_source: bool = False
+    repo_root: Path,
+    output: Path | None = None,
+    *,
+    with_source: bool = False,
+    max_nodes: int = 600,
 ) -> Path:
     repo_root = repo_root.resolve()
     output = output or repo_root / ".cybergraph" / "report.html"
@@ -63,7 +67,7 @@ def generate_html_report(
 
     layers = summarize_layers(repo_root)
     attack_paths = find_attack_paths(repo_root, limit=25)
-    graph_data = build_graph_data(repo_root)
+    graph_data = build_graph_data(repo_root, max_nodes=max_nodes)
     if with_source:
         from cybergraph.report_source import attach_source_snippets
 
@@ -175,7 +179,12 @@ def _truncation_banner(graph_data: dict) -> str:
     if not graph_data.get("truncated"):
         return ""
     shown = len(graph_data.get("nodes", []))
-    total = int(graph_data.get("counts", {}).get("nodes", shown))
+    # Compare like with like: both sides must count *exported* nodes. Falling
+    # back to counts["nodes"] (database rows) understates the total and could
+    # render "Showing 900 of 826".
+    total = int(
+        graph_data.get("graph_nodes_total") or graph_data.get("counts", {}).get("nodes", shown)
+    )
     return (
         "<div style='margin:0 0 12px;padding:10px 12px;border-radius:8px;"
         "background:var(--warn-bg);color:var(--warn-fg);"

--- a/tests/test_report_banner.py
+++ b/tests/test_report_banner.py
@@ -1,5 +1,8 @@
 # tests/test_report_banner.py
-from cybergraph.visualize import _truncation_banner
+from pathlib import Path
+
+from cybergraph.build import build_graph
+from cybergraph.visualize import _truncation_banner, generate_html_report
 
 
 def test_banner_when_truncated():
@@ -12,3 +15,55 @@ def test_no_banner_when_not_truncated():
         _truncation_banner({"truncated": False, "nodes": [0] * 10, "counts": {"nodes": 10}})
         == ""
     )
+
+
+def test_max_nodes_flag_lifts_the_cap(tmp_path: Path) -> None:
+    """`visualize --max-nodes` must be able to raise the cap the banner mentions."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # Enough functions to exceed a deliberately tiny cap.
+    lines = ["import sqlite3", "from fastapi import FastAPI", "app = FastAPI()"]
+    for i in range(30):
+        lines += [
+            f"@app.get('/r{i}')",
+            f"def route_{i}(q: str):",
+            "    db = sqlite3.connect('x.db')",
+            "    return db.execute('select ' + q)",
+        ]
+    (repo / "app.py").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    build_graph(repo)
+
+    capped = tmp_path / "capped.html"
+    generate_html_report(repo, capped, max_nodes=5)
+    assert "raise <code>--max-nodes</code>" in capped.read_text(encoding="utf-8")
+
+    full = tmp_path / "full.html"
+    generate_html_report(repo, full, max_nodes=5000)
+    assert "raise <code>--max-nodes</code>" not in full.read_text(encoding="utf-8")
+
+
+def test_visualize_cli_accepts_max_nodes() -> None:
+    """The flag the banner tells users to raise must exist on `visualize`."""
+    from cybergraph.cli import build_parser
+
+    args = build_parser().parse_args(["visualize", ".", "--max-nodes", "900"])
+    assert args.max_nodes == 900
+
+
+def test_banner_denominator_counts_exported_nodes() -> None:
+    """`shown` and `total` must both count exported nodes.
+
+    counts["nodes"] is the database row count, which is smaller than the
+    exported graph (the export synthesises edge-endpoint nodes), so using it
+    as the denominator produced nonsense like "Showing 900 of 826".
+    """
+    html = _truncation_banner(
+        {
+            "truncated": True,
+            "nodes": [0] * 900,
+            "counts": {"nodes": 826},
+            "graph_nodes_total": 1247,
+        }
+    )
+    assert "900 of 1247" in html
+    assert "of 826" not in html


### PR DESCRIPTION
Two related defects surfaced while recording the demo video, where the banner *"Showing 600 of 826 nodes — raise `--max-nodes`"* sat on screen for the whole take.

### 1. `visualize` had no `--max-nodes` flag
The banner told users to raise a flag that didn't exist on this command — the cap was hardcoded at 600 through `build_graph_data`'s default, and only `export-json`/`opengraph` accepted the option. Adds `--max-nodes` (default 600, unchanged behaviour).

### 2. The banner compared two different populations
`shown` counted **exported** nodes (post-cap) while `total` used `counts["nodes"]` — **database rows**. The export synthesises nodes for edge endpoints that have no row of their own, so the denominator was too small. On PyGoat: 1247 exported vs 826 rows, which rendered as **"Showing 900 of 826 nodes"** once the cap was raised.

`build_graph_data` now publishes `graph_nodes_total` (pre-cap exported size); the banner uses it and falls back to the old key.

### Verification
- `visualize --max-nodes 1500` on OWASP PyGoat renders the full graph with **no banner**
- `--max-nodes 5` still shows it; default 600 behaviour unchanged
- 3 new tests (flag exists, cap is liftable, denominator is correct); **282 passed**, ruff clean