### PR TITLE
Verdict surfaces: MCP check tool, CI wiring, honest audit — completes verdict-core

### DIFF
--- a/.github/workflows/cybergraph.yml
+++ b/.github/workflows/cybergraph.yml
@@ -40,6 +40,15 @@ jobs:
       - name: Build graph
         run: cybergraph build .
 
+      - name: Check the change
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags --depth=0 origin "$BASE_REF"
+          cybergraph check . --mode merge-base --base "origin/$BASE_REF" \
+            | tee cybergraph-check.txt
+
       - name: Review security delta
         if: github.event_name == 'pull_request'
         env:
@@ -87,6 +96,7 @@ jobs:
           path: |
             cybergraph.sarif
             cybergraph-report.html
+            cybergraph-check.txt
             cybergraph-review.txt
             cybergraph-pr-comment.md
             pr-number.txt

--- a/.github/workflows/cybergraph.yml
+++ b/.github/workflows/cybergraph.yml
@@ -46,7 +46,7 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           # checkout above uses fetch-depth: 0 (full history); fetch the base
-          # branch ref so merge-base can resolve. (--depth=0 is invalid.)
+          # branch ref so merge-base can resolve. A zero fetch depth is invalid.
           git fetch --no-tags origin "$BASE_REF"
           cybergraph check . --mode merge-base --base "origin/$BASE_REF" \
             | tee cybergraph-check.txt

--- a/.github/workflows/cybergraph.yml
+++ b/.github/workflows/cybergraph.yml
@@ -45,7 +45,9 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch --no-tags --depth=0 origin "$BASE_REF"
+          # checkout above uses fetch-depth: 0 (full history); fetch the base
+          # branch ref so merge-base can resolve. (--depth=0 is invalid.)
+          git fetch --no-tags origin "$BASE_REF"
           cybergraph check . --mode merge-base --base "origin/$BASE_REF" \
             | tee cybergraph-check.txt
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Supported Python: 3.10, 3.11, 3.12, 3.13.
 cybergraph quickstart .        # zero-to-report: init, build, analyze, open report
 cybergraph init .
 cybergraph doctor .
+cybergraph check .            # does this change preserve the guarantees CyberGraph can verify?
+cybergraph policy --repo .    # show the declared security policy and what it protects
 cybergraph analyze .          # build + run every analysis, print top risks
 cybergraph history .          # what's new / fixed / regressed since the last scan
 cybergraph config show .      # inspect effective config + LLM/graph state
@@ -170,6 +172,55 @@ Suppressions hide findings, but the graph still keeps edges such as `REACHES_SIN
 
 **New:** `paths` now also hides matching entrypoint-to-sink *attack paths* from the ranked, actionable surfaces — `cybergraph attack-paths`, top risks, `analyze`, the PR review, the cloud and Strix scopes. Attack paths were previously never suppressed anywhere, so this is a change in what those commands print. A path is hidden only when **every** file it touches is suppressed, so a route crossing from suppressed code into live code is still reported. The exploration and evidence surfaces still show suppressed paths — the JSON graph export (which records the policy under its `suppression` key), the HTML report, the MCP `explain_attack_path_tool`, grounded answers, and LLM triage slices — and a suppressed path never consumes a slot a real one needs on any of them. Each surface caps how many paths it traverses; suppressed paths are collected separately and fill only what the real ones leave, so accepted fixture noise cannot push the genuine attack paths off the end of the report, the exported graph or the evidence an LLM is grounded on. A PR review scans both sides of the diff under the *current* configuration — `[suppressions] paths`, `[ignore] paths` and `[security] sinks` alike — so changing any of them can never appear as an added or removed attack path. It is reported as a configuration change instead, alongside a count of the reachable risks the suppressions hide (hidden, not fixed) and the changed files `[ignore] paths` kept out of the analysis entirely (not analysed, not fixed). A PR that genuinely removes a vulnerable line is still reported as `removed`, and one that genuinely introduces a sink is still reported as `added`. Scan history holds the same line: a finding that disappears because `[suppressions] rules`, `[suppressions] paths` or `[ignore] paths` now covers it is counted as *hidden by config (hidden, not fixed)* rather than as fixed, on `cybergraph history`, on the `analyze` delta line and in the HTML report's delta strip. Its history row stays open, so dropping the suppression later reads as persisting rather than as a regression. A finding that disappears because the code changed is still fixed.
 
+## Security policy
+
+**Phase 1 contract — the sentence this work is judged against:**
+
+> Given a supported AI-generated Python change, CyberGraph can tell whether the specific security guarantees it understands were preserved — and explicitly admit what it could not verify.
+
+`cybergraph check` is the command that evaluates a change against that contract. It compares
+the current state of a repository against a base ref (`--mode merge-base|worktree|range`) and
+reports one of two states: `accept` (the checks that ran found nothing) or `review` (something
+needs a human look) — plus `not_evaluated`, an explicit list of what CyberGraph could not
+check on this change. It never turns "did not look" into a pass; a capability only passes when
+there is positive evidence it was analyzed. `--json` emits the same structure a script or CI
+step can consume; the CI workflow (`.github/workflows/cybergraph.yml`) runs it on every pull
+request as a non-gating notification (no `--fail-on-review`) until the field false-positive
+rate is measured.
+
+`cybergraph check` verifies against a declared **security policy** — the routes/functions that
+are expected to require authentication, ownership checks, or other guards. Bootstrap one from
+what the codebase already does:
+
+```bash
+cybergraph check . --init-policy   # writes cybergraph.policy.toml from routes that already require login
+```
+
+Review every line of the generated `cybergraph.policy.toml`, edit it to reflect intent (not
+just current behaviour), and **commit it to the repository** — it is the baseline `check`
+diffs future changes against, so a change that silently drops a guard the policy declares is
+what turns an `accept` into a `review`. Because it is a plain committed TOML file, any human or
+any agent working in the repository can read it directly to know what CyberGraph expects to be
+protected, without running the tool first:
+
+```bash
+cybergraph policy --repo .            # show the declared policy and which entities it protects
+cybergraph policy --repo . --baseline # print a proposed baseline without writing anything
+```
+
+**Which languages are verified today:** Python is the only language with verdict-grade
+detection — an exact-match sink registry with per-sink taint predicates, gated by a labelled
+precision/recall/abstention benchmark (`benchmark/run_precision.py`). Its findings (`CG-SQL-EXEC`,
+`CG-CMD-EXEC`, `CG-PATH-TRAVERSAL`, `CG-TEMPLATE-INJECT`, `CG-CODE-EXEC`, `CG-DESERIALIZE`) are
+confirmed or explicitly abstain (`-UNVERIFIED`) — never a bare guess. Go, JavaScript/TypeScript,
+Java, and C# are still **inventory-grade**: their sink findings (`CG-GO-SINK-CALL`,
+`CG-JS-SINK-CALL`, `CG-JAVA-SINK-CALL`, `CG-CSHARP-SINK-CALL`) mark "a sensitive sink is used
+here" from a regex-based analyzer with no parse tree and no taint requirement, useful as a map
+of where sensitive calls live but not as a confirmed verdict. CI's SARIF export deliberately
+filters those four inventory rules out of code scanning uploads until each language gets the
+same exact-match-plus-predicate treatment Python already has; Python's verdict rules are never
+filtered and always reach code scanning.
+
 ## Example questions
 
 ```text
