### PR TITLE
feat: config posture — Firebase rules, Supabase RLS, public buckets (Phase 2, slice 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ CyberGraph is designed to connect those dots.
 - Builds a local SQLite graph in `.cybergraph/graph.db`.
 - Analyzes **five languages**: Python (FastAPI/Flask/Django), JavaScript/TypeScript (Express/Next.js), Go (net/http, Gin, Echo), Java (Spring), and C# (ASP.NET Core) — through a shared analyzer contract with graceful fallback for the rest.
 - Extracts functions, calls, route entrypoints, auth/authz guards, validators, user-input/data-flow edges, secret access/exposure, cloud resources, and sensitive sink calls.
+- **Config posture** — open Firebase security rules, Supabase tables with row-level
+  security off, and public S3/GCS bucket policies. A change that weakens one is a REVIEW.
 - **Cross-file, interprocedural attack paths** (route → service → repository → sink) with confidence, sanitizer-barrier flags, taint/data-reachability, risk scores, and fix guidance; a `--shallow` mode reproduces intra-function traversal for comparison.
 - **Interactive, offline HTML report** built for first-time readers: a dark-mode-first neon graph explorer (glowing, security-typed nodes with a light/dark toggle), NODE/EDGE/ZONE explainer cards, a guided first view that opens on the top attack path with a plain-language narrative, a security-zones view (Attack Surface → Guards → Logic → Sensitive Sinks), search, layer/severity filters, a details panel with source drill-down, and entrypoint→sink path highlighting (Cytoscape.js, fully inlined).
 - **Exec-first report posture**: an A–F security grade with a one-line verdict and severity-distribution bar, a since-last-scan delta strip (new/regressed/fixed), findings grouped into expandable rule cards, an honest findings-cap footer, and a print stylesheet for clean PDF export.

--- a/benchmark/mutation_harness.py
+++ b/benchmark/mutation_harness.py
@@ -472,6 +472,31 @@ MUTATIONS: list[Mutation] = [
         ),
         note="staged mode must read the index (--cached), not the working tree",
     ),
+    # -- D9: config posture findings must reach the verdict, not be dropped --
+    Mutation(
+        id="D9-config-posture-finding-ignored",
+        disaster="D9",
+        file="cybergraph/security/checks.py",
+        old="    confirmed = [f for f in findings if f.rule_id in rules]",
+        new="    confirmed = []",
+        tests=(
+            "tests/test_config_posture_capability.py::test_disabling_rls_makes_check_review",
+        ),
+        note="a config posture finding must FAIL the capability, not be dropped",
+    ),
+    Mutation(
+        id="D9-unparsed-config-reads-clean",
+        disaster="D9",
+        file="cybergraph/analysis/bucket_policy.py",
+        old="    data = json.loads(source)  # JSONDecodeError propagates -> registry containment",
+        new="    try:\n        data = json.loads(source)\n"
+        "    except ValueError:\n        return nodes, [], findings",
+        tests=(
+            "tests/test_config_posture_capability.py::"
+            "test_malformed_bucket_policy_reads_unknown",
+        ),
+        note="an unparseable config must read UNKNOWN, never a clean pass",
+    ),
 ]
 
 

