### PR TITLE
chore(deps): group github-actions bumps into a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,13 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    # Dependabot treats each path inside a composite-action repo as its own
+    # dependency, so github/codeql-action/init and github/codeql-action/analyze
+    # get separate PRs. init and analyze must run the SAME version in one job,
+    # so a split bump fails both PRs with "Loaded a configuration file for
+    # version X, but running version Y" and neither can merge green alone.
+    # Grouping every action into one PR removes that deadlock class.
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Why

Dependabot treats each path inside a composite-action repo as a **separate dependency**, so `github/codeql-action/init` and `github/codeql-action/analyze` were bumped by two independent PRs — #32 (analyze) and #33 (init).

`init` and `analyze` must run the **same version within one job**. Each PR changed only one side, so both failed CodeQL on their own:

```
Loaded a configuration file for version '4.37.3', but running version '4.37.6'
```

Neither could merge green alone, and merging both would have fixed it — the classic split-bump deadlock. It was resolved by hand in #36, and the same thing was worked around by hand earlier in #25 (`chore/bump-actions-combined`).

This groups every `github-actions` update into one PR, which removes the deadlock **class** rather than the occurrence.

## What this does not change

- **No pinned version changes.** The four `codeql-action` pins are already at `v4.37.6` (`5595ccaf`) on main via #36, and `codeql` is green on `992a525`.
- The two `upload-sarif` pins (`cybergraph.yml:79`, `scorecard.yml:30`) run in separate jobs and share no config with `init`, so version skew there was never the problem.
- `pip` updates are left ungrouped and keep arriving as individual PRs.

## Trade-off

One combined PR per cycle means a single bad action bump blocks the others in that PR. That is the accepted cost of never re-entering the split-bump deadlock, and it matches how these bumps were already being handled manually.