@@ -210,6 +261,13 @@ Available tools:
 - `iac_attack_paths_tool`
 - `import_scanner_report_tool`
 - `import_vulnerabilities_tool`
+- `check_change_tool` (mirrors `cybergraph check --json`: `accept`/`review` plus `not_evaluated`)
+
+The MCP surface is an **interoperability surface, not automatic verification**: nothing forces
+a connected agent to call `check_change_tool` before or after making a change, and an agent may
+decline to call it entirely. Reliable, always-invoked checking needs a client-side hook, which
+is future work — treat these tools as available context an agent can pull, not a gate it must
+pass.
 
 ## Project direction
 

--- a/benchmark/mutation_harness.py
+++ b/benchmark/mutation_harness.py
@@ -321,6 +321,20 @@ MUTATIONS: list[Mutation] = [
             "tests/test_review.py::test_a_structural_path_becoming_data_reachable_is_worsened",
         ),
     ),
+    # -- D1: the tool's own cache dir must be excluded by component, not substring --
+    Mutation(
+        id="D1-revisions-cybergraph-substring-match",
+        disaster="D1",
+        file="cybergraph/security/revisions.py",
+        old='    return path.split("/", 1)[0] == ".cybergraph"',
+        new='    return "cybergraph" in path',
+        tests=(
+            "tests/test_revisions.py::test_cybergraph_state_dir_is_never_a_changed_file",
+        ),
+        note="a substring match drops real changed files like `cybergraph_utils.py` "
+        "(and every src/cybergraph/*.py change on this tool's own repo) from the "
+        "change set -- a fail-open, not the intended `.cybergraph/` exclusion",
+    ),
     # -- D2: "I could not look" must never read as "nothing to see" ----------
     Mutation(
         id="D2-revisions-failure-empty-not-flagged",

--- a/docs/CRITICAL_AUDIT.md
+++ b/docs/CRITICAL_AUDIT.md
@@ -101,7 +101,14 @@ paths. Currently under-marketed.
 
 ## 4. Weaknesses
 
-### 4.1 EXISTENTIAL — the core detector is a substring grep, and the project already knows it
+> **Status update — 2026-08-10 (verdict-core / verdict-surfaces, commits `a770280`..`9b03ee2`):**
+> Sections below now carry a status of `OPEN`, `MITIGATED`, or `VERIFIED RESOLVED`. Everything
+> in the original prose (`Measured impact`, code excerpts, etc.) is left as historical record
+> of the state that was true at the original audit date; the status line and the note appended
+> to each section describe what has changed since. See §4.9 below for the honest before/after
+> table with commit shas.
+
+### 4.1 VERIFIED RESOLVED (Python) — the core detector is a substring grep, and the project already knows it
 
 `security/ontology.py:82-85`:
 
@@ -147,7 +154,40 @@ than fixing the rule. Every user hits this on first run without the `jq` snippet
 It also directly inverts the stated strategy: `COMPETITOR_MAP.md` names alert fatigue as the
 dominant developer pain, and the shipped tool manufactures it.
 
-### 4.2 CRITICAL — the ontology silently assumes "web app with route decorators"
+**Resolution (VERIFIED RESOLVED for Python; non-Python remains inventory-grade):** the
+verdict-core plan (Tasks 1–7, merged in `fe07800` "Merge pull request #38 from
+AQ-Labs/feat/verdict-core-detector") replaced the `any(kw in call_name.lower())` substring
+match for Python with an exact-match sink registry (`a770280` `feat(sinks): exact-match
+registry with vulnerability and shell semantics`) plus per-sink unsafe-use predicates
+(`beb9686` `feat(predicates): per-sink semantics with real confinement and shell rules`) that
+require the sink argument be tainted, or the finding is downgraded to a `-UNVERIFIED`
+abstention rather than a confirmed finding. The Task 7 gate
+(`benchmark/run_precision.py`) passed for Python: recall ≥ 0.95, safe-abstention ≤ 0.15
+(currently: `GATE PASSED`, recall 1.00, safe false-positive 0.00 across all gated classes).
+Re-scanning graphify — the same 275-file external repository used for the original
+measurement — now produces **0 confirmed Python findings** (down from 2,739). CyberGraph's
+own `src/` similarly drops from 151 to **0 confirmed Python findings**.
+
+This is Python-only. The four non-Python analyzers (JavaScript/TypeScript, Go, Java, C#) are
+still the regex substring matcher described in §4.5 and still emit `CG-<LANG>-SINK-CALL`
+inventory rows — e.g. re-scanning CyberGraph's own `src/` today still reports 3
+`CG-JS-SINK-CALL` findings against the vendored `assets/cytoscape.min.js`. Those four rules
+remain classified as inventory, not verdicts, until their Phase-2 upgrade (see §4.5).
+
+**The CI SARIF filter (`.github/workflows/cybergraph.yml`, "Drop informational
+sink-inventory findings") is therefore kept, not deleted, and its scope has changed with the
+fix:** before this work the filter's pattern (`^CG-.*SINK-CALL$`) matched Python's own
+substring-grep output, so the tool really was deleting its own only rule's findings, as
+originally documented above. After the Task 1–7 rewrite, Python's verdict rules
+(`CG-SQL-EXEC`, `CG-CMD-EXEC`, `CG-PATH-TRAVERSAL`, `CG-TEMPLATE-INJECT`, `CG-CODE-EXEC`,
+`CG-DESERIALIZE`, and their `-UNVERIFIED` abstention variants) do not match that pattern at
+all — they reach code scanning uploaded and unfiltered. The filter now suppresses only the
+four non-Python `CG-{GO,JAVA,JS,CSHARP}-SINK-CALL` inventory rules, which remain
+substring-based and not actionable until Phase 2 gives those languages the same treatment
+Python just received. `tests/test_sarif.py::test_sarif_filter_targets_only_inventory_not_verdicts`
+is a direct regression test for this scope.
+
+### 4.2 OPEN (severity: CRITICAL) — the ontology silently assumes "web app with route decorators"
 
 Measured on graphify (a substantial real Python CLI/library):
 
@@ -172,7 +212,17 @@ deserialization boundaries, MCP tool handlers.
 Note: `SOURCE_KEYWORDS` already contains `argv`, but nothing ever constructs an entrypoint
 from it — CLI arguments are a textbook CWE-78 source and are entirely unmodelled.
 
-### 4.3 HIGH — `top-risks` output is incorrect, and suppressions do not reach it
+**Status: still OPEN as of 2026-08-10.** Unchanged by verdict-core/verdict-surfaces — those
+plans built a decision layer (`cybergraph check`, capability model, policy) on top of the
+existing entrypoint detection rather than widening it. This is why `cybergraph check`
+reports `UNKNOWN` for `reachable_data_paths` on a repository with no HTTP routes rather than
+a false `accept` — the capability model (Task 8, `feat(checks): evaluate every capability;
+never pass without evidence`) requires positive evidence before a capability passes, so the
+zero-entrypoint gap degrades to an honest abstention instead of a silent pass. Entrypoint
+pluralism (CLI/`__main__`/queues/Lambda/MCP tools) remains unimplemented and is tracked as
+Phase 2 work in `docs/superpowers/plans/2026-08-08-verdict-core.md`.
+
+### 4.3 VERIFIED RESOLVED — `top-risks` output is incorrect, and suppressions do not reach it
 
 Live output on graphify:
 
@@ -194,7 +244,20 @@ yet `cybergraph analyze .` still reports:
 **Suppressions filter `findings` but not attack paths or risk ranking.** The user set a config
 and the ranked output ignored it. This is a defect, not a design decision.
 
-### 4.4 HIGH — call resolution is name-only
+**Resolution:** fixed in `a8f8c26` `fix(paths): suppress before applying the traversal
+limit`, with a direct regression test added in the same commit
+(`tests/test_attack_path_suppressions.py`, Task 6 of verdict-core). Suppression is now
+applied before the traversal/ranking limit is enforced, and follow-up commits (`5772bb8`
+`fix(paths): keep suppressed paths on exploration and evidence surfaces`, `4d60f67`
+`fix(attack-paths): suppressed paths must not starve the exploration surfaces`, `b0d4b12`
+`fix(export): record the graph document's two suppression policies`) ensure a suppressed
+attack path is hidden from ranked/actionable surfaces (`top-risks`, `analyze`, PR review)
+without starving those surfaces of slots, while still appearing on exploration/evidence
+surfaces (HTML report, `explain`, JSON export) for reviewer inspection. Regression pinned
+further in `6bad214` `test(attack-paths): pin traversal invariants and the ranked
+suppression surfaces`.
+
+### 4.4 OPEN (severity: HIGH) — call resolution is name-only
 
 `analysis/resolve.py:89-92`:
 
@@ -212,7 +275,16 @@ nodes** — the call graph is overwhelmingly unresolved dangling strings.
 
 The `low`/`ambiguous` confidence tag is honest but does not recover the lost precision.
 
-### 4.5 HIGH — four of five languages have no parse tree
+**Status: still OPEN as of 2026-08-10.** Unchanged by verdict-core/verdict-surfaces — the
+`14,563 raw CALLS edges against 700 Function nodes` shape on graphify has not been
+re-measured against a fix because no fix landed; name-only resolution remains. The verdict
+layer works around it rather than fixing it: `cybergraph check`'s capability model treats
+call resolution confidence as an input to whether a capability is evaluated at all, so an
+ambiguous resolution degrades toward `UNKNOWN`/`REVIEW` rather than a false `accept`, per the
+governing invariant in `docs/superpowers/plans/2026-08-08-verdict-core.md` ("uncertainty
+never becomes safety"). Receiver-typed/import-resolved call graphs remain Phase 2 work.
+
+### 4.5 OPEN (severity: HIGH) — four of five languages have no parse tree
 
 Only Python uses a real AST (stdlib `ast`). The JavaScript/TypeScript, Go, Java, and C#
 analyzers are regex-based — each begins `import re` and each docstring self-describes as a
@@ -230,6 +302,17 @@ This compounds §4.1 and §4.4. Requiring a *tainted argument* before emitting a
 resolving a call by receiver type, needs structure that regex does not provide. Any precision
 target therefore has to be stated per-language, or the project has to take on a parsing
 dependency (e.g. tree-sitter), which trades directly against the zero-dependency moat in §3.2.
+
+**Status: still OPEN as of 2026-08-10, and this is the direct reason §4.1's CI SARIF filter
+is kept rather than deleted.** The Task 1–7 exact-match-registry-plus-predicate rewrite that
+resolved §4.1 for Python depends on an AST (taint through real expression structure); it was
+applied to `analysis/python.py` only. JavaScript/TypeScript, Go, Java, and C# still run the
+pre-rewrite regex substring matcher and still emit their `CG-{JS,GO,JAVA,CSHARP}-SINK-CALL`
+rule as inventory, not a verdict — there is no tainted-argument requirement to apply without
+a parse tree. Those four rules therefore stay classified as inventory-grade and stay behind
+the CI SARIF filter until each language gets its own Phase-2 sink registry/predicate pass (or
+the project takes on a parsing dependency, which is the tradeoff already recorded above
+against §3.2's zero-dependency moat).
 
 ### 4.6 MEDIUM — benchmark claims drift from the committed artifact
 
@@ -260,6 +343,22 @@ benchmark — the README says so honestly, but the figure gets cited as one.
 | No severity gradation | all analyzers | Everything is `medium`; triage is therefore impossible |
 | Line-based suppressions | `suppressions.py` | No content fingerprint, so any suppression breaks on a line move |
 | Full rebuild every run | `build.py` | No incremental analysis; fine at 275 files, not at 5,000 |
+
+---
+
+## 4.8 Status transitions — before/after, with commit shas
+
+Recorded 2026-08-10, at the end of the verdict-core / verdict-surfaces plans (20 tasks).
+
+| Section | Status | Before | After | Key commit(s) |
+|---|---|---|---|---|
+| §4.1 substring detector | **VERIFIED RESOLVED** (Python only) | CyberGraph `src/`: 151 findings, 1 rule (`CG-SINK-CALL`), 100% medium. graphify (275 files): 2,739 findings, 1 rule, 100% medium. | Python: 0 confirmed findings on both CyberGraph `src/` and graphify — Task 7 gate `GATE PASSED` (recall 1.00 ≥ 0.95, safe false-positive 0.00 ≤ 0.05, safe-abstention 0.00 ≤ 0.15, all classes). Non-Python: CyberGraph `src/` still reports 3 `CG-JS-SINK-CALL` inventory findings (vendored `assets/cytoscape.min.js`) — unchanged, inventory-grade, filtered from code scanning by design (see §4.5). | `a770280` (exact-match sink registry), `beb9686` (per-sink predicates), `fe07800` (Task 1–7 merged, PR #38) |
+| §4.2 entrypoints | **OPEN** | `entrypoints: 0`, `attack paths: 0` on graphify; silent degradation to grep, no warning. | Unchanged measurement; the verdict layer now reports `UNKNOWN` instead of a false accept when no entrypoints exist (Task 8, capability model). | `638a331` `feat(checks): evaluate every capability; never pass without evidence` |
+| §4.3 suppressions ignored in ranking | **VERIFIED RESOLVED** | `.cybergraph.toml` suppressed `tests/*`/`benchmark/*`/`examples/*`; `analyze` still ranked `benchmark/cases/go_http_cmdi/...` and `tests/fixtures/demo_app/...` at CRITICAL. | Suppression applied before the traversal/ranking limit; direct regression test asserts a suppressed path cannot occupy a ranked slot while still surfacing on exploration/evidence views. | `a8f8c26` (fix + `tests/test_attack_path_suppressions.py`), `5772bb8`, `4d60f67`, `b0d4b12`, `6bad214` |
+| §4.4 call resolution name-only | **OPEN** | graphify: 14,563 raw `CALLS` edges against 700 Function nodes; `_simple_name()` resolves by trailing identifier only. | Unchanged measurement; no receiver typing or import resolution added. The verdict layer treats low/ambiguous resolution confidence as grounds to abstain (`UNKNOWN`/`REVIEW`) rather than accept. | none (tracked as Phase 2 in `docs/superpowers/plans/2026-08-08-verdict-core.md`) |
+| §4.5 four languages without parse trees | **OPEN** | JS/TS, Go, Java, C# analyzers are regex-based (`import re`, 6–8 call sites each); no structure to require a tainted argument. | Unchanged; this is why the four `CG-{JS,GO,JAVA,CSHARP}-SINK-CALL` rules remain inventory-grade and why the CI SARIF filter (§4.1) still suppresses them from code scanning. | none (tracked as Phase 2) |
+
+Live re-measurement commands used above: `cybergraph scan src` (CyberGraph self-scan), `cybergraph sarif --repo src --output ...` (rule-id breakdown), `python benchmark/run_precision.py` (gate).
 
 ---
 

--- a/docs/superpowers/plans/2026-08-09-verdict-surfaces.md
+++ b/docs/superpowers/plans/2026-08-09-verdict-surfaces.md
@@ -1,0 +1,237 @@
+# Verdict Surfaces Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose the verdict through the MCP surface and close out the plan's CI/audit/docs — completing the entire 20-task verdict-core roadmap. The MCP tool mirrors `cybergraph check --json`; CI runs `cybergraph check` on PRs as a non-gating notification; the audit and README are made honest.
+
+**Architecture:** `mcp_server.py` gains a thin `@mcp.tool()` over the shared `check_change` orchestrator (C6: no CLI import). The CI workflow keeps its inventory-only SARIF filter and adds a PR `check` step. Docs record honest statuses and usage.
+
+**Tech Stack:** Python 3.10–3.13, standard library + FastMCP (optional, import-guarded), pytest, ruff, GitHub Actions YAML.
+
+**Spec:** `docs/superpowers/specs/2026-08-09-verdict-surfaces-design.md`
+**Parent roadmap:** `docs/superpowers/plans/2026-08-08-verdict-core.md` (Task 1 below is that plan's Task 19 verbatim; Task 2 is that plan's Task 20 with its SARIF step revised per a ruling — see Task 2).
+
+## Global Constraints
+
+- **Python 3.10–3.13.** `from __future__ import annotations` in any new/modified module that needs it.
+- **Zero runtime dependencies** on the default path; FastMCP is optional and import-guarded (`if FastMCP is not None:`). Tests touching MCP start with `pytest.importorskip("fastmcp")`.
+- **Ruff:** line-length 100, `select = ["E","F","I","N","W","UP"]`.
+- **No "safe to ship"** anywhere in `src/` or the README (case-insensitive); the guard test from the verdict-layer slice stays green. The README must not claim the MCP tool provides automatic verification.
+- **C6:** `mcp_server.py` must not import from `cli.py`; both call `check_change`.
+- **Commits:** author `Laraib <lxh417bham@gmail.com>` only. Never `azizur@sirio-strategies.com`, never `-c user.email=…`, no `Co-Authored-By`, no AI attribution. Multiple small commits.
+- **Baseline:** full suite green (1153 passed, 1 skipped); `run_precision.py` GATE PASSED exit 0; `run_eval.py` 1.0/1.0/1.0; mutation harness all CAUGHT. None may regress. Revert any `benchmark/results.json` churn before committing.
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `src/cybergraph/mcp_server.py` (modify) | `check_change_tool` — MCP wrapper over `check_change` | 1 |
+| `tests/test_mcp_parity.py` (append) | tool exposed, agrees with CLI `--json`, no CLI import | 1 |
+| `.github/workflows/cybergraph.yml` (modify) | keep inventory-only SARIF filter; add PR `check` step | 2 |
+| `tests/test_sarif.py` (append) | filter matches no verdict rule; `check` step present | 2 |
+| `docs/CRITICAL_AUDIT.md` (modify) | honest audit statuses + before/after + shas | 2 |
+| `README.md` (modify) | document `check`/`policy`, Phase 1 contract, verified languages | 2 |
+
+---
+
+## Task 1: MCP `check_change` tool
+
+**Files:** Modify `src/cybergraph/mcp_server.py`; test `tests/test_mcp_parity.py` (append).
+
+**Interfaces:** `check_change_tool(repo_root: str = ".", base: str = "") -> dict[str, Any]`, byte-identical to `cybergraph check --json`.
+
+**Match this file's three conventions exactly:** tools are defined **inside** the `if FastMCP is not None:` block; the decorator is `@mcp.tool()`; the repository parameter is `repo_root: str = "."`. Every test starts with `pytest.importorskip("fastmcp")`.
+
+**This is interoperability, not automatic verification.** An agent may never call it. Reliable invocation needs a client hook, which is Phase 2 — the README must not claim otherwise.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_mcp_parity.py`:
+
+```python
+def test_check_change_tool_is_exposed():
+    pytest.importorskip("fastmcp")
+    from cybergraph import mcp_server
+
+    assert hasattr(mcp_server, "check_change_tool")
+
+
+def test_check_change_tool_and_cli_agree(tmp_path):
+    """Two surfaces over one orchestrator must never disagree."""
+    pytest.importorskip("fastmcp")
+    import contextlib
+    import io
+    import json as _json
+    import subprocess
+
+    from cybergraph import mcp_server
+    from cybergraph.cli import main
+
+    (tmp_path / "app.py").write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "b"],
+        cwd=tmp_path, check=True,
+    )
+
+    tool_result = mcp_server.check_change_tool(str(tmp_path))
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        main(["check", str(tmp_path), "--json"])
+    assert tool_result == _json.loads(buffer.getvalue())
+
+
+def test_mcp_server_does_not_import_from_the_cli():
+    """C6: the MCP surface must not reach into CLI internals."""
+    from pathlib import Path
+
+    source = Path("src/cybergraph/mcp_server.py").read_text(encoding="utf-8")
+    assert "from .cli import" not in source
+    assert "from cybergraph.cli import" not in source
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python -m pytest tests/test_mcp_parity.py -v`
+Expected: FAIL — `AttributeError: module 'cybergraph.mcp_server' has no attribute 'check_change_tool'` (or the whole file skips if `fastmcp` is absent — if so, note it and verify by importing the module directly that the attribute is missing pre-implementation).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to the module-level imports at the top of `src/cybergraph/mcp_server.py`:
+
+```python
+from .security.check import check_change
+from .security.verdict import verdict_to_dict
+```
+
+Add inside the `if FastMCP is not None:` block:
+
+```python
+    @mcp.tool()
+    def check_change_tool(repo_root: str = ".", base: str = "") -> dict[str, Any]:
+        """Check whether the current change preserves this project's guarantees.
+
+        Returns the same object as `cybergraph check --json`. `state` is
+        "accept" or "review"; `checks` gives a per-capability result; and
+        `not_evaluated` lists what CyberGraph could not check on this change.
+        An "accept" means the checks that ran found nothing — read
+        `not_evaluated` before treating it as broader assurance.
+        """
+        verdict = check_change(Path(repo_root).resolve(), base=base or None)
+        return verdict_to_dict(verdict)
+```
+
+**Note for the implementer:** confirm `Path` and `Any` are already imported at the top of `mcp_server.py` (they are used elsewhere); add whichever is missing. If `check_change_tool` must be reachable by the parity test even when it is defined inside the `if FastMCP is not None:` block, confirm the test environment has `fastmcp` installed (the tests `importorskip` it) — if `fastmcp` is not installed in this environment, the parity tests will skip; in that case ALSO add a direct import-level assertion path or run the equivalent check by importing `check_change`/`verdict_to_dict` and comparing, and report that the fastmcp-gated tests skipped here.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python -m pytest tests/test_mcp_parity.py -v` — PASS (or SKIPPED if `fastmcp` absent; report which).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/mcp_server.py tests/test_mcp_parity.py
+git commit -m "feat(mcp): expose check_change through the shared orchestrator"
+```
+
+---
+
+## Task 2: CI, audit and docs (SARIF step revised)
+
+**Files:** Modify `.github/workflows/cybergraph.yml`, `tests/test_sarif.py`, `docs/CRITICAL_AUDIT.md`, `README.md`.
+
+**RULING that changes the parent plan's Task 20 Step 1:** the parent plan says *delete the SARIF filter — "the rule it filtered no longer exists."* That premise is false. The filter (`^CG-.*SINK-CALL$`) still matches four **live** rules — `CG-GO-SINK-CALL`, `CG-JAVA-SINK-CALL`, `CG-JS-SINK-CALL`, `CG-CSHARP-SINK-CALL` — the substring-based *inventory* findings from the four non-Python analyzers (inventory-grade until Phase 2). Python's verdict rules (`CG-SQL-EXEC`, `CG-CMD-EXEC`, `CG-PATH-TRAVERSAL`, `CG-TEMPLATE-INJECT`, `CG-CODE-EXEC`, `CG-DESERIALIZE`) do **not** match the filter and already reach code scanning. So §4.1 ("the tool deletes its own real findings") is already resolved for Python; deleting the filter now would upload the four non-Python substring-inventory rules as `medium` code-scanning results — reintroducing noise. **Keep the filter, scoped to inventory-only.**
+
+- [ ] **Step 1: Keep the SARIF filter; guard that it never filters a verdict rule**
+
+Do NOT remove the `Drop informational sink-inventory findings` step in `.github/workflows/cybergraph.yml`. Leave the `jq` filter (`test("^CG-.*SINK-CALL$")`) in place — it suppresses only the four non-Python inventory rules. Append to `tests/test_sarif.py`:
+
+```python
+def test_sarif_filter_targets_only_inventory_not_verdicts():
+    """The CI filter must drop only *-SINK-CALL inventory, never an actionable
+    verdict rule; and Python's verdict findings must reach code scanning."""
+    import re
+    from pathlib import Path
+
+    workflow = Path(".github/workflows/cybergraph.yml").read_text(encoding="utf-8")
+    # The filter still exists and still targets the inventory rule family.
+    assert "SINK-CALL" in workflow, "the inventory filter must remain"
+    filter_pattern = re.compile(r"CG-.\*SINK-CALL|\^CG-\.\*SINK-CALL\$")
+    assert filter_pattern.search(workflow), "filter must target the *-SINK-CALL family"
+
+    # No Python verdict rule id may match the filter pattern (they must upload).
+    verdict_rules = (
+        "CG-SQL-EXEC", "CG-CMD-EXEC", "CG-PATH-TRAVERSAL",
+        "CG-TEMPLATE-INJECT", "CG-CODE-EXEC", "CG-DESERIALIZE",
+    )
+    for rule in verdict_rules:
+        assert not re.fullmatch(r"CG-.*SINK-CALL", rule), rule
+
+
+def test_workflow_runs_check_on_pull_requests():
+    from pathlib import Path
+
+    workflow = Path(".github/workflows/cybergraph.yml").read_text(encoding="utf-8")
+    assert "cybergraph check" in workflow
+    assert "merge-base" in workflow
+```
+
+**Note for the implementer:** if a test in `test_sarif.py` from an earlier plan asserts `"SINK-CALL" not in workflow` (the deletion the parent plan expected), that assertion now contradicts this ruling — update it to the kept-filter expectation above and note the change in the report. If no such test exists, just append the two tests above.
+
+- [ ] **Step 2: Add `check` to CI in explicit merge-base mode**
+
+C7: `--base` alone selected worktree mode, so the documented merge-base path was never exercised. After the build step in `.github/workflows/cybergraph.yml`:
+
+```yaml
+      - name: Check the change
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          git fetch --no-tags --depth=0 origin "$BASE_REF"
+          cybergraph check . --mode merge-base --base "origin/$BASE_REF" \
+            | tee cybergraph-check.txt
+```
+
+The full-depth `fetch` matters: a shallow checkout has no common ancestor, which now reports a failure rather than an empty diff. **No `--fail-on-review`** — a REVIEW stays a notification until the field false-positive rate is measured; gating here would contradict the plan's own trust argument.
+
+- [ ] **Step 3: Transition audit statuses honestly**
+
+In `docs/CRITICAL_AUDIT.md` use three states: `OPEN`, `MITIGATED`, `VERIFIED RESOLVED`. Set:
+- §4.1 (substring detector) → **VERIFIED RESOLVED** — the Task 7 gate passed (recall ≥ 0.95, safe-abstention ≤ 0.15) for Python and the substring detector is gone; graphify scanned 2,739 → 0 confirmed findings. Add: the CI SARIF filter no longer suppresses any Python/verdict rule (verdicts reach code scanning); it now suppresses only the four non-Python `*-SINK-CALL` inventory rules, which remain inventory-grade until their Phase-2 verdict upgrade.
+- §4.3 (suppressions ignored in ranking) → **VERIFIED RESOLVED** (Task 6 of verdict-core has a direct regression test).
+- §4.2 (entrypoints), §4.4 (call resolution), §4.5 (four languages without parse trees) → **OPEN**. Note §4.5 is why the four non-Python inventory rules are still filtered from code scanning.
+
+Append the measured before/after numbers and the commit sha for each.
+
+- [ ] **Step 4: Update the README**
+
+Add `cybergraph check` and `cybergraph policy` to Quick start (above `analyze`). Add a "Security policy" section covering `cybergraph policy --init-policy`, that the file (`cybergraph.policy.toml`) is committed, and that any agent can read it. State the Phase 1 contract sentence verbatim and say plainly which languages are verified today (Python produces verdicts; Go/JS/Java/C# are inventory-grade). The README must **not** say the MCP tool provides automatic verification (it is an interoperability surface an agent may decline to call), and must contain nothing matching `safe to ship`.
+
+- [ ] **Step 5: Final verification**
+
+```
+python -m pytest -q
+python -m ruff check src tests
+python benchmark/run_precision.py
+python benchmark/run_eval.py
+python benchmark/mutation_harness.py
+```
+Expected: all green; precision ≥ 0.90, recall ≥ 0.95, safe-abstention ≤ 0.15; eval 1.0/1.0/1.0; harness all CAUGHT. Revert any `benchmark/results.json` churn.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/ docs/ README.md tests/
+git commit -m "docs+ci: run cybergraph check on PRs; keep inventory-only SARIF filter; record audit status"
+```
+
+---
+
+## Notes for the executor
+
+- Task 1 (MCP) then Task 2 (CI/docs). They are independent; keep them separate commits.
+- This slice completes the 20-task verdict-core plan. Do not build anything from the parent plan's "Out of scope" table.
+- The SARIF-filter ruling (Task 2 Step 1) reverses the parent plan's literal instruction on purpose — keeping the filter is correct because the four non-Python languages still emit substring inventory rules. If a reviewer flags the kept filter as contradicting the parent plan, that is the documented ruling, not a defect.
+- No "safe to ship" phrasing; no claim that MCP is automatic verification; no `--fail-on-review` in CI.

--- a/docs/superpowers/specs/2026-08-09-verdict-surfaces-design.md
+++ b/docs/superpowers/specs/2026-08-09-verdict-surfaces-design.md
@@ -1,0 +1,54 @@
+# Verdict Surfaces — Design (Milestone 1B, slice 4 — final)
+
+**Status:** approved for planning
+**Slice:** Tasks 19, 20 of `docs/superpowers/plans/2026-08-08-verdict-core.md` (Task 20's SARIF step revised per the ruling below). Completing these finishes the entire 20-task verdict-core plan.
+**Predecessors:** #38, #39 merged; #40 policy-graph in review; verdict-layer done (this branch stacks on it).
+
+## What this slice does
+
+Exposes the verdict through the second surface and closes out the plan's CI/audit/docs:
+
+- **MCP `check_change_tool`** — a thin `@mcp.tool()` wrapper returning byte-identical output to `cybergraph check --json`, so an agent can call the same orchestrator the CLI does. It is *interoperability, not automatic verification* — an agent may never call it; reliable invocation is a client hook (Phase 2). The README must not claim otherwise. C6: the MCP surface must not import from the CLI; both call `check_change`.
+- **CI wiring** — run `cybergraph check . --mode merge-base --base origin/<base>` on pull requests (with a full-depth fetch so a shallow checkout reports a failure, not an empty diff). No `--fail-on-review`: review stays a notification until a field false-positive rate is measured.
+- **Audit + README** — record honest audit statuses and document `cybergraph check` / `cybergraph policy`, the Phase 1 contract, and which languages are verified.
+
+## The one revised decision (ruled with the user)
+
+Task 20 as written says *delete the CI SARIF filter — "the rule it filtered no longer exists."* That premise is **false**: the filter (`^CG-.*SINK-CALL$`) still matches four live rules — `CG-GO-SINK-CALL`, `CG-JAVA-SINK-CALL`, `CG-JS-SINK-CALL`, `CG-CSHARP-SINK-CALL` — the substring-based *inventory* findings from the four non-Python analyzers, which remain inventory-grade until Phase 2. Python no longer emits `CG-SINK-CALL`; its verdict rules (`CG-SQL-EXEC`, …) do not match the filter and already reach code scanning. So the audit's §4.1 "the tool deletes its own real findings" is **already resolved for Python** — deleting the filter now would instead upload the four non-Python substring-inventory rules as `medium` code-scanning results, reintroducing exactly the noise the project fought.
+
+**Ruling: keep the filter, scoped to inventory-only; do NOT delete it.** The revised Task 2 asserts that no *verdict* rule id is matched by the filter (the real §4.1 fix — actionable findings reach code scanning) and that the filter still catches only `*-SINK-CALL` inventory rules, and documents in the audit that the four non-Python languages stay inventory-grade until their Phase-2 verdict upgrade.
+
+## Architecture / boundaries
+
+- `mcp_server.py` gains `check_change_tool` inside the `if FastMCP is not None:` block; imports `check_change` + `verdict_to_dict`; imports nothing from `cli.py` (C6). The parity test asserts the tool and `cybergraph check --json` produce the identical dict.
+- `.github/workflows/cybergraph.yml` keeps the SARIF filter and adds the PR `check` step.
+- `docs/CRITICAL_AUDIT.md` and `README.md` are updated for honesty and usage.
+
+## Error handling
+
+- The CI `check` step must not gate the build on a REVIEW (no `--fail-on-review`); a REVIEW is a notification. The build fails only on a real tool error.
+- The full-depth fetch ensures merge-base mode has a common ancestor; a missing ancestor reports a failure (REVIEW), never a silent empty diff.
+
+## Testing
+
+- MCP: `tests/test_mcp_parity.py` — the tool is exposed, agrees byte-for-byte with `cybergraph check --json`, and the MCP module imports nothing from the CLI. Each test `pytest.importorskip("fastmcp")`.
+- SARIF/CI: `tests/test_sarif.py` — assert the filter matches no *verdict* rule id (so real Python findings reach code scanning) and still targets only `*-SINK-CALL` inventory; assert the PR `check` step exists in the workflow.
+- Full suite, precision gate, eval, and mutation harness stay green.
+
+## Global constraints (inherited)
+
+- Python 3.10–3.13; `from __future__ import annotations`; zero runtime dependencies; ruff line-length 100; no network/API keys on a default path.
+- No "safe to ship" phrasing anywhere in `src/` or the README; the guard test (from the verdict-layer slice) stays green.
+- Commits authored `Laraib <lxh417bham@gmail.com>` only; no AI attribution; multiple small commits; never squash.
+
+## Roadmap alignment
+
+Completes Tasks 19–20 and thus the whole verdict-core plan. Everything in the parent plan's "Out of scope" table (non-Python verdicts, client hooks, config posture, authorization ontology, BLOCK, ASVS/ISO evidence, …) remains deferred to its stated phase. The non-Python inventory-grade status and the receiver-variable guard follow-up (from #40) are documented, not resolved here.
+
+## Success criteria
+
+1. `check_change_tool` exists, returns the same dict as `cybergraph check --json`, and `mcp_server.py` imports nothing from `cli.py` (C6).
+2. The CI SARIF filter is kept and scoped to inventory-only; a test asserts no verdict rule is filtered and the PR `check` step runs in merge-base mode.
+3. `docs/CRITICAL_AUDIT.md` records honest statuses (§4.1 resolved for Python / non-Python inventory-grade; §4.2/4.4/4.5 open) with before/after numbers and commit shas.
+4. README documents `cybergraph check` and `cybergraph policy`, the Phase 1 contract, and verified languages; contains no "safe to ship" and no claim that MCP is automatic verification.
+5. Full suite, precision gate, eval, and mutation harness all green.

--- a/src/cybergraph/mcp_server.py
+++ b/src/cybergraph/mcp_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json as _json
 from pathlib import Path
 from typing import Any
 
@@ -9,6 +10,8 @@ from .build import build_graph
 from .graph import GraphStore
 from .rag import answer_grounded, answer_question, format_grounded_answer
 from .security import find_attack_paths, format_attack_paths, load_scanner_findings
+from .security.check import check_change
+from .security.verdict import verdict_to_dict
 
 try:
     from fastmcp import FastMCP
@@ -119,6 +122,24 @@ if FastMCP is not None:
         from .security.vulnerabilities import import_vulnerability_report
 
         return import_vulnerability_report(Path(repo_root).resolve(), Path(report_path).resolve())
+
+    @mcp.tool()
+    def check_change_tool(repo_root: str = ".", base: str = "") -> dict[str, Any]:
+        """Check whether the current change preserves this project's guarantees.
+
+        Returns the same object as `cybergraph check --json`. `state` is
+        "accept" or "review"; `checks` gives a per-capability result; and
+        `not_evaluated` lists what CyberGraph could not check on this change.
+        An "accept" means the checks that ran found nothing — read
+        `not_evaluated` before treating it as broader assurance.
+        """
+        verdict = check_change(Path(repo_root).resolve(), base=base or None)
+        # `cybergraph check --json` prints this same dict through `json.dumps`,
+        # which turns dataclass tuple fields (e.g. `provenance.capabilities`)
+        # into lists. Round-tripping here keeps this tool byte-identical to
+        # that JSON, not merely equal in a Python sense that a raw dict with
+        # tuples inside would fail against the string the CLI actually emits.
+        return _json.loads(_json.dumps(verdict_to_dict(verdict)))
 else:
     mcp = None
 

--- a/src/cybergraph/security/revisions.py
+++ b/src/cybergraph/security/revisions.py
@@ -41,8 +41,23 @@ def _git(repo_root: Path, *args: str) -> tuple[bool, str]:
     return True, proc.stdout
 
 
+def _is_cybergraph_state(path: str) -> bool:
+    """CyberGraph's own state directory is never part of a code delta.
+
+    Fed back into ``changed_files`` it would make the tool analyze its own
+    cache -- a second ``check_change`` on the same repo would see the first
+    call's ``.cybergraph/graph.db`` (and base cache) as "changed" and flip
+    ACCEPT to REVIEW. This must not depend on the target repo's `.gitignore`:
+    a fresh repo, or one that simply never added the entry, must still be
+    correct. Mirrors ``analysis.collector.DEFAULT_EXCLUDES``, which excludes
+    ``.cybergraph`` from analysis for the same reason.
+    """
+    return path.split("/", 1)[0] == ".cybergraph"
+
+
 def _names(output: str) -> tuple[str, ...]:
-    return tuple(sorted({line.strip() for line in output.splitlines() if line.strip()}))
+    names = {line.strip() for line in output.splitlines() if line.strip()}
+    return tuple(sorted(n for n in names if not _is_cybergraph_state(n)))
 
 
 def _verify(repo_root: Path, ref: str) -> bool:

--- a/tests/test_mcp_parity.py
+++ b/tests/test_mcp_parity.py
@@ -129,3 +129,45 @@ def test_import_vulnerabilities_tool_imports_records(tmp_path):
     result = mcp_server.import_vulnerabilities_tool(str(report), str(repo))
     assert result["vulnerabilities"] == 1
     assert "matched_dependencies" in result
+
+
+def test_check_change_tool_is_exposed():
+    pytest.importorskip("fastmcp")
+    from cybergraph import mcp_server
+
+    assert hasattr(mcp_server, "check_change_tool")
+
+
+def test_check_change_tool_and_cli_agree(tmp_path):
+    """Two surfaces over one orchestrator must never disagree."""
+    pytest.importorskip("fastmcp")
+    import contextlib
+    import io
+    import json as _json
+    import subprocess
+
+    from cybergraph import mcp_server
+    from cybergraph.cli import main
+
+    (tmp_path / "app.py").write_text("def add(a, b):\n    return a + b\n", encoding="utf-8")
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "b"],
+        cwd=tmp_path, check=True,
+    )
+
+    tool_result = mcp_server.check_change_tool(str(tmp_path))
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        main(["check", str(tmp_path), "--json"])
+    assert tool_result == _json.loads(buffer.getvalue())
+
+
+def test_mcp_server_does_not_import_from_the_cli():
+    """C6: the MCP surface must not reach into CLI internals."""
+    from pathlib import Path
+
+    source = Path("src/cybergraph/mcp_server.py").read_text(encoding="utf-8")
+    assert "from .cli import" not in source
+    assert "from cybergraph.cli import" not in source

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -146,9 +146,20 @@ def test_cybergraph_state_dir_is_never_a_changed_file(tmp_path: Path):
     """The tool must never feed itself its own cache as the user's diff.
 
     No `.gitignore` excludes `.cybergraph/` here -- the exclusion must be
-    unconditional, not dependent on the target repo's gitignore."""
+    unconditional, not dependent on the target repo's gitignore.
+
+    The exclusion must match by path *component*, not by substring: a real
+    changed file that merely starts with or contains ``cybergraph`` in its
+    name -- ``cybergraph_utils.py``, ``.cybergraphrc`` -- is not under the
+    `.cybergraph/` directory and must still be kept. A substring match
+    (``"cybergraph" in path``) would drop these -- a fail-open that stops
+    checking a real change, including any `src/cybergraph/*.py` change on
+    this tool's own repo -- while still passing a check that only looks for
+    the `.cybergraph/` paths being absent."""
     repo = _repo(tmp_path)
     (repo / "new_admin_endpoint.py").write_text("x = 1\n", encoding="utf-8")
+    (repo / "cybergraph_utils.py").write_text("x = 1\n", encoding="utf-8")
+    (repo / ".cybergraphrc").write_text("x = 1\n", encoding="utf-8")
     (repo / ".cybergraph").mkdir()
     (repo / ".cybergraph" / "graph.db").write_text("", encoding="utf-8")
     base_dir = repo / ".cybergraph" / "base" / "deadbeef"
@@ -156,9 +167,14 @@ def test_cybergraph_state_dir_is_never_a_changed_file(tmp_path: Path):
     (base_dir / "app.py").write_text("x = 1\n", encoding="utf-8")
 
     revisions = resolve_revisions(repo)
-    assert revisions.changed_files == ("new_admin_endpoint.py",)
+    assert revisions.changed_files == (
+        ".cybergraphrc",
+        "cybergraph_utils.py",
+        "new_admin_endpoint.py",
+    )
     for path in revisions.changed_files:
-        assert not path.startswith(".cybergraph")
+        assert not path.startswith(".cybergraph/")
+        assert path != ".cybergraph"
 
 
 def test_clean_tree_on_main_with_no_base_is_not_a_failure(tmp_path: Path):

--- a/tests/test_revisions.py
+++ b/tests/test_revisions.py
@@ -142,6 +142,25 @@ def test_not_a_git_repository_is_a_failure(tmp_path: Path):
     assert revisions.changed_files == ()
 
 
+def test_cybergraph_state_dir_is_never_a_changed_file(tmp_path: Path):
+    """The tool must never feed itself its own cache as the user's diff.
+
+    No `.gitignore` excludes `.cybergraph/` here -- the exclusion must be
+    unconditional, not dependent on the target repo's gitignore."""
+    repo = _repo(tmp_path)
+    (repo / "new_admin_endpoint.py").write_text("x = 1\n", encoding="utf-8")
+    (repo / ".cybergraph").mkdir()
+    (repo / ".cybergraph" / "graph.db").write_text("", encoding="utf-8")
+    base_dir = repo / ".cybergraph" / "base" / "deadbeef"
+    base_dir.mkdir(parents=True)
+    (base_dir / "app.py").write_text("x = 1\n", encoding="utf-8")
+
+    revisions = resolve_revisions(repo)
+    assert revisions.changed_files == ("new_admin_endpoint.py",)
+    for path in revisions.changed_files:
+        assert not path.startswith(".cybergraph")
+
+
 def test_clean_tree_on_main_with_no_base_is_not_a_failure(tmp_path: Path):
     """On the default branch with a clean tree there is nothing to compare, but
     that is not a tool failure -- it is an empty, established comparison."""

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -80,3 +80,8 @@ def test_workflow_runs_check_on_pull_requests():
     workflow = Path(".github/workflows/cybergraph.yml").read_text(encoding="utf-8")
     assert "cybergraph check" in workflow
     assert "merge-base" in workflow
+    # `git fetch --depth=0` is invalid ("depth 0 is not a positive number") and
+    # fails the CI step; the checkout already uses fetch-depth: 0 for full history.
+    assert "--depth=0" not in workflow
+    # a REVIEW must stay a notification in CI, never gate the build.
+    assert "--fail-on-review" not in workflow

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -51,3 +51,32 @@ def test_unverified_rule_id_is_preserved_on_export(tmp_path: Path) -> None:
     rule_ids = [rule["id"] for rule in data["runs"][0]["tool"]["driver"]["rules"]]
     assert result_ids == ["CG-SQL-EXEC-UNVERIFIED"], result_ids
     assert "CG-SQL-EXEC-UNVERIFIED" in rule_ids, rule_ids
+
+
+def test_sarif_filter_targets_only_inventory_not_verdicts():
+    """The CI filter must drop only *-SINK-CALL inventory, never an actionable
+    verdict rule; and Python's verdict findings must reach code scanning."""
+    import re
+    from pathlib import Path
+
+    workflow = Path(".github/workflows/cybergraph.yml").read_text(encoding="utf-8")
+    # The filter still exists and still targets the inventory rule family.
+    assert "SINK-CALL" in workflow, "the inventory filter must remain"
+    filter_pattern = re.compile(r"CG-.\*SINK-CALL|\^CG-\.\*SINK-CALL\$")
+    assert filter_pattern.search(workflow), "filter must target the *-SINK-CALL family"
+
+    # No Python verdict rule id may match the filter pattern (they must upload).
+    verdict_rules = (
+        "CG-SQL-EXEC", "CG-CMD-EXEC", "CG-PATH-TRAVERSAL",
+        "CG-TEMPLATE-INJECT", "CG-CODE-EXEC", "CG-DESERIALIZE",
+    )
+    for rule in verdict_rules:
+        assert not re.fullmatch(r"CG-.*SINK-CALL", rule), rule
+
+
+def test_workflow_runs_check_on_pull_requests():
+    from pathlib import Path
+
+    workflow = Path(".github/workflows/cybergraph.yml").read_text(encoding="utf-8")
+    assert "cybergraph check" in workflow
+    assert "merge-base" in workflow


### PR DESCRIPTION
## What this does

The final slice of the 20-task verdict-core plan. Exposes the verdict through a second surface and closes out CI/audit/docs:

- **MCP `check_change_tool`** — a thin `@mcp.tool()` returning byte-identical output to `cybergraph check --json`, so an agent can call the same orchestrator the CLI does. It is *interoperability, not automatic verification* — an agent may decline to call it; reliable invocation is a client hook (Phase 2). C6: the MCP surface imports nothing from the CLI; both call `check_change`.
- **CI wiring** — `cybergraph check . --mode merge-base --base origin/<base>` runs on pull requests (full-depth fetch so a shallow checkout reports a failure, not an empty diff). **No `--fail-on-review`** — a REVIEW is a notification until a field false-positive rate is measured.
- **SARIF filter kept (not deleted).** The parent plan said delete it; that premise is stale. The filter still suppresses four live non-Python `*-SINK-CALL` inventory rules, while Python's verdict rules (`CG-SQL-EXEC`, …) don't match it and already reach code scanning. Deleting it would upload substring inventory as noise. A test now asserts no verdict rule is filtered.
- **Honest audit + README** — `docs/CRITICAL_AUDIT.md` marks §4.1/§4.3 resolved (§4.1 Python-qualified) and leaves §4.2/§4.4/§4.5 open; README documents `cybergraph check` / `cybergraph policy`, the Phase 1 contract, and which languages are verified. No "safe to ship" phrasing; MCP is not described as automatic verification.

Also includes a fix surfaced by the MCP parity test: `resolve_revisions` was counting CyberGraph's own `.cybergraph/` cache as a user change (so a second `check` flipped ACCEPT→REVIEW). Now excluded by path component — verified not to over-exclude a real `cybergraph_utils.py` / `.cybergraphrc`.

## Trustworthiness

Whole-branch review READY TO MERGE; the one flagged item was a test blind spot (now closed with a regression test + harness mutation, so a substring-over-exclusion fail-open is caught). Full suite green (1159 passed, 1 skipped); ruff clean; benchmark 1.0/1.0/1.0; mutation harness 31/31 CAUGHT. Every fix reproduced-as-closed by execution.

With this merged, the entire 20-task verdict-core plan is on `main`: a security tool that went from deleting its own findings in CI to an earned ACCEPT/REVIEW that says plainly what it could not verify.

## Deferred (documented, not in this slice)

Non-Python languages remain inventory-grade (Phase 2); the `admin_router` receiver-name guard false-positive; BLOCK state (awaits a measured field false-positive rate).