--- a/docs/superpowers/plans/2026-08-10-config-posture.md
+++ b/docs/superpowers/plans/2026-08-10-config-posture.md
@@ -1,0 +1,918 @@
+# Config Posture (Declarative Trio) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect three declarative-config exposures — an open Firebase rule, a Supabase table with row-level security off, a public storage bucket — and make a change that weakens one return REVIEW from `cybergraph check` (so the client hooks catch it), never a silent ACCEPT and never a false alarm on a config it could not parse.
+
+**Architecture:** Three new lightweight analyzers (`firebase_rules.py`, `supabase_rls.py`, `bucket_policy.py`) modeled on `terraform.py` — regex/`json`, stdlib only, always a File node, findings carry a CWE + verbatim evidence and honor inline suppressions. They register in `analysis/registry.py` and are recognized by scoped path/name heuristics in `analysis/collector.py`. Then the deliberately-placeholder `cloud_configuration` capability is activated: `supported=True`, its `covers` and `assess_coverage` both keyed on a new `CONFIG_GLOBS` (one source of truth), and `_FINDING_RULES` maps it to a *set* of rule ids (the trio + Terraform's existing `CG-IAC-*`) so a posture regression on a changed config file → FAIL → REVIEW.
+
+**Tech Stack:** Python 3.10–3.13, standard library only (`re`, `json`, `pathlib`, `fnmatch`). Existing `graph.Finding/Node/Edge`, `suppressions.is_inline_suppressed`, the analyzer registry, the capability/coverage machinery, `security/checks.py`.
+
+## Global Constraints
+
+- **Zero runtime dependencies** (`dependencies = []`); standard library only. No HCL/YAML/SQL parser dependency — regex/`json` like the existing lightweight analyzers.
+- Python 3.10–3.13. `from __future__ import annotations` as the first line of every new `.py` file.
+- Ruff line-length 100; run `ruff check` on every touched file; it must be clean (fix unused imports/vars too).
+- No network; no API keys on any default path.
+- **Precision over recall.** A verification tool's false alarm is worse than a miss: an analyzer emits a finding only on a definite insecure signal, and matches config files *narrowly* — never "every `.sql`/`.json` in the repo."
+- **Coverage honesty.** A changed in-scope config file that could not be parsed must read UNKNOWN, never PASS. Malformed JSON must reach the registry's per-file containment (raise, don't swallow).
+- Analyzer contract: `analyze_X_file(path, repo_root, ...) -> (nodes, edges, findings)`; always emit a `File` node; never raise except the contained `OSError/ValueError/RecursionError`.
+- Commits authored `Laraib <lxh417bham@gmail.com>` only (repo-local git config already carries it — do **not** pass `-c user.email=`); no `Co-Authored-By`, no AI attribution. Many small commits; never squash. Push only to `https://github.com/AQ-Labs/cybergraph`.
+
+---
+
+## File Structure
+
+- `src/cybergraph/analysis/firebase_rules.py` (create) — Firebase security-rules analyzer.
+- `src/cybergraph/analysis/supabase_rls.py` (create) — Supabase SQL-migration RLS analyzer.
+- `src/cybergraph/analysis/bucket_policy.py` (create) — standalone S3/GCS bucket-policy analyzer.
+- `src/cybergraph/analysis/collector.py` (modify) — recognize the new config files (scoped helpers).
+- `src/cybergraph/analysis/registry.py` (modify) — dispatch the three analyzers.
+- `src/cybergraph/security/capability.py` (modify) — `CONFIG_GLOBS`; `cloud_configuration` → supported, `covers=CONFIG_GLOBS`.
+- `src/cybergraph/security/coverage.py` (modify) — track `CONFIG_GLOBS` files as verified sources.
+- `src/cybergraph/security/checks.py` (modify) — `_FINDING_RULES` value → set; generic branch matches membership.
+- Tests: `tests/test_firebase_rules.py`, `tests/test_supabase_rls.py`, `tests/test_bucket_policy.py`, `tests/test_config_posture_capability.py` (create); edits to `tests/test_capability.py`, `tests/test_checks.py`, `tests/test_coverage_report.py` (flip `cloud_configuration` NOT_SUPPORTED expectations).
+- `benchmark/mutation_harness.py` (modify) — two seeded config fail-opens.
+- `README.md` (modify) — one line noting config-posture coverage.
+
+---
+
+## Task 1: Firebase rules analyzer
+
+**Files:**
+- Create: `src/cybergraph/analysis/firebase_rules.py`
+- Modify: `src/cybergraph/analysis/collector.py` (recognize `*.rules` and `firebase.json`)
+- Modify: `src/cybergraph/analysis/registry.py` (dispatch)
+- Test: `tests/test_firebase_rules.py` (create)
+
+**Interfaces:**
+- Produces: `analyze_firebase_rules_file(path: Path, repo_root: Path) -> tuple[list[Node], list[Edge], list[Finding]]`. Rule id **`CG-FIREBASE-RULES-OPEN`**, severity `high`, CWE-732.
+- Consumes: `graph.Node/Edge/Finding`, `suppressions.is_inline_suppressed`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_firebase_rules.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from cybergraph.analysis.firebase_rules import analyze_firebase_rules_file
+
+OPEN = """rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{uid} {
+      allow read, write: if true;
+    }
+  }
+}
+"""
+
+GUARDED = """rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{uid} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}
+"""
+
+
+def _write(tmp_path: Path, name: str, text: str) -> Path:
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_open_rule_is_flagged(tmp_path: Path) -> None:
+    p = _write(tmp_path, "firestore.rules", OPEN)
+    nodes, _edges, findings = analyze_firebase_rules_file(p, tmp_path)
+    assert any(n.kind == "File" for n in nodes)
+    assert [f.rule_id for f in findings] == ["CG-FIREBASE-RULES-OPEN"]
+    f = findings[0]
+    assert f.cwe == "CWE-732"
+    assert "if true" in f.evidence
+
+
+def test_guarded_rule_is_clean(tmp_path: Path) -> None:
+    p = _write(tmp_path, "firestore.rules", GUARDED)
+    nodes, _edges, findings = analyze_firebase_rules_file(p, tmp_path)
+    assert findings == []
+    assert any(n.kind == "File" for n in nodes)
+
+
+def test_inline_suppression_respected(tmp_path: Path) -> None:
+    text = OPEN.replace("if true;", "if true; // cybergraph:ignore CG-FIREBASE-RULES-OPEN")
+    p = _write(tmp_path, "firestore.rules", text)
+    _nodes, _edges, findings = analyze_firebase_rules_file(p, tmp_path)
+    assert findings == []
+```
+
+> Note: confirm the exact inline-suppression token by reading `src/cybergraph/suppressions.py` before writing the suppression test; use whatever `is_inline_suppressed` actually recognizes.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/test_firebase_rules.py -v` — Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Implement the analyzer**
+
+Create `src/cybergraph/analysis/firebase_rules.py`:
+
+```python
+"""Firebase security-rules analyzer (firestore.rules / storage.rules).
+
+Regex-based, no dependency. Flags an ``allow`` whose condition is
+unconditionally true -- the classic "open to the whole internet" rule. A rule
+guarded by any real condition (``request.auth != null``, a function call, a
+comparison) produces no finding. Conservative: only a literal-true condition is
+flagged, and the file always yields a File node so the build never crashes.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from cybergraph.graph import Edge, Finding, Node
+from cybergraph.suppressions import is_inline_suppressed
+
+# allow <ops> : if <condition> ;   -- capture the condition up to the semicolon.
+ALLOW_RE = re.compile(
+    r"allow\s+(?P<ops>[a-z, \t]+?)\s*:\s*if\s+(?P<cond>[^;{]+);",
+    re.IGNORECASE,
+)
+# An unconditionally-true condition: `true`, `(true)`, `true == true`, etc.
+_TRUE_RE = re.compile(r"^\(*\s*true\s*\)*$", re.IGNORECASE)
+
+
+def analyze_firebase_rules_file(
+    path: Path, repo_root: Path
+) -> tuple[list[Node], list[Edge], list[Finding]]:
+    source = path.read_text(encoding="utf-8", errors="ignore")
+    lines = source.splitlines()
+    rel = path.relative_to(repo_root).as_posix()
+    nodes: list[Node] = [
+        Node("File", rel, rel, rel, 1, len(lines), {"language": "firebase-rules"})
+    ]
+    findings: list[Finding] = []
+
+    for match in ALLOW_RE.finditer(source):
+        cond = match.group("cond").strip()
+        if not _TRUE_RE.match(cond):
+            continue
+        line_no = source.count("\n", 0, match.start()) + 1
+        if is_inline_suppressed(lines, line_no, "CG-FIREBASE-RULES-OPEN"):
+            continue
+        ops = " ".join(match.group("ops").split())
+        findings.append(
+            Finding(
+                rule_id="CG-FIREBASE-RULES-OPEN",
+                severity="high",
+                message=f"Firebase rule grants `{ops}` to everyone (condition is always true)",
+                file_path=rel,
+                line_start=line_no,
+                cwe="CWE-732",
+                evidence=lines[line_no - 1].strip() if 0 < line_no <= len(lines) else "",
+            )
+        )
+    return nodes, [], findings
+```
+
+- [ ] **Step 4: Recognize the files in the collector**
+
+In `src/cybergraph/analysis/collector.py`, add `".rules"` to `SUPPORTED_SUFFIXES` and `"firebase.json"` to `SUPPORTED_FILENAMES`.
+
+- [ ] **Step 5: Dispatch in the registry**
+
+In `src/cybergraph/analysis/registry.py`: import `analyze_firebase_rules_file`; add a `FIREBASE_SUFFIXES = {".rules"}` and, in `_dispatch`, before the fallback:
+
+```python
+    if suffix in FIREBASE_SUFFIXES or path.name == "firebase.json":
+        return analyze_firebase_rules_file(path, repo_root)
+```
+
+Add `".rules"` to `ANALYZED_SUFFIXES`.
+
+- [ ] **Step 6: Run tests + ruff**
+
+Run: `pytest tests/test_firebase_rules.py -v` — Expected: PASS.
+Run: `ruff check src/cybergraph/analysis/firebase_rules.py src/cybergraph/analysis/collector.py src/cybergraph/analysis/registry.py tests/test_firebase_rules.py` — Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cybergraph/analysis/firebase_rules.py src/cybergraph/analysis/collector.py src/cybergraph/analysis/registry.py tests/test_firebase_rules.py
+git commit -m "feat(analysis): detect open Firebase security rules"
+```
+
+---
+
+## Task 2: Supabase RLS analyzer
+
+**Files:**
+- Create: `src/cybergraph/analysis/supabase_rls.py`
+- Modify: `src/cybergraph/analysis/collector.py` (recognize `*.sql` under `supabase/`)
+- Modify: `src/cybergraph/analysis/registry.py` (dispatch)
+- Test: `tests/test_supabase_rls.py` (create)
+
+**Interfaces:**
+- Produces: `analyze_supabase_rls_file(path, repo_root) -> (nodes, edges, findings)`; rule id **`CG-SUPABASE-RLS-DISABLED`**, severity `high`, CWE-1230.
+- Produces (shared helper in collector, imported by the registry): `is_supabase_sql(path: Path) -> bool` — a `.sql` file with a `supabase` path component.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_supabase_rls.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from cybergraph.analysis.supabase_rls import analyze_supabase_rls_file
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    d = tmp_path / "supabase" / "migrations"
+    d.mkdir(parents=True)
+    p = d / "0001_init.sql"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_disable_rls_is_flagged(tmp_path: Path) -> None:
+    p = _write(tmp_path, "ALTER TABLE public.profiles DISABLE ROW LEVEL SECURITY;\n")
+    _n, _e, findings = analyze_supabase_rls_file(p, tmp_path)
+    assert [f.rule_id for f in findings] == ["CG-SUPABASE-RLS-DISABLED"]
+    assert findings[0].cwe == "CWE-1230"
+
+
+def test_policy_using_true_is_flagged(tmp_path: Path) -> None:
+    text = (
+        "ALTER TABLE t ENABLE ROW LEVEL SECURITY;\n"
+        'CREATE POLICY p ON t FOR SELECT USING (true);\n'
+    )
+    p = _write(tmp_path, text)
+    _n, _e, findings = analyze_supabase_rls_file(p, tmp_path)
+    assert [f.rule_id for f in findings] == ["CG-SUPABASE-RLS-DISABLED"]
+
+
+def test_create_without_enable_is_flagged(tmp_path: Path) -> None:
+    p = _write(tmp_path, "CREATE TABLE public.secrets (id int, val text);\n")
+    _n, _e, findings = analyze_supabase_rls_file(p, tmp_path)
+    assert [f.rule_id for f in findings] == ["CG-SUPABASE-RLS-DISABLED"]
+
+
+def test_create_then_enable_is_clean(tmp_path: Path) -> None:
+    text = (
+        "CREATE TABLE public.secrets (id int, val text);\n"
+        "ALTER TABLE public.secrets ENABLE ROW LEVEL SECURITY;\n"
+    )
+    p = _write(tmp_path, text)
+    _n, _e, findings = analyze_supabase_rls_file(p, tmp_path)
+    assert findings == []
+
+
+def test_file_node_always_present(tmp_path: Path) -> None:
+    p = _write(tmp_path, "-- just a comment\n")
+    nodes, _e, findings = analyze_supabase_rls_file(p, tmp_path)
+    assert any(n.kind == "File" for n in nodes)
+    assert findings == []
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/test_supabase_rls.py -v` — Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Implement the analyzer**
+
+Create `src/cybergraph/analysis/supabase_rls.py`:
+
+```python
+"""Supabase RLS analyzer for SQL migrations.
+
+Row-level security is Supabase's authorization boundary; a table with RLS off
+(or a policy that re-opens it with ``USING (true)``) exposes its rows to the
+public API role. Regex-based, per-file. Three definite signals:
+
+* ``DISABLE ROW LEVEL SECURITY`` -- an explicit switch-off;
+* ``CREATE POLICY ... USING (true)`` -- a policy that grants everyone access;
+* ``CREATE TABLE t`` with no ``ENABLE ROW LEVEL SECURITY`` for ``t`` in the same
+  file -- Supabase migrations conventionally enable RLS in the migration that
+  creates the table, so a create with no same-file enable is the classic
+  "forgot to turn on RLS" bug. Cross-file enable is possible but rare; the
+  same-file scope keeps precision high and the finding is a REVIEW, not a block.
+
+Table identity is compared on the bare table name (schema-qualified or not).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from cybergraph.graph import Edge, Finding, Node
+from cybergraph.suppressions import is_inline_suppressed
+
+DISABLE_RE = re.compile(
+    r"alter\s+table\s+(?:if\s+exists\s+)?(?P<tbl>[\w.\"]+)\s+disable\s+row\s+level\s+security",
+    re.IGNORECASE,
+)
+ENABLE_RE = re.compile(
+    r"alter\s+table\s+(?:if\s+exists\s+)?(?P<tbl>[\w.\"]+)\s+enable\s+row\s+level\s+security",
+    re.IGNORECASE,
+)
+CREATE_TABLE_RE = re.compile(
+    r"create\s+table\s+(?:if\s+not\s+exists\s+)?(?P<tbl>[\w.\"]+)",
+    re.IGNORECASE,
+)
+POLICY_TRUE_RE = re.compile(
+    r"create\s+policy\b[^;]*?\busing\s*\(\s*true\s*\)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _bare(name: str) -> str:
+    return name.replace('"', "").split(".")[-1].lower()
+
+
+def _line_of(source: str, index: int) -> int:
+    return source.count("\n", 0, index) + 1
+
+
+def analyze_supabase_rls_file(
+    path: Path, repo_root: Path
+) -> tuple[list[Node], list[Edge], list[Finding]]:
+    source = path.read_text(encoding="utf-8", errors="ignore")
+    lines = source.splitlines()
+    rel = path.relative_to(repo_root).as_posix()
+    nodes: list[Node] = [Node("File", rel, rel, rel, 1, len(lines), {"language": "sql"})]
+    findings: list[Finding] = []
+
+    def emit(line_no: int, message: str) -> None:
+        if is_inline_suppressed(lines, line_no, "CG-SUPABASE-RLS-DISABLED"):
+            return
+        findings.append(
+            Finding(
+                rule_id="CG-SUPABASE-RLS-DISABLED",
+                severity="high",
+                message=message,
+                file_path=rel,
+                line_start=line_no,
+                cwe="CWE-1230",
+                evidence=lines[line_no - 1].strip() if 0 < line_no <= len(lines) else "",
+            )
+        )
+
+    for m in DISABLE_RE.finditer(source):
+        emit(_line_of(source, m.start()),
+             f"row-level security is disabled on `{_bare(m.group('tbl'))}`")
+    for m in POLICY_TRUE_RE.finditer(source):
+        emit(_line_of(source, m.start()),
+             "a policy grants access to everyone (`USING (true)`)")
+
+    enabled = {_bare(m.group("tbl")) for m in ENABLE_RE.finditer(source)}
+    for m in CREATE_TABLE_RE.finditer(source):
+        tbl = _bare(m.group("tbl"))
+        if tbl not in enabled:
+            emit(_line_of(source, m.start()),
+                 f"table `{tbl}` is created without enabling row-level security")
+
+    return nodes, [], findings
+```
+
+- [ ] **Step 4: Recognize the files in the collector**
+
+In `collector.py`, add and export:
+
+```python
+def is_supabase_sql(path: Path) -> bool:
+    return path.suffix.lower() == ".sql" and any(
+        part.lower() == "supabase" for part in path.parts
+    )
+```
+
+and OR it into `is_supported_source`:
+
+```python
+    return (
+        path.suffix.lower() in SUPPORTED_SUFFIXES
+        or path.name in SUPPORTED_FILENAMES
+        or is_supabase_sql(path)
+    )
+```
+
+- [ ] **Step 5: Dispatch in the registry**
+
+In `registry.py`: `from .supabase_rls import analyze_supabase_rls_file` and `from .collector import is_supabase_sql`; in `_dispatch`, before the fallback:
+
+```python
+    if is_supabase_sql(path):
+        return analyze_supabase_rls_file(path, repo_root)
+```
+
+- [ ] **Step 6: Run tests + ruff**
+
+Run: `pytest tests/test_supabase_rls.py -v` — Expected: PASS.
+Run: `ruff check src/cybergraph/analysis/supabase_rls.py src/cybergraph/analysis/collector.py src/cybergraph/analysis/registry.py tests/test_supabase_rls.py` — Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cybergraph/analysis/supabase_rls.py src/cybergraph/analysis/collector.py src/cybergraph/analysis/registry.py tests/test_supabase_rls.py
+git commit -m "feat(analysis): detect Supabase tables with row-level security off"
+```
+
+---
+
+## Task 3: Bucket-policy analyzer
+
+**Files:**
+- Create: `src/cybergraph/analysis/bucket_policy.py`
+- Modify: `src/cybergraph/analysis/collector.py` (recognize bucket-policy JSON by name)
+- Modify: `src/cybergraph/analysis/registry.py` (dispatch)
+- Test: `tests/test_bucket_policy.py` (create)
+
+**Interfaces:**
+- Produces: `analyze_bucket_policy_file(path, repo_root) -> (nodes, edges, findings)`; rule id **`CG-STORAGE-BUCKET-PUBLIC`**, severity `high`, CWE-732.
+- Produces (shared helper in collector): `is_bucket_policy(path: Path) -> bool`.
+- **Coverage-honesty contract:** on `json.JSONDecodeError` the analyzer does NOT catch — it lets the error propagate to `registry.analyze_source_file`'s per-file containment (`ValueError`), which emits `CG-FILE-UNREADABLE` + a File node → coverage `FAILED` → capability UNKNOWN. A *valid* JSON that is not a policy shape → no finding, bare File node.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_bucket_policy.py`:
+
+```python
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cybergraph.analysis.bucket_policy import analyze_bucket_policy_file
+
+S3_PUBLIC = {
+    "Statement": [
+        {"Effect": "Allow", "Principal": "*", "Action": "s3:GetObject",
+         "Resource": "arn:aws:s3:::b/*"}
+    ]
+}
+S3_SCOPED = {
+    "Statement": [
+        {"Effect": "Allow", "Principal": {"AWS": "arn:aws:iam::1:role/r"},
+         "Action": "s3:GetObject"}
+    ]
+}
+GCS_PUBLIC = {"bindings": [{"role": "roles/storage.objectViewer", "members": ["allUsers"]}]}
+
+
+def _write(tmp_path: Path, obj) -> Path:
+    p = tmp_path / "bucket-policy.json"
+    p.write_text(json.dumps(obj), encoding="utf-8")
+    return p
+
+
+def test_s3_public_principal_is_flagged(tmp_path: Path) -> None:
+    p = _write(tmp_path, S3_PUBLIC)
+    _n, _e, findings = analyze_bucket_policy_file(p, tmp_path)
+    assert [f.rule_id for f in findings] == ["CG-STORAGE-BUCKET-PUBLIC"]
+    assert findings[0].cwe == "CWE-732"
+
+
+def test_s3_scoped_principal_is_clean(tmp_path: Path) -> None:
+    p = _write(tmp_path, S3_SCOPED)
+    _n, _e, findings = analyze_bucket_policy_file(p, tmp_path)
+    assert findings == []
+
+
+def test_gcs_all_users_is_flagged(tmp_path: Path) -> None:
+    p = _write(tmp_path, GCS_PUBLIC)
+    _n, _e, findings = analyze_bucket_policy_file(p, tmp_path)
+    assert [f.rule_id for f in findings] == ["CG-STORAGE-BUCKET-PUBLIC"]
+
+
+def test_non_policy_json_is_clean(tmp_path: Path) -> None:
+    p = _write(tmp_path, {"name": "not a policy", "version": 3})
+    nodes, _e, findings = analyze_bucket_policy_file(p, tmp_path)
+    assert findings == []
+    assert any(n.kind == "File" for n in nodes)
+
+
+def test_malformed_json_propagates_valueerror(tmp_path: Path) -> None:
+    p = tmp_path / "bucket-policy.json"
+    p.write_text("{not json", encoding="utf-8")
+    with pytest.raises(ValueError):  # JSONDecodeError is a ValueError
+        analyze_bucket_policy_file(p, tmp_path)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/test_bucket_policy.py -v` — Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Implement the analyzer**
+
+Create `src/cybergraph/analysis/bucket_policy.py`:
+
+```python
+"""Standalone S3/GCS bucket-policy analyzer (not Terraform -- terraform.py owns HCL).
+
+Parses a JSON policy file and flags a grant of public access:
+
+* S3 bucket policy: a ``Statement`` with ``Effect: Allow`` and a wildcard
+  ``Principal`` (``"*"`` or ``{"AWS": "*"}``);
+* GCS IAM policy: a ``binding`` whose ``members`` include ``allUsers`` or
+  ``allAuthenticatedUsers`` on a storage role.
+
+A valid JSON that is not a policy shape yields no finding (a bare File node).
+Malformed JSON is NOT caught here -- it raises ``JSONDecodeError`` (a
+``ValueError``) so the registry's per-file containment records the file as
+unreadable, which the coverage layer reads as UNKNOWN rather than a clean pass.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cybergraph.graph import Edge, Finding, Node
+from cybergraph.suppressions import is_inline_suppressed
+
+_PUBLIC_MEMBERS = {"allusers", "allauthenticatedusers"}
+
+
+def _is_wildcard_principal(principal: object) -> bool:
+    if principal == "*":
+        return True
+    if isinstance(principal, dict):
+        return any(
+            v == "*" or (isinstance(v, list) and "*" in v) for v in principal.values()
+        )
+    return False
+
+
+def _evidence_line(lines: list[str], needle: str) -> int:
+    for i, line in enumerate(lines, start=1):
+        if needle in line:
+            return i
+    return 1
+
+
+def analyze_bucket_policy_file(
+    path: Path, repo_root: Path
+) -> tuple[list[Node], list[Edge], list[Finding]]:
+    source = path.read_text(encoding="utf-8", errors="ignore")
+    lines = source.splitlines()
+    rel = path.relative_to(repo_root).as_posix()
+    nodes: list[Node] = [Node("File", rel, rel, rel, 1, len(lines), {"language": "json"})]
+    findings: list[Finding] = []
+
+    data = json.loads(source)  # JSONDecodeError propagates -> registry containment
+
+    def emit(line_no: int, message: str) -> None:
+        if is_inline_suppressed(lines, line_no, "CG-STORAGE-BUCKET-PUBLIC"):
+            return
+        findings.append(
+            Finding(
+                rule_id="CG-STORAGE-BUCKET-PUBLIC",
+                severity="high",
+                message=message,
+                file_path=rel,
+                line_start=line_no,
+                cwe="CWE-732",
+                evidence=lines[line_no - 1].strip() if 0 < line_no <= len(lines) else "",
+            )
+        )
+
+    if isinstance(data, dict) and isinstance(data.get("Statement"), list):
+        for stmt in data["Statement"]:
+            if not isinstance(stmt, dict):
+                continue
+            if stmt.get("Effect") == "Allow" and _is_wildcard_principal(stmt.get("Principal")):
+                emit(_evidence_line(lines, "Principal"),
+                     "S3 bucket policy grants access to everyone (Principal \"*\")")
+                break
+
+    if isinstance(data, dict) and isinstance(data.get("bindings"), list):
+        for binding in data["bindings"]:
+            if not isinstance(binding, dict):
+                continue
+            members = binding.get("members", [])
+            if isinstance(members, list) and any(
+                isinstance(m, str) and m.lower() in _PUBLIC_MEMBERS for m in members
+            ):
+                emit(_evidence_line(lines, "allUsers"),
+                     "storage IAM binding grants access to all users")
+                break
+
+    return nodes, [], findings
+```
+
+- [ ] **Step 4: Recognize the files in the collector**
+
+In `collector.py`, add and export:
+
+```python
+def is_bucket_policy(path: Path) -> bool:
+    name = path.name.lower()
+    return name.endswith(".json") and (
+        "bucket-policy" in name or "bucket_policy" in name or name.endswith(".iam.json")
+    )
+```
+
+and OR it into `is_supported_source` (alongside `is_supabase_sql`).
+
+- [ ] **Step 5: Dispatch in the registry**
+
+In `registry.py`: `from .bucket_policy import analyze_bucket_policy_file` and `from .collector import is_bucket_policy`; in `_dispatch`, before the fallback:
+
+```python
+    if is_bucket_policy(path):
+        return analyze_bucket_policy_file(path, repo_root)
+```
+
+- [ ] **Step 6: Run tests + ruff**
+
+Run: `pytest tests/test_bucket_policy.py -v` — Expected: PASS.
+Run: `ruff check src/cybergraph/analysis/bucket_policy.py src/cybergraph/analysis/collector.py src/cybergraph/analysis/registry.py tests/test_bucket_policy.py` — Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cybergraph/analysis/bucket_policy.py src/cybergraph/analysis/collector.py src/cybergraph/analysis/registry.py tests/test_bucket_policy.py
+git commit -m "feat(analysis): detect public S3/GCS bucket policies"
+```
+
+---
+
+## Task 4: Activate the `cloud_configuration` capability
+
+**Files:**
+- Modify: `src/cybergraph/security/capability.py`
+- Modify: `src/cybergraph/security/coverage.py`
+- Modify: `src/cybergraph/security/checks.py`
+- Modify: `tests/test_capability.py`, `tests/test_checks.py`, `tests/test_coverage_report.py` (flip NOT_SUPPORTED expectations)
+- Test: `tests/test_config_posture_capability.py` (create)
+
+**Interfaces:**
+- Consumes: the three rule ids from Tasks 1–3 and Terraform's existing `CG-IAC-*`.
+- Produces: `CONFIG_GLOBS` in `capability.py`; `cloud_configuration` with `supported=True` and `covers=CONFIG_GLOBS`; `_FINDING_RULES["cloud_configuration"]` as a set; a generic `_evaluate` branch that matches rule-id membership.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_config_posture_capability.py`:
+
+```python
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from cybergraph.security.capability import (
+    FAIL, NOT_APPLICABLE, PASS, UNKNOWN, CAPABILITIES,
+)
+from cybergraph.security.check import check_change
+from cybergraph.security.verdict import STATE_ACCEPT, STATE_REVIEW
+
+
+def _cap(cid: str):
+    return next(c for c in CAPABILITIES if c.id == cid)
+
+
+def test_cloud_configuration_is_supported():
+    assert _cap("cloud_configuration").supported is True
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "t@e.com"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "t"], check=True)
+    (repo / "README.md").write_text("# x\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "base"], check=True)
+    return repo
+
+
+def test_disabling_rls_makes_check_review(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    d = repo / "supabase" / "migrations"
+    d.mkdir(parents=True)
+    (d / "0002_open.sql").write_text(
+        "ALTER TABLE public.profiles DISABLE ROW LEVEL SECURITY;\n", encoding="utf-8"
+    )
+    verdict = check_change(repo, mode="worktree")
+    assert verdict.state == STATE_REVIEW
+    assert any("cloud_configuration" == c.capability_id and c.status == FAIL
+               for c in verdict.checks)
+
+
+def test_clean_readme_change_accepts(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    (repo / "README.md").write_text("# x\nmore\n", encoding="utf-8")
+    verdict = check_change(repo, mode="worktree")
+    # cloud_configuration is NOT_APPLICABLE (no config file changed); overall may
+    # still accept if nothing else reviews.
+    cc = next(c for c in verdict.checks if c.capability_id == "cloud_configuration")
+    assert cc.status == NOT_APPLICABLE
+```
+
+> Note: confirm `check_change`'s signature and that `Verdict.checks` carries `CheckResult`s with `.capability_id`/`.status` before finalizing asserts (read `security/check.py` and `security/verdict.py`). A README-only change may make other capabilities NOT_APPLICABLE too; assert only on `cloud_configuration` and the overall state as written.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/test_config_posture_capability.py -v` — Expected: FAIL (`cloud_configuration` not supported / no FAIL).
+
+- [ ] **Step 3: Add `CONFIG_GLOBS` and activate the capability**
+
+In `capability.py`, after the `*_GLOBS` definitions add:
+
+```python
+# Declarative config surfaces with a Phase-2 posture analyzer. Kept narrow so a
+# changed config file that is analyzed-and-clean can PASS and an unparsed one
+# reads UNKNOWN -- broad globs (e.g. every *.yaml) would make unrelated changes
+# review. Single source of truth for the capability's `covers` and coverage.
+CONFIG_GLOBS = (
+    "*.tf", "*.tfvars",
+    "*.rules", "firebase.json",
+    "supabase/*.sql",
+    "*bucket-policy*.json", "*bucket_policy*.json", "*.iam.json",
+)
+```
+
+Change the `cloud_configuration` entry from
+`Capability("cloud_configuration", "Cloud and database configuration", INFRA_GLOBS, False)`
+to:
+
+```python
+    Capability("cloud_configuration",
+               "Cloud and database configuration", CONFIG_GLOBS, True),
+```
+
+> `fnmatch("supabase/migrations/0001.sql", "supabase/*.sql")` is True (`*` spans `/` in fnmatch), so nested migrations match. Verify with a one-off `python -c` if unsure. Leave `INFRA_GLOBS` defined if other code imports it; confirm with a grep and remove only if unused.
+
+- [ ] **Step 4: Track config files in coverage**
+
+In `coverage.py`, import `CONFIG_GLOBS` and include it so config files are treated as verified sources:
+
+```python
+from cybergraph.security.capability import CONFIG_GLOBS, SOURCE_GLOBS, VERIFIED_GLOBS
+```
+
+Change the `sources` filter to `SOURCE_GLOBS + CONFIG_GLOBS`, and the UNSUPPORTED gate from
+`elif not any(fnmatch(file, pattern) for pattern in VERIFIED_GLOBS):`
+to
+`elif not any(fnmatch(file, pattern) for pattern in VERIFIED_GLOBS + CONFIG_GLOBS):`
+so a config file with a File node is `ANALYZED`, an unreadable one is `FAILED`, and neither is mislabeled `UNSUPPORTED`.
+
+- [ ] **Step 5: Make `_FINDING_RULES` a set and match membership**
+
+In `checks.py`, change the `cloud_configuration` mapping (add the entry) so `_FINDING_RULES` reads:
+
+```python
+_FINDING_RULES = {
+    "sql_construction": "CG-SQL-EXEC",
+    "command_execution": "CG-CMD-EXEC",
+    "code_execution": "CG-CODE-EXEC",
+    "deserialization": "CG-DESERIALIZE",
+    "path_access": "CG-PATH-TRAVERSAL",
+    "cloud_configuration": {
+        "CG-FIREBASE-RULES-OPEN", "CG-SUPABASE-RLS-DISABLED", "CG-STORAGE-BUCKET-PUBLIC",
+        "CG-IAC-PUBLIC-BUCKET", "CG-IAC-WILDCARD-IAM", "CG-IAC-OPEN-INGRESS",
+        "CG-IAC-HARDCODED-SECRET",
+    },
+}
+```
+
+In the generic branch of `_evaluate` (currently `checks.py:194-218`), normalize to a set and match membership:
+
+```python
+    rule = _FINDING_RULES.get(capability_id)
+    if rule is None:  # pragma: no cover - guarded by test_every_capability_is_evaluated
+        raise AssertionError(f"capability {capability_id} has no evaluator")
+    rules = {rule} if isinstance(rule, str) else set(rule)
+
+    relevant_files = _capability_files(capability_id, changed_files)
+    missing, failed, analyzed = _coverage_summary(relevant_files, coverage)
+    if failed:
+        return CheckResult(capability_id, UNKNOWN, failed[0].reason, len(failed))
+    if missing:
+        return CheckResult(
+            capability_id, UNKNOWN,
+            f"`{missing[0]}` changed but has no analysis record", len(missing),
+        )
+    confirmed = [f for f in findings if f.rule_id in rules]
+    unverified = [f for f in findings if f.rule_id in {f"{r}-UNVERIFIED" for r in rules}]
+    if confirmed:
+        return CheckResult(capability_id, FAIL, confirmed[0].message, len(confirmed))
+    if unverified:
+        return CheckResult(capability_id, UNKNOWN, unverified[0].message, len(unverified))
+    if not analyzed:
+        return CheckResult(
+            capability_id, UNKNOWN,
+            "no changed file in this capability's scope was analyzed",
+        )
+    return CheckResult(capability_id, PASS, evidence_count=len(analyzed))
+```
+
+The single-rule capabilities are unchanged in behavior (`{rule}` membership == equality).
+
+- [ ] **Step 6: Update the tests that assumed `cloud_configuration` was NOT_SUPPORTED**
+
+Run `pytest tests/test_capability.py tests/test_checks.py tests/test_coverage_report.py -v` and update every assertion that expected `cloud_configuration` to be `NOT_SUPPORTED` / unsupported to its new supported behavior. Read each failing assertion and change the *expectation*, never the production code, to match the intended activation. (Search: `grep -rn "cloud_configuration\|NOT_SUPPORTED" tests/`.) Do not weaken any unrelated assertion.
+
+- [ ] **Step 7: Run tests + ruff**
+
+Run: `pytest tests/test_config_posture_capability.py tests/test_capability.py tests/test_checks.py tests/test_coverage_report.py -v` — Expected: PASS.
+Run: `ruff check src/cybergraph/security/capability.py src/cybergraph/security/coverage.py src/cybergraph/security/checks.py tests/test_config_posture_capability.py` — Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/cybergraph/security/capability.py src/cybergraph/security/coverage.py src/cybergraph/security/checks.py tests/
+git commit -m "feat(verdict): activate cloud_configuration -- config posture regressions review"
+```
+
+---
+
+## Task 5: Mutation harness + docs + full verification
+
+**Files:**
+- Modify: `benchmark/mutation_harness.py` (two seeded fail-opens)
+- Modify: `README.md` (one line)
+- Verification: full suite, ruff, harness, precision/eval.
+
+**Interfaces:**
+- Consumes: the finished analyzers (Tasks 1–3) and the wiring (Task 4).
+
+- [ ] **Step 1: Add the mutations**
+
+Append two `Mutation` entries to `MUTATIONS` in `benchmark/mutation_harness.py`. Match every `old` string to the committed source verbatim (open the files and copy exactly; fix the `old` string if it differs — never edit the source to fit the mutation).
+
+Mutation A — a posture finding read as PASS. Target the membership match in `checks.py`:
+- `old` = `    confirmed = [f for f in findings if f.rule_id in rules]`
+- `new` = `    confirmed = []`
+- `tests` = `("tests/test_config_posture_capability.py::test_disabling_rls_makes_check_review",)`
+- id `D9-config-posture-finding-ignored`, disaster `D9`, note "a config posture finding must FAIL the capability, not be dropped".
+
+Mutation B — an unparsed config read as PASS instead of UNKNOWN. Target the bucket analyzer's propagation:
+- `old` = `    data = json.loads(source)  # JSONDecodeError propagates -> registry containment`
+- `new` = `    try:\n        data = json.loads(source)\n    except ValueError:\n        return nodes, [], findings`
+- `tests` = a new guard test (add it in Step 2) that a malformed in-scope bucket-policy JSON makes `cybergraph check` report `cloud_configuration` UNKNOWN, not PASS.
+- id `D9-unparsed-config-reads-clean`, disaster `D9`, note "an unparseable config must read UNKNOWN, never a clean pass".
+
+> If the multi-line `new` for Mutation B is awkward in the harness's single-edit model, instead target a one-line equivalent that still reproduces the swallow (e.g. wrap the assignment so a decode error yields empty findings). The invariant under test is what matters: malformed in-scope config → UNKNOWN.
+
+- [ ] **Step 2: Add the coverage-honesty guard test**
+
+Append to `tests/test_config_posture_capability.py`:
+
+```python
+def test_malformed_bucket_policy_reads_unknown(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    (repo / "bucket-policy.json").write_text("{not json", encoding="utf-8")
+    verdict = check_change(repo, mode="worktree")
+    cc = next(c for c in verdict.checks if c.capability_id == "cloud_configuration")
+    assert cc.status == UNKNOWN  # never a silent PASS on something we could not parse
+```
+
+Run: `pytest tests/test_config_posture_capability.py::test_malformed_bucket_policy_reads_unknown -v` — Expected: PASS (proves the propagation path end-to-end).
+
+- [ ] **Step 3: Run the harness**
+
+Run: `python benchmark/mutation_harness.py` — Expected: every mutation CAUGHT, including the two new ones. (Use `--only <id>` to iterate if supported.)
+
+- [ ] **Step 4: Document in the README**
+
+Add one line to the analyzer/coverage list noting config-posture coverage:
+
+```markdown
+- **Config posture** — open Firebase security rules, Supabase tables with row-level
+  security off, and public S3/GCS bucket policies. A change that weakens one is a REVIEW.
+```
+
+- [ ] **Step 5: Full verification**
+
+Run: `pytest -q` — Expected: all pass (prior count + the new analyzer/capability tests, minus none).
+Run: `ruff check .` — Expected: no new errors beyond the repo's pre-existing baseline (the deliberately-vulnerable `benchmark/` fixtures and the one pre-existing `mutation_harness.py:381` E501 exist on `main`; introduce none in the files this branch touches).
+Run: `python benchmark/mutation_harness.py` — Expected: every mutation CAUGHT.
+Run: `python benchmark/run_precision.py` and `python benchmark/run_eval.py` — Expected: unchanged (these exercise the Python corpus, untouched here).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add benchmark/mutation_harness.py README.md tests/test_config_posture_capability.py
+git commit -m "test(config): seed config-posture fail-open mutations; document coverage"
+```
+
+---
+
+## Notes for the executor
+
+- **Precision is the product's cardinal value.** If a detection is ambiguous, prefer no finding over a false one; document the recall gap rather than risk a false alarm.
+- Confirm dataclass field/constructor names (`Finding`, `Node`, `CheckResult`, `Verdict`) and the exact inline-suppression token against the source before running each task's tests; adapt the *test* to the real names, never the reverse.
+- The three analyzer tasks each touch `collector.py` and `registry.py`; they are dispatched sequentially (one implementer at a time), so there is no conflict, but each task must leave those two files ruff-clean and not disturb the other analyzers' clauses.
+- Do NOT add a YAML/HCL/SQL parser dependency, a new CLI command, CORS detection, or the Next.js `client_secret_boundary` — those are explicitly out of scope (slice 3).

--- a/docs/superpowers/specs/2026-08-10-config-posture-design.md
+++ b/docs/superpowers/specs/2026-08-10-config-posture-design.md
@@ -1,0 +1,216 @@
+# Config Posture (Declarative Trio) — Design (Phase 2, slice 2)
+
+**Status:** approved for planning
+**Slice:** the parent plan's out-of-scope row "Config posture (Supabase RLS, Firebase rules,
+Next.js boundary, CORS, buckets)" (Phase 3 there; pulled forward as Phase-2 slice 2) — the
+*declarative-config* subset only.
+**Predecessors:** the 20-task verdict-core plan and Phase-2 slice 1 (client hooks), both merged
+to `main`. The capability model (`security/capability.py`), the coverage machinery
+(`security/coverage.py`/`checks.py`), the analyzer registry (`analysis/registry.py`), the
+Terraform analyzer (`analysis/terraform.py`), and `cybergraph check`/the hooks all exist.
+
+## The sentence this slice is judged against
+
+> CyberGraph can read the three declarative config surfaces where a single line silently
+> exposes everything — a Firebase rule opened to the world, a table with row-level security
+> switched off, a storage bucket made public — and turn a change that weakens one into an
+> earned REVIEW at the accept-the-diff moment, never a silent ACCEPT, and never a false alarm
+> on a config it could not actually parse.
+
+## Why this is the right slice
+
+- These are the roadmap's "most common real failure modes": an open Firestore rule or a table
+  with RLS off exposes an entire database; a public bucket leaks whatever it holds. They cause
+  real breaches far more often than the subtle code-level flaws the graph already models.
+- It makes the client hooks shipped in slice 1 *pay off on config*: because a
+  `secure_configuration` regression now reaches the verdict, `cybergraph check` — and therefore
+  the Stop hook and the pre-commit hook — flag "you just disabled RLS" at the moment the change
+  is accepted, not in a later audit.
+- The capability already exists as a declared-but-absent placeholder: `cloud_configuration`
+  (`capability.py:71`, `supported=False`). This slice largely *activates* scaffolding the
+  design deliberately left in place, rather than inventing a new subsystem.
+
+## Decisions already made (do not re-litigate in planning)
+
+1. **Declarative trio only.** Firebase rules, Supabase RLS, and public storage buckets — the
+   three that live in dedicated config/migration files. CORS and the Next.js client/server
+   boundary (the `client_secret_boundary` capability) stay out; they live in code files and are
+   a different analysis shape (slice 3).
+2. **Detection + verdict, not detection alone.** The analyzers emit findings AND the
+   `cloud_configuration` capability consumes them, so a posture regression on a changed config
+   file returns REVIEW from `cybergraph check`. (A findings-only surface would leave the hooks
+   silent on config — the opposite of the point.)
+3. **Fold in Terraform.** The activated capability's rule-set includes the Terraform analyzer's
+   existing `CG-IAC-*` findings as well as the new trio, so a Terraform change that opens a
+   bucket / adds wildcard IAM / opens ingress *also* produces REVIEW. The label is "Cloud and
+   database configuration"; it would be incoherent for a config-file bucket to review while an
+   identical HCL bucket does not. This changes verdict behavior for Terraform-only changes and
+   updates the tests that assert `cloud_configuration` is `NOT_SUPPORTED`.
+
+## Architecture — three analyzers, one activated capability
+
+```
+src/cybergraph/analysis/firebase_rules.py  (create)  firestore.rules / storage.rules / firebase.json
+src/cybergraph/analysis/supabase_rls.py    (create)  Supabase SQL migrations (RLS on/off)
+src/cybergraph/analysis/bucket_policy.py   (create)  standalone S3/GCS bucket-policy / IAM JSON
+src/cybergraph/analysis/registry.py        (modify)  dispatch the three by name/suffix/path
+src/cybergraph/analysis/collector.py       (modify)  recognise the new config files (scoped)
+src/cybergraph/security/capability.py      (modify)  cloud_configuration -> supported=True; covers globs
+src/cybergraph/security/checks.py          (modify)  _FINDING_RULES value becomes a set; generic branch matches any
+```
+
+Each analyzer follows the `terraform.py` contract exactly: it returns
+`(nodes, edges, findings)`; it is regex / brace / `json`-parse based with **no new
+dependency**; it is conservative — an unrecognised or malformed file still yields a valid
+`File` node so the build never crashes (an unreadable file is reported, never silently
+skipped); and every finding carries a stable `rule_id`, a `severity`, a CWE, and a **verbatim
+evidence line**, and honors `suppressions.is_inline_suppressed`.
+
+### The three checks
+
+- **Firebase rules — `CG-FIREBASE-RULES-OPEN` (CWE-732).** In `firestore.rules` /
+  `storage.rules` (the Firebase security-rules DSL) and the `rules` references in
+  `firebase.json`: a `match` block whose `allow read`, `allow write`, or `allow read, write`
+  resolves to `if true` (or a condition that is unconditionally true). A rule guarded by
+  `request.auth != null` or any real condition is secure and produces no finding.
+- **Supabase RLS — `CG-SUPABASE-RLS-DISABLED` (CWE-1230).** In Supabase SQL migrations: an
+  explicit `ALTER TABLE <t> DISABLE ROW LEVEL SECURITY`; a `CREATE TABLE` in the migration set
+  with no corresponding `ENABLE ROW LEVEL SECURITY` anywhere in scope; or a `CREATE POLICY …
+  USING (true)` that re-opens a table to everyone. RLS enabled with a real `USING`/`WITH CHECK`
+  predicate is secure.
+- **Public buckets — `CG-STORAGE-BUCKET-PUBLIC` (CWE-732).** In standalone bucket-policy / IAM
+  config (NOT Terraform — `terraform.py` owns HCL): an S3 bucket-policy JSON `Statement` with
+  `"Effect":"Allow"`, `"Principal":"*"` (or `{"AWS":"*"}`), and a public action
+  (`s3:GetObject`/`s3:*`/…); or a GCS IAM binding granting a storage role to `allUsers` /
+  `allAuthenticatedUsers`.
+
+### File matching is scoped, never broad
+
+`.sql` and `.json` appear all over a repo; parsing every one as a config surface would be both
+slow and false-positive-prone. The collector recognises these files **only** by path/name
+heuristics, handled in `registry._dispatch` and `collector.is_supported_source`:
+
+- `firestore.rules`, `storage.rules`, any `*.rules` → firebase analyzer; `firebase.json` (by
+  name) → firebase analyzer.
+- `*.sql` **only** under a `supabase/` path component (Supabase's migration convention) →
+  supabase analyzer. A stray application `*.sql` elsewhere is not treated as a migration.
+- bucket-policy files by name convention (e.g. `*bucket-policy*.json`, `*.iam.json`, or a
+  `gcs`/`s3` policy path) → bucket analyzer. When a JSON file's *shape* is ambiguous the
+  analyzer inspects content (an S3 `Statement`/`Principal` shape, or a GCS `bindings`/`members`
+  shape) and emits nothing — plus a plain `File` node — when it does not match, so a random
+  JSON never yields a spurious finding.
+
+The exact glob/name/path predicates are pinned in the plan; the principle is: **recognise
+narrowly, fall back to a bare File node, and never let a broad extension pull unrelated files
+into config analysis.**
+
+## Verdict integration — activating `cloud_configuration`
+
+- `capability.py`: `cloud_configuration` → `supported=True`. Its `covers` globs extend
+  `INFRA_GLOBS` to include the trio's surfaces: add `*.rules`, `firebase.json` (already
+  present), and the Supabase migration path. (`supabase/*` is present; confirm `fnmatch`
+  matches nested migration paths and widen to `supabase/**` semantics via an explicit
+  `supabase/` component test if needed — pinned in the plan.)
+- `checks.py`: `_FINDING_RULES["cloud_configuration"]` becomes a **set** —
+  `{CG-FIREBASE-RULES-OPEN, CG-SUPABASE-RLS-DISABLED, CG-STORAGE-BUCKET-PUBLIC,
+  CG-IAC-PUBLIC-BUCKET, CG-IAC-WILDCARD-IAM, CG-IAC-OPEN-INGRESS, CG-IAC-HARDCODED-SECRET}`.
+  The generic evaluator branch (`checks.py:194+`) currently does
+  `rule = _FINDING_RULES.get(id)` then `confirmed = [f for f in findings if f.rule_id == rule]`;
+  it changes to treat the value as a set of rule ids and match membership (`f.rule_id in rules`,
+  with the `-UNVERIFIED` suffix handled the same way). Capabilities that map to a single rule
+  keep working — a one-element set, or a small normalisation, whichever keeps the other
+  capabilities' evaluation byte-identical.
+- Five-state result (unchanged machinery, via `_coverage_summary`):
+  - **FAIL** — a changed, in-scope config file carries a finding whose `rule_id` is in the set.
+  - **UNKNOWN** — a changed in-scope config file has a failed/missing coverage record (we could
+    not parse what changed; it is never assumed safe).
+  - **NOT_APPLICABLE** — no config file in the capability's scope changed.
+  - **PASS** — changed in-scope config files were analyzed and clean (positive evidence; an
+    empty coverage set is not a PASS).
+
+## Coverage honesty
+
+The three analyzers must produce coverage records the same way the code analyzers do, so a
+changed config file that could not be parsed becomes **UNKNOWN**, not a silent PASS. This is
+the single most important correctness property of the slice and gets an explicit test and a
+seeded mutation. If the coverage pipeline keys on analyzer participation, the new analyzers
+inherit it by registering; the plan verifies the record actually appears for a `firestore.rules`
+/ Supabase `.sql` / bucket-policy file.
+
+## Surfaces
+
+No new command. Findings flow through the existing pipelines automatically:
+`cybergraph sarif` (new rule ids as first-class results — note the CyberGraph self-scan SARIF
+filter only drops `*-SINK-CALL`, so these are unaffected), the HTML report, `cybergraph review`
+(the security delta), and now `cybergraph check` / the client hooks (REVIEW on a posture
+regression). `cybergraph coverage` and `cybergraph policy` are untouched.
+
+## Error handling
+
+- A malformed or unparseable config file → a `File` node and, where the file is clearly in
+  scope but could not be read, the existing `CG-FILE-UNREADABLE` info finding; the capability
+  reads it as UNKNOWN, never PASS. Parsing never raises to the caller (contained by
+  `registry.analyze_source_file`).
+- A JSON file whose shape does not match S3/GCS policy → no finding, bare `File` node (not a
+  false positive, not an error).
+- A `.rules` / Supabase `.sql` that parses but declares nothing insecure → no finding; if it is
+  a changed in-scope file, it contributes positive PASS evidence.
+
+## Testing
+
+- **Per-analyzer units:** open rule → finding (correct rule id, CWE, evidence line); secure rule
+  → no finding; unparseable/ambiguous file → `File` node only, no spurious finding; inline
+  suppression respected. For Supabase: disable-RLS, create-without-enable, and `USING (true)`
+  each caught; enable-with-real-predicate clean. For buckets: `Principal:"*"` and `allUsers`
+  caught; a scoped principal clean; a non-policy JSON silent.
+- **Capability five-state** (`test_checks.py` / `test_capability.py`): FAIL on a changed config
+  file with a posture finding; UNKNOWN on a changed-but-unparsed config file; NOT_APPLICABLE on
+  a README-only change; PASS on a changed-and-clean config file. Plus the Terraform fold-in:
+  a changed `.tf` with `CG-IAC-PUBLIC-BUCKET` now yields FAIL for `cloud_configuration`.
+- **Updated existing tests:** every test asserting `cloud_configuration` is `NOT_SUPPORTED`
+  flips to its new supported behavior (this is expected, not a regression).
+- **End-to-end:** `cybergraph check` on a diff that disables RLS (or opens a Firebase rule)
+  returns REVIEW with the finding as the reason; a clean config change ACCEPTs.
+- **Mutation harness** (`benchmark/mutation_harness.py`): two seeded fail-opens, each red under
+  its guard test — (a) a posture finding that the capability reads as PASS (e.g. the rule-set
+  membership test inverted), and (b) an unparsed/failed-coverage config file that reads PASS
+  instead of UNKNOWN.
+- Full suite green; ruff clean on touched files; `run_precision.py` and `run_eval.py` unchanged
+  (they exercise the Python corpus, which this slice does not touch).
+
+## Global constraints (inherited, unchanged)
+
+- Python 3.10–3.13. **Zero runtime dependencies** (`dependencies = []`); standard library only
+  (`re`, `json`, `pathlib`). No HCL/YAML/SQL parser dependency — regex/brace/`json` like the
+  existing lightweight analyzers.
+- Ruff line-length 100; `from __future__ import annotations` first line of every new file.
+- No network; no API keys on any default path.
+- Commits authored `Laraib <lxh417bham@gmail.com>` only — never `azizur@sirio-strategies.com`,
+  no `Co-Authored-By`, no AI attribution. Many small commits; never squash a PR. Push only to
+  `https://github.com/AQ-Labs/cybergraph`.
+
+## Roadmap alignment — what this does NOT touch
+
+Builds the declarative trio and activates `cloud_configuration`. Deliberately excluded: CORS
+detection and the Next.js `client_secret_boundary` (slice 3 — code-file analysis); the
+non-Python verdict upgrade; any new CLI command; the `secret_server_only` policy rule; the
+`BLOCK` verdict state (`--strict` on the existing REVIEW remains the only gate). `require_authz`
+and the typed authorization ontology remain future work.
+
+## Success criteria
+
+1. `firestore.rules` / `storage.rules` with `allow …: if true` → `CG-FIREBASE-RULES-OPEN`; a
+   guarded rule is clean.
+2. A Supabase migration that disables RLS, creates a table without enabling it, or opens it with
+   `USING (true)` → `CG-SUPABASE-RLS-DISABLED`; RLS with a real predicate is clean.
+3. A standalone S3/GCS policy granting public/`allUsers` access → `CG-STORAGE-BUCKET-PUBLIC`; a
+   scoped policy and a non-policy JSON are clean.
+4. Config files are recognised **narrowly** (no unrelated `.sql`/`.json` pulled in); an
+   unparseable in-scope config reads UNKNOWN, never PASS.
+5. `cloud_configuration` is `supported=True`, consumes the trio's + Terraform's `CG-IAC-*` rule
+   ids, and returns FAIL→REVIEW on a changed config file that weakens posture, PASS on
+   analyzed-clean, NOT_APPLICABLE off-scope, UNKNOWN on unparsed.
+6. `cybergraph check` returns REVIEW on a diff that disables RLS / opens a rule / makes a bucket
+   public (verified end-to-end, so the client hooks catch it).
+7. Full suite green; ruff clean; the mutation harness catches both seeded config fail-opens;
+   `run_precision.py` and `run_eval.py` unchanged.

--- a/src/cybergraph/analysis/bucket_policy.py
+++ b/src/cybergraph/analysis/bucket_policy.py
@@ -1,0 +1,91 @@
+"""Standalone S3/GCS bucket-policy analyzer (not Terraform -- terraform.py owns HCL).
+
+Parses a JSON policy file and flags a grant of public access:
+
+* S3 bucket policy: a ``Statement`` with ``Effect: Allow`` and a wildcard
+  ``Principal`` (``"*"`` or ``{"AWS": "*"}``);
+* GCS IAM policy: a ``binding`` whose ``members`` include ``allUsers`` or
+  ``allAuthenticatedUsers`` on a storage role.
+
+A valid JSON that is not a policy shape yields no finding (a bare File node).
+Malformed JSON is NOT caught here -- it raises ``JSONDecodeError`` (a
+``ValueError``) so the registry's per-file containment records the file as
+unreadable, which the coverage layer reads as UNKNOWN rather than a clean pass.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from cybergraph.graph import Edge, Finding, Node
+from cybergraph.suppressions import is_inline_suppressed
+
+_PUBLIC_MEMBERS = {"allusers", "allauthenticatedusers"}
+
+
+def _is_wildcard_principal(principal: object) -> bool:
+    if principal == "*":
+        return True
+    if isinstance(principal, dict):
+        return any(
+            v == "*" or (isinstance(v, list) and "*" in v) for v in principal.values()
+        )
+    return False
+
+
+def _evidence_line(lines: list[str], needle: str) -> int:
+    for i, line in enumerate(lines, start=1):
+        if needle in line:
+            return i
+    return 1
+
+
+def analyze_bucket_policy_file(
+    path: Path, repo_root: Path
+) -> tuple[list[Node], list[Edge], list[Finding]]:
+    source = path.read_text(encoding="utf-8", errors="ignore")
+    lines = source.splitlines()
+    rel = path.relative_to(repo_root).as_posix()
+    nodes: list[Node] = [Node("File", rel, rel, rel, 1, len(lines), {"language": "json"})]
+    findings: list[Finding] = []
+
+    data = json.loads(source)  # JSONDecodeError propagates -> registry containment
+
+    def emit(line_no: int, message: str) -> None:
+        if is_inline_suppressed(lines, line_no, "CG-STORAGE-BUCKET-PUBLIC"):
+            return
+        findings.append(
+            Finding(
+                rule_id="CG-STORAGE-BUCKET-PUBLIC",
+                severity="high",
+                message=message,
+                file_path=rel,
+                line_start=line_no,
+                cwe="CWE-732",
+                evidence=lines[line_no - 1].strip() if 0 < line_no <= len(lines) else "",
+            )
+        )
+
+    if isinstance(data, dict) and isinstance(data.get("Statement"), list):
+        for stmt in data["Statement"]:
+            if not isinstance(stmt, dict):
+                continue
+            if stmt.get("Effect") == "Allow" and _is_wildcard_principal(stmt.get("Principal")):
+                emit(_evidence_line(lines, "Principal"),
+                     "S3 bucket policy grants access to everyone (Principal \"*\")")
+                break
+
+    if isinstance(data, dict) and isinstance(data.get("bindings"), list):
+        for binding in data["bindings"]:
+            if not isinstance(binding, dict):
+                continue
+            members = binding.get("members", [])
+            if isinstance(members, list) and any(
+                isinstance(m, str) and m.lower() in _PUBLIC_MEMBERS for m in members
+            ):
+                emit(_evidence_line(lines, "allUsers"),
+                     "storage IAM binding grants access to all users")
+                break
+
+    return nodes, [], findings

--- a/src/cybergraph/analysis/collector.py
+++ b/src/cybergraph/analysis/collector.py
@@ -32,8 +32,15 @@ SUPPORTED_SUFFIXES = {
     ".php",
     ".tf",
     ".dockerfile",
+    ".rules",
 }
-SUPPORTED_FILENAMES = {"package.json", "requirements.txt", "pyproject.toml", "Dockerfile"}
+SUPPORTED_FILENAMES = {
+    "package.json",
+    "requirements.txt",
+    "pyproject.toml",
+    "Dockerfile",
+    "firebase.json",
+}
 
 
 def is_ignored_path(rel_path: str, ignored_paths: tuple[str, ...] = ()) -> bool:

--- a/src/cybergraph/analysis/collector.py
+++ b/src/cybergraph/analysis/collector.py
@@ -67,12 +67,20 @@ def is_supabase_sql(path: Path) -> bool:
     )
 
 
+def is_bucket_policy(path: Path) -> bool:
+    name = path.name.lower()
+    return name.endswith(".json") and (
+        "bucket-policy" in name or "bucket_policy" in name or name.endswith(".iam.json")
+    )
+
+
 def is_supported_source(path: Path) -> bool:
     """Whether the analyzers would read this file at all, ignoring config."""
     return (
         path.suffix.lower() in SUPPORTED_SUFFIXES
         or path.name in SUPPORTED_FILENAMES
         or is_supabase_sql(path)
+        or is_bucket_policy(path)
     )
 
 

--- a/src/cybergraph/analysis/collector.py
+++ b/src/cybergraph/analysis/collector.py
@@ -61,9 +61,19 @@ def is_ignored_path(rel_path: str, ignored_paths: tuple[str, ...] = ()) -> bool:
     return False
 
 
+def is_supabase_sql(path: Path) -> bool:
+    return path.suffix.lower() == ".sql" and any(
+        part.lower() == "supabase" for part in path.parts
+    )
+
+
 def is_supported_source(path: Path) -> bool:
     """Whether the analyzers would read this file at all, ignoring config."""
-    return path.suffix.lower() in SUPPORTED_SUFFIXES or path.name in SUPPORTED_FILENAMES
+    return (
+        path.suffix.lower() in SUPPORTED_SUFFIXES
+        or path.name in SUPPORTED_FILENAMES
+        or is_supabase_sql(path)
+    )
 
 
 def iter_source_files(repo_root: Path, ignored_paths: tuple[str, ...] = ()) -> list[Path]:

--- a/src/cybergraph/analysis/firebase_rules.py
+++ b/src/cybergraph/analysis/firebase_rules.py
@@ -1,0 +1,57 @@
+"""Firebase security-rules analyzer (firestore.rules / storage.rules).
+
+Regex-based, no dependency. Flags an ``allow`` whose condition is
+unconditionally true -- the classic "open to the whole internet" rule. A rule
+guarded by any real condition (``request.auth != null``, a function call, a
+comparison) produces no finding. Conservative: only a literal-true condition is
+flagged, and the file always yields a File node so the build never crashes.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from cybergraph.graph import Edge, Finding, Node
+from cybergraph.suppressions import is_inline_suppressed
+
+# allow <ops> : if <condition> ;   -- capture the condition up to the semicolon.
+ALLOW_RE = re.compile(
+    r"allow\s+(?P<ops>[a-z, \t]+?)\s*:\s*if\s+(?P<cond>[^;{]+);",
+    re.IGNORECASE,
+)
+# An unconditionally-true condition: `true`, `(true)`, `true == true`, etc.
+_TRUE_RE = re.compile(r"^\(*\s*true\s*\)*$", re.IGNORECASE)
+
+
+def analyze_firebase_rules_file(
+    path: Path, repo_root: Path
+) -> tuple[list[Node], list[Edge], list[Finding]]:
+    source = path.read_text(encoding="utf-8", errors="ignore")
+    lines = source.splitlines()
+    rel = path.relative_to(repo_root).as_posix()
+    nodes: list[Node] = [
+        Node("File", rel, rel, rel, 1, len(lines), {"language": "firebase-rules"})
+    ]
+    findings: list[Finding] = []
+
+    for match in ALLOW_RE.finditer(source):
+        cond = match.group("cond").strip()
+        if not _TRUE_RE.match(cond):
+            continue
+        line_no = source.count("\n", 0, match.start()) + 1
+        if is_inline_suppressed(lines, line_no, "CG-FIREBASE-RULES-OPEN"):
+            continue
+        ops = " ".join(match.group("ops").split())
+        findings.append(
+            Finding(
+                rule_id="CG-FIREBASE-RULES-OPEN",
+                severity="high",
+                message=f"Firebase rule grants `{ops}` to everyone (condition is always true)",
+                file_path=rel,
+                line_start=line_no,
+                cwe="CWE-732",
+                evidence=lines[line_no - 1].strip() if 0 < line_no <= len(lines) else "",
+            )
+        )
+    return nodes, [], findings

--- a/src/cybergraph/analysis/registry.py
+++ b/src/cybergraph/analysis/registry.py
@@ -30,6 +30,7 @@ from cybergraph.graph import Edge, Finding, Node
 
 from .csharp import analyze_csharp_file
 from .dockerfile import analyze_dockerfile_file
+from .firebase_rules import analyze_firebase_rules_file
 from .go import analyze_go_file
 from .java import analyze_java_file
 from .javascript import analyze_javascript_file
@@ -46,11 +47,12 @@ CSHARP_SUFFIXES = {".cs"}
 TERRAFORM_SUFFIXES = {".tf"}
 DOCKERFILE_SUFFIXES = {".dockerfile"}
 DOCKERFILE_NAMES = {"Dockerfile"}
+FIREBASE_SUFFIXES = {".rules"}
 
 # Suffixes that have a dedicated security analyzer (everything else falls back).
 ANALYZED_SUFFIXES = (
     PYTHON_SUFFIXES | JAVASCRIPT_SUFFIXES | GO_SUFFIXES | JAVA_SUFFIXES | CSHARP_SUFFIXES
-    | TERRAFORM_SUFFIXES
+    | TERRAFORM_SUFFIXES | FIREBASE_SUFFIXES
 )
 
 
@@ -175,6 +177,8 @@ def _dispatch(path: Path, repo_root: Path, config: CyberGraphConfig) -> Analyzer
             repo_root,
             secret_markers=config.secret_markers,
         )
+    if suffix in FIREBASE_SUFFIXES or path.name == "firebase.json":
+        return analyze_firebase_rules_file(path, repo_root)
     return _fallback_file_node(path, repo_root)
 
 

--- a/src/cybergraph/analysis/registry.py
+++ b/src/cybergraph/analysis/registry.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from cybergraph.config import CyberGraphConfig
 from cybergraph.graph import Edge, Finding, Node
 
+from .collector import is_supabase_sql
 from .csharp import analyze_csharp_file
 from .dockerfile import analyze_dockerfile_file
 from .firebase_rules import analyze_firebase_rules_file
@@ -35,6 +36,7 @@ from .go import analyze_go_file
 from .java import analyze_java_file
 from .javascript import analyze_javascript_file
 from .python import analyze_python_file
+from .supabase_rls import analyze_supabase_rls_file
 from .terraform import analyze_terraform_file
 
 AnalyzerResult = tuple[list[Node], list[Edge], list[Finding]]
@@ -179,6 +181,8 @@ def _dispatch(path: Path, repo_root: Path, config: CyberGraphConfig) -> Analyzer
         )
     if suffix in FIREBASE_SUFFIXES or path.name == "firebase.json":
         return analyze_firebase_rules_file(path, repo_root)
+    if is_supabase_sql(path):
+        return analyze_supabase_rls_file(path, repo_root)
     return _fallback_file_node(path, repo_root)
 
 

--- a/src/cybergraph/analysis/registry.py
+++ b/src/cybergraph/analysis/registry.py
@@ -28,7 +28,8 @@ from pathlib import Path
 from cybergraph.config import CyberGraphConfig
 from cybergraph.graph import Edge, Finding, Node
 
-from .collector import is_supabase_sql
+from .bucket_policy import analyze_bucket_policy_file
+from .collector import is_bucket_policy, is_supabase_sql
 from .csharp import analyze_csharp_file
 from .dockerfile import analyze_dockerfile_file
 from .firebase_rules import analyze_firebase_rules_file
@@ -183,6 +184,8 @@ def _dispatch(path: Path, repo_root: Path, config: CyberGraphConfig) -> Analyzer
         return analyze_firebase_rules_file(path, repo_root)
     if is_supabase_sql(path):
         return analyze_supabase_rls_file(path, repo_root)
+    if is_bucket_policy(path):
+        return analyze_bucket_policy_file(path, repo_root)
     return _fallback_file_node(path, repo_root)
 
 

--- a/src/cybergraph/analysis/supabase_rls.py
+++ b/src/cybergraph/analysis/supabase_rls.py
@@ -1,0 +1,90 @@
+"""Supabase RLS analyzer for SQL migrations.
+
+Row-level security is Supabase's authorization boundary; a table with RLS off
+(or a policy that re-opens it with ``USING (true)``) exposes its rows to the
+public API role. Regex-based, per-file. Three definite signals:
+
+* ``DISABLE ROW LEVEL SECURITY`` -- an explicit switch-off;
+* ``CREATE POLICY ... USING (true)`` -- a policy that grants everyone access;
+* ``CREATE TABLE t`` with no ``ENABLE ROW LEVEL SECURITY`` for ``t`` in the same
+  file -- Supabase migrations conventionally enable RLS in the migration that
+  creates the table, so a create with no same-file enable is the classic
+  "forgot to turn on RLS" bug. Cross-file enable is possible but rare; the
+  same-file scope keeps precision high and the finding is a REVIEW, not a block.
+
+Table identity is compared on the bare table name (schema-qualified or not).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from cybergraph.graph import Edge, Finding, Node
+from cybergraph.suppressions import is_inline_suppressed
+
+DISABLE_RE = re.compile(
+    r"alter\s+table\s+(?:if\s+exists\s+)?(?P<tbl>[\w.\"]+)\s+disable\s+row\s+level\s+security",
+    re.IGNORECASE,
+)
+ENABLE_RE = re.compile(
+    r"alter\s+table\s+(?:if\s+exists\s+)?(?P<tbl>[\w.\"]+)\s+enable\s+row\s+level\s+security",
+    re.IGNORECASE,
+)
+CREATE_TABLE_RE = re.compile(
+    r"create\s+table\s+(?:if\s+not\s+exists\s+)?(?P<tbl>[\w.\"]+)",
+    re.IGNORECASE,
+)
+POLICY_TRUE_RE = re.compile(
+    r"create\s+policy\b[^;]*?\busing\s*\(\s*true\s*\)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _bare(name: str) -> str:
+    return name.replace('"', "").split(".")[-1].lower()
+
+
+def _line_of(source: str, index: int) -> int:
+    return source.count("\n", 0, index) + 1
+
+
+def analyze_supabase_rls_file(
+    path: Path, repo_root: Path
+) -> tuple[list[Node], list[Edge], list[Finding]]:
+    source = path.read_text(encoding="utf-8", errors="ignore")
+    lines = source.splitlines()
+    rel = path.relative_to(repo_root).as_posix()
+    nodes: list[Node] = [Node("File", rel, rel, rel, 1, len(lines), {"language": "sql"})]
+    findings: list[Finding] = []
+
+    def emit(line_no: int, message: str) -> None:
+        if is_inline_suppressed(lines, line_no, "CG-SUPABASE-RLS-DISABLED"):
+            return
+        findings.append(
+            Finding(
+                rule_id="CG-SUPABASE-RLS-DISABLED",
+                severity="high",
+                message=message,
+                file_path=rel,
+                line_start=line_no,
+                cwe="CWE-1230",
+                evidence=lines[line_no - 1].strip() if 0 < line_no <= len(lines) else "",
+            )
+        )
+
+    for m in DISABLE_RE.finditer(source):
+        emit(_line_of(source, m.start()),
+             f"row-level security is disabled on `{_bare(m.group('tbl'))}`")
+    for m in POLICY_TRUE_RE.finditer(source):
+        emit(_line_of(source, m.start()),
+             "a policy grants access to everyone (`USING (true)`)")
+
+    enabled = {_bare(m.group("tbl")) for m in ENABLE_RE.finditer(source)}
+    for m in CREATE_TABLE_RE.finditer(source):
+        tbl = _bare(m.group("tbl"))
+        if tbl not in enabled:
+            emit(_line_of(source, m.start()),
+                 f"table `{tbl}` is created without enabling row-level security")
+
+    return nodes, [], findings

--- a/src/cybergraph/security/capability.py
+++ b/src/cybergraph/security/capability.py
@@ -51,9 +51,9 @@ VERIFIED_GLOBS = PYTHON_GLOBS
 # reads UNKNOWN -- broad globs (e.g. every *.yaml) would make unrelated changes
 # review. Single source of truth for the capability's `covers` and coverage.
 CONFIG_GLOBS = (
-    "*.tf", "*.tfvars",
-    "*.rules", "firebase.json",
-    "supabase/*.sql",
+    "*.tf",
+    "*.rules", "firebase.json", "*/firebase.json",
+    "supabase/*.sql", "*/supabase/*.sql",
     "*bucket-policy*.json", "*bucket_policy*.json", "*.iam.json",
 )
 

