### PR TITLE
chore(deps): bump github/codeql-action to v4.37.6 (init + analyze together)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
       actions: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      - uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: python
           # Fixture/example code is deliberately vulnerable — scanning it only
@@ -33,4 +33,4 @@ jobs:
               - tests/fixtures
               - benchmark
               - examples
-      - uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+      - uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6


### PR DESCRIPTION
Supersedes **#32** (analyze) and **#33** (init).

## Why they can't be merged separately

CodeQL requires `init` and `analyze` to run the **same version**. Dependabot split the bump into two PRs, so each one alone produces a version mismatch and the CodeQL job fails:

```
##[error]Loaded a configuration file for version '4.37.3', but running version '4.37.6'
```

Both #32 and #33 are currently red for exactly this reason. Merging either would break code scanning on `main`.

## This PR

Bumps both pins in one commit, which keeps the job green. It also aligns `codeql.yml` with `upload-sarif` in `cybergraph.yml` and `scorecard.yml`, which are **already** on v4.37.6 — so this removes a live version inconsistency.

## Verification

- Target SHA `5595ccaf912efad79be6eef63a5619ff05969be3` resolved from the upstream `github/codeql-action` **v4.37.6** tag via the API — not taken on trust from Dependabot
- YAML validated
- The CodeQL check on this PR is the real test

Closes #32
Closes #33