--- a/src/cybergraph/security/capability.py
+++ b/src/cybergraph/security/capability.py
@@ -36,7 +36,6 @@ _REVIEW_STATES = frozenset({FAIL, UNKNOWN, NOT_SUPPORTED})
 
 PYTHON_GLOBS = ("*.py",)
 WEB_GLOBS = ("*.ts", "*.tsx", "*.js", "*.jsx", "*.vue", "*.svelte", "*.mjs", "*.cjs")
-INFRA_GLOBS = ("*.tf", "*.tfvars", "supabase/*", "firebase.json", "*.yaml", "*.yml")
 
 # Every extension CyberGraph recognises as executable source, supported or not.
 SOURCE_GLOBS = (
@@ -46,6 +45,17 @@ SOURCE_GLOBS = (
 )
 # The subset with a Phase 1 analyzer that produces findings.
 VERIFIED_GLOBS = PYTHON_GLOBS
+
+# Declarative config surfaces with a Phase-2 posture analyzer. Kept narrow so a
+# changed config file that is analyzed-and-clean can PASS and an unparsed one
+# reads UNKNOWN -- broad globs (e.g. every *.yaml) would make unrelated changes
+# review. Single source of truth for the capability's `covers` and coverage.
+CONFIG_GLOBS = (
+    "*.tf", "*.tfvars",
+    "*.rules", "firebase.json",
+    "supabase/*.sql",
+    "*bucket-policy*.json", "*bucket_policy*.json", "*.iam.json",
+)
 
 
 @dataclass(frozen=True)
@@ -69,7 +79,7 @@ CAPABILITIES: tuple[Capability, ...] = (
                "Languages CyberGraph can read", SOURCE_GLOBS, True),
     Capability("client_secret_boundary", "Secrets reaching the browser", WEB_GLOBS, False),
     Capability("cloud_configuration",
-               "Cloud and database configuration", INFRA_GLOBS, False),
+               "Cloud and database configuration", CONFIG_GLOBS, True),
 )
 
 _BY_ID = {capability.id: capability for capability in CAPABILITIES}

--- a/src/cybergraph/security/checks.py
+++ b/src/cybergraph/security/checks.py
@@ -42,6 +42,11 @@ _FINDING_RULES = {
     "code_execution": "CG-CODE-EXEC",
     "deserialization": "CG-DESERIALIZE",
     "path_access": "CG-PATH-TRAVERSAL",
+    "cloud_configuration": {
+        "CG-FIREBASE-RULES-OPEN", "CG-SUPABASE-RLS-DISABLED", "CG-STORAGE-BUCKET-PUBLIC",
+        "CG-IAC-PUBLIC-BUCKET", "CG-IAC-WILDCARD-IAM", "CG-IAC-OPEN-INGRESS",
+        "CG-IAC-HARDCODED-SECRET",
+    },
 }
 
 _BY_ID = {capability.id: capability for capability in CAPABILITIES}
@@ -194,6 +199,7 @@ def _evaluate(
     rule = _FINDING_RULES.get(capability_id)
     if rule is None:  # pragma: no cover - guarded by test_every_capability_is_evaluated
         raise AssertionError(f"capability {capability_id} has no evaluator")
+    rules = {rule} if isinstance(rule, str) else set(rule)
 
     relevant_files = _capability_files(capability_id, changed_files)
     missing, failed, analyzed = _coverage_summary(relevant_files, coverage)
@@ -204,8 +210,8 @@ def _evaluate(
             capability_id, UNKNOWN,
             f"`{missing[0]}` changed but has no analysis record", len(missing),
         )
-    confirmed = [f for f in findings if f.rule_id == rule]
-    unverified = [f for f in findings if f.rule_id == f"{rule}-UNVERIFIED"]
+    confirmed = [f for f in findings if f.rule_id in rules]
+    unverified = [f for f in findings if f.rule_id in {f"{r}-UNVERIFIED" for r in rules}]
     if confirmed:
         return CheckResult(capability_id, FAIL, confirmed[0].message, len(confirmed))
     if unverified:

--- a/src/cybergraph/security/coverage.py
+++ b/src/cybergraph/security/coverage.py
@@ -24,7 +24,7 @@ STATUS_FAILED = "failed"
 STATUS_UNSUPPORTED = "unsupported"
 STATUS_MISSING = "missing"
 
-_PARSE_FAILURE_RULES = ("PY-SYNTAX",)
+_PARSE_FAILURE_RULES = ("PY-SYNTAX", "CG-FILE-UNREADABLE")
 
 
 @dataclass(frozen=True)

--- a/src/cybergraph/security/coverage.py
+++ b/src/cybergraph/security/coverage.py
@@ -17,7 +17,7 @@ from fnmatch import fnmatch
 from pathlib import Path
 
 from cybergraph.graph import GraphStore
-from cybergraph.security.capability import SOURCE_GLOBS, VERIFIED_GLOBS
+from cybergraph.security.capability import CONFIG_GLOBS, SOURCE_GLOBS, VERIFIED_GLOBS
 
 STATUS_ANALYZED = "analyzed"
 STATUS_FAILED = "failed"
@@ -41,7 +41,7 @@ def assess_coverage(
     repo_root = Path(repo_root).resolve()
     sources = tuple(
         file for file in changed_files
-        if any(fnmatch(file, pattern) for pattern in SOURCE_GLOBS)
+        if any(fnmatch(file, pattern) for pattern in SOURCE_GLOBS + CONFIG_GLOBS)
     )
     if not sources:
         return ()
@@ -67,7 +67,7 @@ def assess_coverage(
     for file in sources:
         if file in failed:
             results.append(FileCoverage(file, STATUS_FAILED, "the file could not be read"))
-        elif not any(fnmatch(file, pattern) for pattern in VERIFIED_GLOBS):
+        elif not any(fnmatch(file, pattern) for pattern in VERIFIED_GLOBS + CONFIG_GLOBS):
             results.append(
                 FileCoverage(file, STATUS_UNSUPPORTED, "no analyzer for this language yet")
             )

--- a/tests/test_bucket_policy.py
+++ b/tests/test_bucket_policy.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cybergraph.analysis.bucket_policy import analyze_bucket_policy_file
+
+S3_PUBLIC = {
+    "Statement": [
+        {"Effect": "Allow", "Principal": "*", "Action": "s3:GetObject",
+         "Resource": "arn:aws:s3:::b/*"}
+    ]
+}
+S3_SCOPED = {
+    "Statement": [
+        {"Effect": "Allow", "Principal": {"AWS": "arn:aws:iam::1:role/r"},
+         "Action": "s3:GetObject"}
+    ]
+}
+GCS_PUBLIC = {"bindings": [{"role": "roles/storage.objectViewer", "members": ["allUsers"]}]}
+
+
+def _write(tmp_path: Path, obj) -> Path:
+    p = tmp_path / "bucket-policy.json"
+    p.write_text(json.dumps(obj), encoding="utf-8")
+    return p
+
+
+def test_s3_public_principal_is_flagged(tmp_path: Path) -> None:
+    p = _write(tmp_path, S3_PUBLIC)
+    _n, _e, findings = analyze_bucket_policy_file(p, tmp_path)
+    assert [f.rule_id for f in findings] == ["CG-STORAGE-BUCKET-PUBLIC"]
+    assert findings[0].cwe == "CWE-732"
+
+
+def test_s3_scoped_principal_is_clean(tmp_path: Path) -> None:
+    p = _write(tmp_path, S3_SCOPED)
+    _n, _e, findings = analyze_bucket_policy_file(p, tmp_path)
+    assert findings == []
+
+
+def test_gcs_all_users_is_flagged(tmp_path: Path) -> None:
+    p = _write(tmp_path, GCS_PUBLIC)
+    _n, _e, findings = analyze_bucket_policy_file(p, tmp_path)
+    assert [f.rule_id for f in findings] == ["CG-STORAGE-BUCKET-PUBLIC"]
+
+
+def test_non_policy_json_is_clean(tmp_path: Path) -> None:
+    p = _write(tmp_path, {"name": "not a policy", "version": 3})
+    nodes, _e, findings = analyze_bucket_policy_file(p, tmp_path)
+    assert findings == []
+    assert any(n.kind == "File" for n in nodes)
+
+
+def test_malformed_json_propagates_valueerror(tmp_path: Path) -> None:
+    p = tmp_path / "bucket-policy.json"
+    p.write_text("{not json", encoding="utf-8")
+    with pytest.raises(ValueError):  # JSONDecodeError is a ValueError
+        analyze_bucket_policy_file(p, tmp_path)

--- a/tests/test_config_posture_capability.py
+++ b/tests/test_config_posture_capability.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from cybergraph.security.capability import (
+    CAPABILITIES,
+    FAIL,
+    NOT_APPLICABLE,
+)
+from cybergraph.security.check import check_change
+from cybergraph.security.verdict import STATE_REVIEW
+
+
+def _cap(cid: str):
+    return next(c for c in CAPABILITIES if c.id == cid)
+
+
+def test_cloud_configuration_is_supported():
+    assert _cap("cloud_configuration").supported is True
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "t@e.com"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "t"], check=True)
+    (repo / "README.md").write_text("# x\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "base"], check=True)
+    return repo
+
+
+def test_disabling_rls_makes_check_review(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    d = repo / "supabase" / "migrations"
+    d.mkdir(parents=True)
+    (d / "0002_open.sql").write_text(
+        "ALTER TABLE public.profiles DISABLE ROW LEVEL SECURITY;\n", encoding="utf-8"
+    )
+    verdict = check_change(repo, mode="worktree")
+    assert verdict.state == STATE_REVIEW
+    assert any("cloud_configuration" == c.capability_id and c.status == FAIL
+               for c in verdict.checks)
+
+
+def test_clean_readme_change_accepts(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    (repo / "README.md").write_text("# x\nmore\n", encoding="utf-8")
+    verdict = check_change(repo, mode="worktree")
+    # cloud_configuration is NOT_APPLICABLE (no config file changed); overall may
+    # still accept if nothing else reviews.
+    cc = next(c for c in verdict.checks if c.capability_id == "cloud_configuration")
+    assert cc.status == NOT_APPLICABLE

--- a/tests/test_config_posture_capability.py
+++ b/tests/test_config_posture_capability.py
@@ -7,6 +7,7 @@ from cybergraph.security.capability import (
     CAPABILITIES,
     FAIL,
     NOT_APPLICABLE,
+    UNKNOWN,
 )
 from cybergraph.security.check import check_change
 from cybergraph.security.verdict import STATE_REVIEW
@@ -53,3 +54,11 @@ def test_clean_readme_change_accepts(tmp_path: Path) -> None:
     # still accept if nothing else reviews.
     cc = next(c for c in verdict.checks if c.capability_id == "cloud_configuration")
     assert cc.status == NOT_APPLICABLE
+
+
+def test_malformed_bucket_policy_reads_unknown(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    (repo / "bucket-policy.json").write_text("{not json", encoding="utf-8")
+    verdict = check_change(repo, mode="worktree")
+    cc = next(c for c in verdict.checks if c.capability_id == "cloud_configuration")
+    assert cc.status == UNKNOWN  # never a silent PASS on something we could not parse

--- a/tests/test_config_posture_capability.py
+++ b/tests/test_config_posture_capability.py
@@ -62,3 +62,16 @@ def test_malformed_bucket_policy_reads_unknown(tmp_path: Path) -> None:
     verdict = check_change(repo, mode="worktree")
     cc = next(c for c in verdict.checks if c.capability_id == "cloud_configuration")
     assert cc.status == UNKNOWN  # never a silent PASS on something we could not parse
+
+
+def test_nested_supabase_migration_disabling_rls_reviews(tmp_path):
+    repo = _repo(tmp_path)
+    d = repo / "apps" / "web" / "supabase" / "migrations"
+    d.mkdir(parents=True)
+    (d / "0003_open.sql").write_text(
+        "ALTER TABLE public.profiles DISABLE ROW LEVEL SECURITY;\n", encoding="utf-8"
+    )
+    verdict = check_change(repo, mode="worktree")
+    assert verdict.state == STATE_REVIEW
+    assert any(c.capability_id == "cloud_configuration" and c.status == FAIL
+               for c in verdict.checks)

--- a/tests/test_firebase_rules.py
+++ b/tests/test_firebase_rules.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cybergraph.analysis.firebase_rules import analyze_firebase_rules_file
+
+OPEN = """rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{uid} {
+      allow read, write: if true;
+    }
+  }
+}
+"""
+
+GUARDED = """rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /users/{uid} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}
+"""
+
+
+def _write(tmp_path: Path, name: str, text: str) -> Path:
+    p = tmp_path / name
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_open_rule_is_flagged(tmp_path: Path) -> None:
+    p = _write(tmp_path, "firestore.rules", OPEN)
+    nodes, _edges, findings = analyze_firebase_rules_file(p, tmp_path)
+    assert any(n.kind == "File" for n in nodes)
+    assert [f.rule_id for f in findings] == ["CG-FIREBASE-RULES-OPEN"]
+    f = findings[0]
+    assert f.cwe == "CWE-732"
+    assert "if true" in f.evidence
+
+
+def test_guarded_rule_is_clean(tmp_path: Path) -> None:
+    p = _write(tmp_path, "firestore.rules", GUARDED)
+    nodes, _edges, findings = analyze_firebase_rules_file(p, tmp_path)
+    assert findings == []
+    assert any(n.kind == "File" for n in nodes)
+
+
+def test_inline_suppression_respected(tmp_path: Path) -> None:
+    text = OPEN.replace("if true;", "if true; // cybergraph: ignore CG-FIREBASE-RULES-OPEN")
+    p = _write(tmp_path, "firestore.rules", text)
+    _nodes, _edges, findings = analyze_firebase_rules_file(p, tmp_path)
+    assert findings == []

--- a/tests/test_supabase_rls.py
+++ b/tests/test_supabase_rls.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cybergraph.analysis.supabase_rls import analyze_supabase_rls_file
+
+
+def _write(tmp_path: Path, text: str) -> Path:
+    d = tmp_path / "supabase" / "migrations"
+    d.mkdir(parents=True)
+    p = d / "0001_init.sql"
+    p.write_text(text, encoding="utf-8")
+    return p
+
+
+def test_disable_rls_is_flagged(tmp_path: Path) -> None:
+    p = _write(tmp_path, "ALTER TABLE public.profiles DISABLE ROW LEVEL SECURITY;\n")
+    _n, _e, findings = analyze_supabase_rls_file(p, tmp_path)
+    assert [f.rule_id for f in findings] == ["CG-SUPABASE-RLS-DISABLED"]
+    assert findings[0].cwe == "CWE-1230"
+
+
+def test_policy_using_true_is_flagged(tmp_path: Path) -> None:
+    text = (
+        "ALTER TABLE t ENABLE ROW LEVEL SECURITY;\n"
+        'CREATE POLICY p ON t FOR SELECT USING (true);\n'
+    )
+    p = _write(tmp_path, text)
+    _n, _e, findings = analyze_supabase_rls_file(p, tmp_path)
+    assert [f.rule_id for f in findings] == ["CG-SUPABASE-RLS-DISABLED"]
+
+
+def test_create_without_enable_is_flagged(tmp_path: Path) -> None:
+    p = _write(tmp_path, "CREATE TABLE public.secrets (id int, val text);\n")
+    _n, _e, findings = analyze_supabase_rls_file(p, tmp_path)
+    assert [f.rule_id for f in findings] == ["CG-SUPABASE-RLS-DISABLED"]
+
+
+def test_create_then_enable_is_clean(tmp_path: Path) -> None:
+    text = (
+        "CREATE TABLE public.secrets (id int, val text);\n"
+        "ALTER TABLE public.secrets ENABLE ROW LEVEL SECURITY;\n"
+    )
+    p = _write(tmp_path, text)
+    _n, _e, findings = analyze_supabase_rls_file(p, tmp_path)
+    assert findings == []
+
+
+def test_file_node_always_present(tmp_path: Path) -> None:
+    p = _write(tmp_path, "-- just a comment\n")
+    nodes, _e, findings = analyze_supabase_rls_file(p, tmp_path)
+    assert any(n.kind == "File" for n in nodes)
+    assert findings == []


### PR DESCRIPTION
## What this does

Phase-2 slice 2 — **config posture**. Adds detection for three declarative-config exposures that cause a large share of real breaches, and wires them into the ACCEPT/REVIEW verdict so a change that weakens one is caught at the accept-the-diff moment (via the client hooks shipped in slice 1), not in a later audit.

Three new lightweight analyzers (modeled on `terraform.py` — stdlib only, always a File node, findings carry a CWE + verbatim evidence, inline-suppression aware):

- **Firebase security rules** — `allow …: if true` in `firestore.rules` / `storage.rules` → `CG-FIREBASE-RULES-OPEN` (CWE-732). A rule with any real condition (`request.auth != null`, …) is clean.
- **Supabase RLS** — `DISABLE ROW LEVEL SECURITY`, a `CREATE TABLE` with no same-file `ENABLE`, or `CREATE POLICY … USING (true)` in Supabase SQL migrations → `CG-SUPABASE-RLS-DISABLED` (CWE-1230).
- **Public buckets** — a standalone S3 bucket policy with `Effect: Allow` + wildcard `Principal`, or a GCS IAM binding to `allUsers`/`allAuthenticatedUsers` → `CG-STORAGE-BUCKET-PUBLIC` (CWE-732). (Terraform HCL buckets are already `terraform.py`'s job.)

Then the deliberately-placeholder **`cloud_configuration` capability is activated** (`supported=True`): a new `CONFIG_GLOBS` is the single source of truth for both the capability's `covers` and coverage tracking, and `_FINDING_RULES` maps it to a *set* of rule ids — the new trio **plus** Terraform's existing `CG-IAC-*` (fold-in) — so a posture regression in config *or* Terraform now returns REVIEW from `cybergraph check`.

## Safety — precision and honesty, verified end-to-end

- **A posture regression → REVIEW, never a silent ACCEPT.** Disable RLS, open a Firebase rule, or make a bucket public on a changed file and `cybergraph check` reviews it (end-to-end tests).
- **An unparsed config → UNKNOWN, never PASS.** A malformed bucket-policy JSON raises through the registry's containment to `CG-FILE-UNREADABLE`; this exposed a real latent fail-open — `coverage.py`'s `_PARSE_FAILURE_RULES` didn't include that rule, so an unreadable file read PASS. Fixed (a one-line hardening that also closes the same hole for unreadable Python).
- **Precision over recall.** File matching is narrow (`CONFIG_GLOBS` has no broad `*.yaml`/`*.json`; Supabase `.sql` only under a `supabase/` component), so unrelated changes don't review. Secure configs (guarded rules, create-then-enable, scoped/`Deny` policies) produce no finding.

The adversarial review loop earned its keep again: the whole-branch review caught a **Critical cross-module fail-open** — the collector recognized a `.sql` under *any* `supabase/` component, but the capability's glob `supabase/*.sql` was root-anchored under `fnmatch`, so a migration in the normal monorepo layout (`apps/web/supabase/…`) that disabled RLS was analyzed, emitted the finding, yet shipped a **silent ACCEPT**. Fixed (`*/supabase/*.sql` + a nested-path regression test that fails pre-fix), plus two glob-consistency cleanups.

## Verification

- Full suite **1214 passed, 1 skipped**; ruff clean on every file this branch touches.
- Mutation harness **35/35 CAUGHT**, including two new config fail-opens (a posture finding read as PASS; an unparsed config read as clean).
- `run_precision` gate passed; `run_eval` **1.0 / 1.0 / 1.0** (the Python corpus is untouched).

No verdict-space change: still exactly ACCEPT/REVIEW. `cloud_configuration`'s five states behave honestly — FAIL on a weakened config, UNKNOWN on one it couldn't parse, NOT_APPLICABLE when no config changed, PASS only on positive analyzed-clean evidence.

## Out of scope (slice 3)

CORS wildcard detection and the Next.js `client_secret_boundary` (both live in code files; that capability stays `supported=False`). Documented deferred minors: a firebase `true == true` comment/regex mismatch (contrived, no FP), a `CREATE TABLE`-in-SQL-comment false positive (the regex-analyzer class shared with `terraform.py`), and a stale `coverage.py` docstring.
