### PR TITLE
feat: CORS + Next.js client-secret boundary (Phase 2, slice 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ CyberGraph is designed to connect those dots.
 - Extracts functions, calls, route entrypoints, auth/authz guards, validators, user-input/data-flow edges, secret access/exposure, cloud resources, and sensitive sink calls.
 - **Config posture** — open Firebase security rules, Supabase tables with row-level
   security off, and public S3/GCS bucket policies. A change that weakens one is a REVIEW.
+- **CORS & client secrets** — a CORS policy allowing any origin *with credentials*
+  (FastAPI / Express), and secrets shipped to the browser via `NEXT_PUBLIC_`. A change
+  that introduces either is a REVIEW.
 - **Cross-file, interprocedural attack paths** (route → service → repository → sink) with confidence, sanitizer-barrier flags, taint/data-reachability, risk scores, and fix guidance; a `--shallow` mode reproduces intra-function traversal for comparison.
 - **Interactive, offline HTML report** built for first-time readers: a dark-mode-first neon graph explorer (glowing, security-typed nodes with a light/dark toggle), NODE/EDGE/ZONE explainer cards, a guided first view that opens on the top attack path with a plain-language narrative, a security-zones view (Attack Surface → Guards → Logic → Sensitive Sinks), search, layer/severity filters, a details panel with source drill-down, and entrypoint→sink path highlighting (Cytoscape.js, fully inlined).
 - **Exec-first report posture**: an A–F security grade with a one-line verdict and severity-distribution bar, a since-last-scan delta strip (new/regressed/fixed), findings grouped into expandable rule cards, an honest findings-cap footer, and a print stylesheet for clean PDF export.

--- a/benchmark/mutation_harness.py
+++ b/benchmark/mutation_harness.py
@@ -497,6 +497,26 @@ MUTATIONS: list[Mutation] = [
         ),
         note="an unparseable config must read UNKNOWN, never a clean pass",
     ),
+    # -- D9: CORS/client-secret detectors fail open ------------------------
+    Mutation(
+        id="D9-cors-credentialed-wildcard-missed",
+        disaster="D9",
+        file="cybergraph/analysis/python.py",
+        old='        if not _kw_is_true(kw.get("allow_credentials")):\n'
+        "            continue",
+        new="        if True:\n            continue",
+        tests=("tests/test_python_cors.py::test_credentialed_wildcard_is_flagged",),
+        note="a credentialed-wildcard CORS must be flagged, never dropped",
+    ),
+    Mutation(
+        id="D9-client-secret-exposure-missed",
+        disaster="D9",
+        file="cybergraph/analysis/javascript.py",
+        old='_NEXT_PUBLIC_RE = re.compile(r"NEXT_PUBLIC_[A-Za-z0-9_]+")',
+        new='_NEXT_PUBLIC_RE = re.compile(r"__CYBERGRAPH_NEVER_MATCHES__")',
+        tests=("tests/test_js_cors_nextjs.py::test_next_public_secret_is_flagged",),
+        note="a NEXT_PUBLIC_ secret must be flagged, never missed",
+    ),
 ]
 
 

--- a/docs/superpowers/plans/2026-08-10-cors-client-boundary.md
+++ b/docs/superpowers/plans/2026-08-10-cors-client-boundary.md
@@ -1,0 +1,554 @@
+# CORS + Next.js Client-Secret Boundary — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Flag two in-code web exposures — a CORS policy that allows any origin *with credentials*, and a secret shipped to the browser via `NEXT_PUBLIC_` — and make a change that introduces either return REVIEW from `cybergraph check`, precisely, with no false alarm on a scoped CORS config or a public-by-design value.
+
+**Architecture:** Extend the two existing code analyzers (`python.py` AST-based, `javascript.py` line/source-based) with new detectors, then activate the declared-but-absent `client_secret_boundary` capability and add a new `cross_origin_policy` capability so their findings drive the verdict. One coverage wiring change lets a changed web file reach PASS/FAIL for these capabilities instead of perpetual UNKNOWN.
+
+**Tech Stack:** Python 3.10–3.13, standard library only (`ast`, `re`, `pathlib`). Existing `graph.Finding/Node`, `suppressions.is_inline_suppressed`, the capability/coverage/checks machinery.
+
+## Global Constraints
+
+- **Zero runtime dependencies**; standard library only. Python 3.10–3.13. `from __future__ import annotations` first line of any new file (both target files already have it).
+- Ruff line-length 100; run `ruff check` on every touched file — clean.
+- No network; no API keys on any default path.
+- **Precision over recall (cardinal):** flag only the definite signals below. An unresolved/dynamic CORS config or an ambiguous name yields NO finding — document the recall gap, never risk a false alarm.
+- Findings carry `rule_id`, `severity`, `message`, `file_path`, `line_start`, `cwe`, `evidence`, and honor `is_inline_suppressed` — mirror the existing `Finding(...)` calls in each analyzer.
+- Commits authored `Laraib <lxh417bham@gmail.com>` only (repo-local git config already carries it — do **not** pass `-c user.email=`); no `Co-Authored-By`, no AI attribution. Many small commits; never squash. Push only to `https://github.com/AQ-Labs/cybergraph`.
+- Branch `feat/cors-client-boundary` is stacked on `feat/config-posture`; do not rebase during implementation.
+
+---
+
+## File Structure
+
+- `src/cybergraph/analysis/python.py` (modify) — FastAPI CORS detector (`_add_cors_findings`).
+- `src/cybergraph/analysis/javascript.py` (modify) — Express CORS + `NEXT_PUBLIC_` secret detectors.
+- `src/cybergraph/security/capability.py` (modify) — activate `client_secret_boundary`; add `cross_origin_policy` + `CORS_GLOBS`.
+- `src/cybergraph/security/coverage.py` (modify) — add `WEB_GLOBS` to the verified gate.
+- `src/cybergraph/security/checks.py` (modify) — `_FINDING_RULES` += both rule ids.
+- Tests: `tests/test_python_cors.py`, `tests/test_js_cors_nextjs.py`, `tests/test_web_capabilities.py` (create); edits to any test asserting these capabilities `NOT_SUPPORTED`.
+- `benchmark/mutation_harness.py` (modify) — two seeded fail-opens.
+- `README.md` (modify) — one line.
+
+---
+
+## Task 1: FastAPI CORS detector (Python)
+
+**Files:**
+- Modify: `src/cybergraph/analysis/python.py`
+- Test: `tests/test_python_cors.py` (create)
+
+**Interfaces:**
+- Consumes: existing `ast`, `_callable_name`, `Finding`, `is_inline_suppressed`.
+- Produces: `_add_cors_findings(tree, rel, lines, findings)` appending `CG-CORS-CREDENTIALED-WILDCARD` (severity `high`, CWE-942); invoked from `analyze_python_file` right after `_add_django_url_routes(tree, rel, nodes, edges)` (python.py:167).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_python_cors.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from cybergraph.analysis.python import analyze_python_file
+
+
+def _run(tmp_path: Path, src: str):
+    p = tmp_path / "main.py"
+    p.write_text(src, encoding="utf-8")
+    _nodes, _edges, findings = analyze_python_file(p, tmp_path)
+    return [f.rule_id for f in findings]
+
+
+CRED_WILDCARD = """from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+app = FastAPI()
+app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True)
+"""
+
+SCOPED = """from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+app = FastAPI()
+app.add_middleware(CORSMiddleware, allow_origins=["https://app.example.com"], allow_credentials=True)
+"""
+
+WILDCARD_NO_CREDS = """from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+app = FastAPI()
+app.add_middleware(CORSMiddleware, allow_origins=["*"])
+"""
+
+REGEX_ALL = """from starlette.middleware.cors import CORSMiddleware
+app.add_middleware(CORSMiddleware, allow_origin_regex=".*", allow_credentials=True)
+"""
+
+
+def test_credentialed_wildcard_is_flagged(tmp_path):
+    assert _run(tmp_path, CRED_WILDCARD) == ["CG-CORS-CREDENTIALED-WILDCARD"]
+
+
+def test_scoped_origin_is_clean(tmp_path):
+    assert "CG-CORS-CREDENTIALED-WILDCARD" not in _run(tmp_path, SCOPED)
+
+
+def test_wildcard_without_credentials_is_clean(tmp_path):
+    assert "CG-CORS-CREDENTIALED-WILDCARD" not in _run(tmp_path, WILDCARD_NO_CREDS)
+
+
+def test_regex_all_origins_with_credentials_is_flagged(tmp_path):
+    assert _run(tmp_path, REGEX_ALL) == ["CG-CORS-CREDENTIALED-WILDCARD"]
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/test_python_cors.py -v` — Expected: FAIL (no finding emitted yet).
+
+- [ ] **Step 3: Implement `_add_cors_findings`**
+
+In `python.py`, add these helpers (near `_add_django_url_routes`):
+
+```python
+def _cors_allows_all(origins: ast.AST | None, regex: ast.AST | None) -> bool:
+    if isinstance(origins, (ast.List, ast.Tuple)):
+        if any(isinstance(e, ast.Constant) and e.value == "*" for e in origins.elts):
+            return True
+    if isinstance(origins, ast.Constant) and origins.value == "*":
+        return True
+    if isinstance(regex, ast.Constant) and isinstance(regex.value, str):
+        if regex.value in {".*", "^.*$", "*", ".*$", "^.*", "(.*)"}:
+            return True
+    return False
+
+
+def _kw_is_true(node: ast.AST | None) -> bool:
+    return isinstance(node, ast.Constant) and node.value is True
+
+
+def _add_cors_findings(
+    tree: ast.AST, rel: str, lines: list[str], findings: list[Finding]
+) -> None:
+    """Flag a FastAPI/Starlette CORS middleware allowing any origin WITH credentials.
+
+    The credentialed wildcard is the real vulnerability: any site can make
+    authenticated cross-origin requests. A scoped origin list, or a wildcard
+    without credentials, is not flagged (precision over recall).
+    """
+    for call in (n for n in ast.walk(tree) if isinstance(n, ast.Call)):
+        name = _callable_name(call.func)
+        is_cors = name == "CORSMiddleware" or (
+            name.endswith("add_middleware")
+            and call.args
+            and _callable_name(call.args[0]) == "CORSMiddleware"
+        )
+        if not is_cors:
+            continue
+        kw = {k.arg: k.value for k in call.keywords if k.arg}
+        if not _cors_allows_all(kw.get("allow_origins"), kw.get("allow_origin_regex")):
+            continue
+        if not _kw_is_true(kw.get("allow_credentials")):
+            continue
+        line_no = getattr(call, "lineno", 1)
+        if is_inline_suppressed(lines, line_no, "CG-CORS-CREDENTIALED-WILDCARD"):
+            continue
+        findings.append(
+            Finding(
+                rule_id="CG-CORS-CREDENTIALED-WILDCARD",
+                severity="high",
+                message="CORS allows any origin with credentials "
+                        "(allow_origins '*' + allow_credentials=True)",
+                file_path=rel,
+                line_start=line_no,
+                cwe="CWE-942",
+                evidence=lines[line_no - 1].strip() if 0 < line_no <= len(lines) else "",
+            )
+        )
+```
+
+Invoke it in `analyze_python_file`, immediately after `_add_django_url_routes(tree, rel, nodes, edges)`:
+
+```python
+    _add_cors_findings(tree, rel, lines, findings)
+```
+
+- [ ] **Step 4: Run tests + ruff**
+
+Run: `pytest tests/test_python_cors.py -v` — Expected: PASS.
+Run: `ruff check src/cybergraph/analysis/python.py tests/test_python_cors.py` — Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/analysis/python.py tests/test_python_cors.py
+git commit -m "feat(analysis): detect FastAPI credentialed-wildcard CORS"
+```
+
+---
+
+## Task 2: Express CORS + Next.js secret detector (JavaScript)
+
+**Files:**
+- Modify: `src/cybergraph/analysis/javascript.py`
+- Test: `tests/test_js_cors_nextjs.py` (create)
+
+**Interfaces:**
+- Consumes: existing `Finding`, `is_inline_suppressed`, module regex conventions.
+- Produces: `_add_js_web_findings(source, lines, rel, findings)` appending `CG-CORS-CREDENTIALED-WILDCARD` (CWE-942) and `CG-CLIENT-SECRET-EXPOSED` (CWE-200); invoked once from `analyze_javascript_file` before `return nodes, edges, findings`.
+
+**Detection rules (operate on the RAW `source`/`lines`, not the strings-blanked `code_lines` — the values we need live inside string literals):**
+- **CORS:** a `cors(` call whose options object contains BOTH an all-origins setting (`origin: "*"`, `origin: '*'`, or `origin: true`) AND `credentials: true`. A scoped origin, a bare `cors()` (credentials default off), or credentials-only is clean.
+- **Next.js secret:** a `NEXT_PUBLIC_<NAME>` token whose `<NAME>` contains a secret keyword (`SECRET`, `KEY`, `TOKEN`, `PASSWORD`, `PASSWD`, `APIKEY`, `PRIVATE`), case-insensitive. `NEXT_PUBLIC_API_URL` etc. are clean.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_js_cors_nextjs.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from cybergraph.analysis.javascript import analyze_javascript_file
+
+
+def _run(tmp_path: Path, name: str, src: str):
+    p = tmp_path / name
+    p.write_text(src, encoding="utf-8")
+    _n, _e, findings = analyze_javascript_file(p, tmp_path)
+    return [f.rule_id for f in findings]
+
+
+def test_express_credentialed_wildcard_cors_is_flagged(tmp_path):
+    src = "const cors = require('cors');\napp.use(cors({ origin: '*', credentials: true }));\n"
+    assert "CG-CORS-CREDENTIALED-WILDCARD" in _run(tmp_path, "server.js", src)
+
+
+def test_express_origin_true_with_credentials_is_flagged(tmp_path):
+    src = "app.use(cors({ origin: true, credentials: true }));\n"
+    assert "CG-CORS-CREDENTIALED-WILDCARD" in _run(tmp_path, "server.js", src)
+
+
+def test_scoped_cors_is_clean(tmp_path):
+    src = "app.use(cors({ origin: ['https://app.example.com'], credentials: true }));\n"
+    assert "CG-CORS-CREDENTIALED-WILDCARD" not in _run(tmp_path, "server.js", src)
+
+
+def test_bare_cors_is_clean(tmp_path):
+    src = "app.use(cors());\n"
+    assert "CG-CORS-CREDENTIALED-WILDCARD" not in _run(tmp_path, "server.js", src)
+
+
+def test_next_public_secret_is_flagged(tmp_path):
+    src = "const k = process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY;\n"
+    assert "CG-CLIENT-SECRET-EXPOSED" in _run(tmp_path, "config.ts", src)
+
+
+def test_next_public_url_is_clean(tmp_path):
+    src = "const u = process.env.NEXT_PUBLIC_API_URL;\n"
+    assert "CG-CLIENT-SECRET-EXPOSED" not in _run(tmp_path, "config.ts", src)
+
+
+def test_server_side_secret_is_not_a_client_boundary_finding(tmp_path):
+    src = "const k = process.env.STRIPE_SECRET_KEY;\n"
+    assert "CG-CLIENT-SECRET-EXPOSED" not in _run(tmp_path, "server.ts", src)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/test_js_cors_nextjs.py -v` — Expected: FAIL.
+
+- [ ] **Step 3: Implement the detectors**
+
+In `javascript.py`, add module-level regexes and helpers:
+
+```python
+_CORS_CALL_RE = re.compile(r"\bcors\s*\(\s*\{")
+_ORIGIN_ALL_RE = re.compile(r"""origin\s*:\s*(?:['"]\*['"]|true)""")
+_CREDENTIALS_TRUE_RE = re.compile(r"credentials\s*:\s*true")
+_NEXT_PUBLIC_RE = re.compile(
+    r"NEXT_PUBLIC_[A-Za-z0-9_]*"
+    r"(?:SECRET|APIKEY|API_KEY|TOKEN|PASSWORD|PASSWD|PRIVATE|_KEY|KEY)"
+    r"[A-Za-z0-9_]*",
+    re.IGNORECASE,
+)
+
+
+def _brace_object(source: str, open_index: int) -> tuple[str, int]:
+    """From the '{' at open_index, return (object_text, end_index) at its match."""
+    depth = 0
+    for i in range(open_index, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[open_index : i + 1], i
+    return source[open_index:], len(source)
+
+
+def _line_of(source: str, index: int) -> int:
+    return source.count("\n", 0, index) + 1
+
+
+def _add_js_web_findings(
+    source: str, lines: list[str], rel: str, findings: list[Finding]
+) -> None:
+    # CORS: cors({ ... origin:*/true ... credentials:true ... })
+    for m in _CORS_CALL_RE.finditer(source):
+        obj, _end = _brace_object(source, m.end() - 1)
+        if _ORIGIN_ALL_RE.search(obj) and _CREDENTIALS_TRUE_RE.search(obj):
+            line_no = _line_of(source, m.start())
+            if is_inline_suppressed(lines, line_no, "CG-CORS-CREDENTIALED-WILDCARD"):
+                continue
+            findings.append(
+                Finding(
+                    rule_id="CG-CORS-CREDENTIALED-WILDCARD",
+                    severity="high",
+                    message="CORS allows any origin with credentials "
+                            "(origin '*'/true + credentials: true)",
+                    file_path=rel,
+                    line_start=line_no,
+                    cwe="CWE-942",
+                    evidence=lines[line_no - 1].strip() if 0 < line_no <= len(lines) else "",
+                )
+            )
+    # Next.js: a NEXT_PUBLIC_ name that looks like a secret -> inlined into the bundle.
+    seen: set[int] = set()
+    for m in _NEXT_PUBLIC_RE.finditer(source):
+        line_no = _line_of(source, m.start())
+        if line_no in seen:
+            continue
+        seen.add(line_no)
+        if is_inline_suppressed(lines, line_no, "CG-CLIENT-SECRET-EXPOSED"):
+            continue
+        findings.append(
+            Finding(
+                rule_id="CG-CLIENT-SECRET-EXPOSED",
+                severity="high",
+                message=f"`{m.group(0)}` ships a secret to the browser bundle "
+                        "(NEXT_PUBLIC_ is inlined client-side)",
+                file_path=rel,
+                line_start=line_no,
+                cwe="CWE-200",
+                evidence=lines[line_no - 1].strip() if 0 < line_no <= len(lines) else "",
+            )
+        )
+```
+
+Invoke once in `analyze_javascript_file`, just before `return nodes, edges, findings`:
+
+```python
+    _add_js_web_findings(source, lines, rel, findings)
+```
+
+> The `_NEXT_PUBLIC_RE` intentionally requires a secret-ish token after the `NEXT_PUBLIC_` prefix; verify against the test cases that `NEXT_PUBLIC_API_URL` does NOT match (it must not) while `NEXT_PUBLIC_STRIPE_SECRET_KEY` does. Adjust the alternation if a test case reveals an over/under-match — keep `NEXT_PUBLIC_API_URL` clean.
+
+- [ ] **Step 4: Run tests + ruff**
+
+Run: `pytest tests/test_js_cors_nextjs.py -v` — Expected: PASS.
+Run: `ruff check src/cybergraph/analysis/javascript.py tests/test_js_cors_nextjs.py` — Expected: clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/analysis/javascript.py tests/test_js_cors_nextjs.py
+git commit -m "feat(analysis): detect Express credentialed-wildcard CORS and NEXT_PUBLIC secrets"
+```
+
+---
+
+## Task 3: Activate the two web capabilities
+
+**Files:**
+- Modify: `src/cybergraph/security/capability.py`
+- Modify: `src/cybergraph/security/coverage.py`
+- Modify: `src/cybergraph/security/checks.py`
+- Modify: any test asserting `client_secret_boundary`/`cross_origin_policy` unsupported
+- Test: `tests/test_web_capabilities.py` (create)
+
+**Interfaces:**
+- Consumes: rule ids from Tasks 1–2.
+- Produces: `client_secret_boundary` `supported=True`; new `cross_origin_policy` capability with `covers=CORS_GLOBS` (`PYTHON_GLOBS + WEB_GLOBS`); `_FINDING_RULES` entries for both; a coverage gate that treats web files as verified so these capabilities can PASS/FAIL.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_web_capabilities.py`:
+
+```python
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from cybergraph.security.capability import CAPABILITIES, FAIL
+from cybergraph.security.check import check_change
+from cybergraph.security.verdict import STATE_REVIEW
+
+
+def _cap(cid):
+    return next(c for c in CAPABILITIES if c.id == cid)
+
+
+def test_both_web_capabilities_supported():
+    assert _cap("client_secret_boundary").supported is True
+    assert _cap("cross_origin_policy").supported is True
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for a in (["init", "-q"], ["config", "user.email", "t@e.com"], ["config", "user.name", "t"]):
+        subprocess.run(["git", "-C", str(repo), *a], check=True)
+    (repo / "README.md").write_text("# x\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "base"], check=True)
+    return repo
+
+
+def test_python_credentialed_cors_reviews(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "main.py").write_text(
+        "from fastapi.middleware.cors import CORSMiddleware\n"
+        "app.add_middleware(CORSMiddleware, allow_origins=['*'], allow_credentials=True)\n",
+        encoding="utf-8",
+    )
+    verdict = check_change(repo, mode="worktree")
+    assert verdict.state == STATE_REVIEW
+    assert any(c.capability_id == "cross_origin_policy" and c.status == FAIL
+               for c in verdict.checks)
+
+
+def test_next_public_secret_reviews(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "config.ts").write_text(
+        "export const k = process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY;\n", encoding="utf-8"
+    )
+    verdict = check_change(repo, mode="worktree")
+    assert verdict.state == STATE_REVIEW
+    assert any(c.capability_id == "client_secret_boundary" and c.status == FAIL
+               for c in verdict.checks)
+```
+
+> Note: confirm `check_change`/`Verdict.checks`/`CheckResult` names against source before finalizing. A `.py`/`.ts` change will also make `source_analysis_support` review (JS) or run other Python capabilities — assert only on the specific capability id + FAIL and the overall REVIEW state, as written.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/test_web_capabilities.py -v` — Expected: FAIL (capabilities not supported / no FAIL).
+
+- [ ] **Step 3: Activate the capabilities**
+
+In `capability.py`: add `CORS_GLOBS = PYTHON_GLOBS + WEB_GLOBS` near the other `*_GLOBS`. Change the `client_secret_boundary` entry's last field from `False` to `True`. Add a new entry to `CAPABILITIES`:
+
+```python
+    Capability("cross_origin_policy", "Cross-origin resource sharing", CORS_GLOBS, True),
+```
+
+- [ ] **Step 4: Track web files as verified in coverage**
+
+In `coverage.py`, import `WEB_GLOBS` and add it to the verified gate so an analyzed web file is `ANALYZED` (able to PASS) rather than `UNSUPPORTED`:
+
+```python
+from cybergraph.security.capability import CONFIG_GLOBS, SOURCE_GLOBS, VERIFIED_GLOBS, WEB_GLOBS
+```
+
+and change the UNSUPPORTED gate to:
+
+```python
+        elif not any(fnmatch(file, pattern) for pattern in VERIFIED_GLOBS + CONFIG_GLOBS + WEB_GLOBS):
+```
+
+> This does NOT change `source_analysis_support`: that capability decides NOT_SUPPORTED via `unverified_source_files` (VERIFIED_GLOBS), which is unchanged, and it pre-filters web files out before consulting coverage. A changed `.js` therefore still makes `source_analysis_support` NOT_SUPPORTED (JS is inventory-grade) while `cross_origin_policy`/`client_secret_boundary` can now PASS/FAIL on it. Verify a Go file (no web glob) stays UNSUPPORTED.
+
+- [ ] **Step 5: Map the rule ids**
+
+In `checks.py`, add to `_FINDING_RULES`:
+
+```python
+    "client_secret_boundary": "CG-CLIENT-SECRET-EXPOSED",
+    "cross_origin_policy": "CG-CORS-CREDENTIALED-WILDCARD",
+```
+
+(Single-rule strings; the existing `{rule} if isinstance(rule, str) else set(rule)` normalization handles them.)
+
+- [ ] **Step 6: Update stale unsupported expectations**
+
+Run `grep -rn "client_secret_boundary\|cross_origin_policy\|NOT_SUPPORTED" tests/` and update any assertion that expected `client_secret_boundary` to be unsupported to the new supported behavior. Change only the expectation, never production code, and never weaken an unrelated assertion. (A `decide()` unit test that constructs a `CheckResult("client_secret_boundary", NOT_SUPPORTED)` by hand is still valid — it tests `decide`, not the capability's flag — leave it unless it asserts the flag.)
+
+- [ ] **Step 7: Run tests + ruff**
+
+Run: `pytest tests/test_web_capabilities.py tests/test_capability.py tests/test_checks.py tests/test_coverage_report.py tests/test_verdict.py -v` — Expected: PASS.
+Run: `ruff check src/cybergraph/security/capability.py src/cybergraph/security/coverage.py src/cybergraph/security/checks.py tests/test_web_capabilities.py` — Expected: clean.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/cybergraph/security/capability.py src/cybergraph/security/coverage.py src/cybergraph/security/checks.py tests/
+git commit -m "feat(verdict): activate cross-origin and client-secret-boundary capabilities"
+```
+
+---
+
+## Task 4: Mutation harness + docs + full verification
+
+**Files:**
+- Modify: `benchmark/mutation_harness.py` (two seeded fail-opens)
+- Modify: `README.md` (one line)
+- Verification: full suite, ruff, harness, precision/eval.
+
+**Interfaces:** consumes the finished detectors (Tasks 1–2) and wiring (Task 3).
+
+- [ ] **Step 1: Add the mutations**
+
+Append two `Mutation` entries to `MUTATIONS` in `benchmark/mutation_harness.py`. Match every `old` string to committed source verbatim (open the files; fix the `old` string if it differs — never edit source to fit the mutation).
+
+Mutation A — Python CORS fail-open: the detector is short-circuited so a real credentialed wildcard is never flagged. Target the credentials guard in `python.py`'s `_add_cors_findings` and turn it into an unconditional `continue` (skip every CORS call):
+- `old` = `        if not _kw_is_true(kw.get("allow_credentials")):\n            continue`
+- `new` = `        if True:\n            continue`
+- `tests` = `("tests/test_python_cors.py::test_credentialed_wildcard_is_flagged",)`
+- id `D9-cors-credentialed-wildcard-missed`, disaster `D9`, note "a credentialed-wildcard CORS must be flagged, never dropped".
+
+  (Suppressing emission — not `if False` — is what makes `test_credentialed_wildcard_is_flagged` go red; `if False` would still flag the credentialed case and merely add false positives, which a fail-open test does not catch.)
+
+Mutation B — Next.js secret fail-open (the client-boundary finding is never emitted). Target the append or the regex in `javascript.py`. Simplest robust target: the `_NEXT_PUBLIC_RE` alternation, replacing the secret keywords with a token that cannot match a real name:
+- `old` = the exact `_NEXT_PUBLIC_RE = re.compile(` line block — copy the committed multi-line assignment verbatim; if multi-line editing is awkward, instead target the single guard line where the finding is appended (e.g. wrap the `NEXT_PUBLIC_` loop body so nothing is appended). The invariant under test: `test_next_public_secret_is_flagged` must FAIL under the mutation.
+- `new` = a form that makes the loop emit nothing (e.g. `_NEXT_PUBLIC_RE = re.compile(r"__CYBERGRAPH_NEVER_MATCHES__")`).
+- `tests` = `("tests/test_js_cors_nextjs.py::test_next_public_secret_is_flagged",)`
+- id `D9-client-secret-exposure-missed`, disaster `D9`, note "a NEXT_PUBLIC_ secret must be flagged, never missed".
+
+- [ ] **Step 2: Run the harness**
+
+Run: `python benchmark/mutation_harness.py` — Expected: every mutation CAUGHT, incl. the two new ones. (Use `--only`/`--id` if supported to iterate.)
+
+- [ ] **Step 3: Document in the README**
+
+Add near the analyzer/coverage list:
+
+```markdown
+- **CORS & client secrets** — a CORS policy allowing any origin *with credentials*
+  (FastAPI / Express), and secrets shipped to the browser via `NEXT_PUBLIC_`. A change
+  that introduces either is a REVIEW.
+```
+
+- [ ] **Step 4: Full verification**
+
+Run: `pytest -q` — Expected: all pass.
+Run: `ruff check .` — Expected: no new errors beyond the repo's pre-existing baseline.
+Run: `python benchmark/mutation_harness.py` — Expected: every mutation CAUGHT.
+Run: `python benchmark/run_precision.py` and `python benchmark/run_eval.py` — Expected: unchanged (1.0/1.0/1.0). **Additionally confirm the new CORS rule does not fire on any precision-corpus fixture** (a false positive there would change the numbers) — if it does, tighten the detector, do not adjust the corpus.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add benchmark/mutation_harness.py README.md
+git commit -m "test(web): seed CORS/client-secret fail-open mutations; document coverage"
+```
+
+---
+
+## Notes for the executor
+
+- **Precision is cardinal.** Prefer no finding to a false one; if a CORS config or a `NEXT_PUBLIC_` name is ambiguous, emit nothing and note the recall gap.
+- Confirm dataclass/field names (`Finding`, `CheckResult`, `Verdict`, `_callable_name`) against source before running each task's tests; adapt the test to the real names, never the reverse.
+- Read the raw `source`/`lines` for the JS detectors — the values needed (`origin: "*"`, the `NEXT_PUBLIC_` name) live inside string literals, which the analyzer's `code_lines` view blanks out.
+- Do NOT add wildcard-CORS-without-credentials detection, server-import-into-client analysis, a new CLI command, or any dependency — all out of scope (a later slice).

--- a/docs/superpowers/specs/2026-08-10-cors-client-boundary-design.md
+++ b/docs/superpowers/specs/2026-08-10-cors-client-boundary-design.md
@@ -1,0 +1,165 @@
+# CORS + Next.js Client-Secret Boundary — Design (Phase 2, slice 3)
+
+**Status:** approved for planning
+**Slice:** the config-posture roadmap's two *in-code* targets — CORS and the Next.js client/server
+boundary — deferred from slice 2 (declarative trio).
+**Predecessors:** verdict-core (merged), client hooks (#43, merged), config-posture declarative
+trio (#44, open). This branch is **stacked on `feat/config-posture`** because it edits
+`capability.py`/`checks.py`, which #44 also changed; it rebases onto `main` once #44 merges.
+
+## The sentence this slice is judged against
+
+> CyberGraph can catch the two most common web exposures that live in code — a CORS policy that
+> lets any origin call a credentialed API, and a secret marked to ship to the browser via
+> `NEXT_PUBLIC_` — turning either regression into a REVIEW, precisely, without false alarms on a
+> scoped CORS config or a public-by-design value.
+
+## Why this is the right slice
+
+- CORS misconfiguration and client-bundled secrets are among the most frequent real web
+  vulnerabilities, and both are *code*, not declarative config — so they complete the
+  config-posture theme where slice 2's file-parsers could not reach.
+- The `client_secret_boundary` capability already exists as a declared-but-absent placeholder
+  (`capability.py:80`, `supported=False`, label "Secrets reaching the browser", covers
+  `WEB_GLOBS`) — precisely for the Next.js case. This slice activates it.
+- Combined with the client hooks, a CORS or client-secret regression now surfaces as REVIEW at
+  the accept-the-diff moment.
+
+## Decisions already made (do not re-litigate in planning)
+
+1. **Two targets, two capabilities.** CORS is a Python-*and*-JS access-control concern, distinct
+   from "secrets reaching the browser" (JS/TS only). CORS gets a NEW `cross_origin_policy`
+   capability; the Next.js boundary activates the existing `client_secret_boundary`. Folding
+   both into one capability would be semantically wrong and would misattribute a Python CORS
+   finding to a browser-secret capability.
+2. **Precision over recall — the credentialed-wildcard combo only.** CORS flags only a wildcard
+   (or reflect-all) origin *together with* credentials enabled — the combination that actually
+   lets any site make authenticated cross-origin calls. A scoped origin list, or a wildcard
+   *without* credentials, is clean. (Wildcard-without-credentials as a separate medium-severity
+   finding is explicitly deferred.)
+3. **Next.js: `NEXT_PUBLIC_<secret-name>` only.** A `NEXT_PUBLIC_`-prefixed identifier whose name
+   also matches the secret heuristic is a definite client-bundle leak. The harder "server-only
+   value imported into a `"use client"` component" needs import-graph analysis and is FP-prone —
+   deferred to a follow-up.
+
+## Architecture — extend two analyzers, wire two capabilities
+
+```
+src/cybergraph/analysis/python.py       (modify)  FastAPI CORSMiddleware credentialed-wildcard
+src/cybergraph/analysis/javascript.py   (modify)  Express cors() credentialed-wildcard; NEXT_PUBLIC_ secret
+src/cybergraph/security/capability.py   (modify)  activate client_secret_boundary; add cross_origin_policy
+src/cybergraph/security/checks.py       (modify)  _FINDING_RULES: add both rule ids
+```
+
+New rule ids (findings carry a CWE + verbatim evidence line, honor inline suppressions, mirror
+the existing analyzers' `Finding(...)` shape):
+
+- **`CG-CORS-CREDENTIALED-WILDCARD`** (CWE-942) — emitted by both `python.py` and `javascript.py`.
+- **`CG-CLIENT-SECRET-EXPOSED`** (CWE-200) — emitted by `javascript.py`.
+
+### CORS detection (`CG-CORS-CREDENTIALED-WILDCARD`, CWE-942)
+
+- **Python / FastAPI (`python.py`):** an `add_middleware(CORSMiddleware, …)` or
+  `CORSMiddleware(…)` call where `allow_origins` contains `"*"` (or `allow_origin_regex` is an
+  all-matching pattern such as `".*"`/`"*"`) **and** `allow_credentials=True`. Because
+  `python.py` is AST-based, read the keyword arguments precisely: the finding requires BOTH the
+  wildcard-origin keyword and the credentials-true keyword on the same call. Neither alone fires.
+- **JavaScript / Express (`javascript.py`):** a `cors({ … })` call with `origin: "*"` or
+  `origin: true` **and** `credentials: true`, or a bare `cors()` (no options → allows all
+  origins) used as middleware. `javascript.py` is line/regex-based; match the `cors(` call and
+  its option object conservatively, requiring both signals (or the bare-`cors()` all-origins
+  case, which is credential-permissive by default in common setups — pinned in the plan).
+- Evidence is the call's line; the CWE is 942 (permissive cross-domain policy).
+
+### Next.js client-secret boundary (`CG-CLIENT-SECRET-EXPOSED`, CWE-200)
+
+- In `javascript.py`: a `NEXT_PUBLIC_`-prefixed identifier (typically `process.env.NEXT_PUBLIC_…`,
+  but any `NEXT_PUBLIC_<NAME>` token) whose `<NAME>` matches the secret heuristic
+  (`SECRET`/`KEY`/`TOKEN`/`PASSWORD`/`PASSWD`/`APIKEY`, case-insensitive — reuse/extend the
+  existing `SECRET_MARKERS` logic). `NEXT_PUBLIC_` inlines the value into the browser bundle, so
+  a secret-named one is a definite leak. `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_APP_NAME`, etc. are
+  public by design → no finding. CWE-200 (exposure of sensitive information).
+
+## Verdict integration — one activation, one new capability
+
+- `capability.py`: `client_secret_boundary` → `supported=True` (covers `WEB_GLOBS`, unchanged).
+  Add `Capability("cross_origin_policy", "Cross-origin resource sharing", CORS_GLOBS, True)`
+  where `CORS_GLOBS = PYTHON_GLOBS + WEB_GLOBS` (CORS occurs in both).
+- `checks.py`: `_FINDING_RULES["client_secret_boundary"] = "CG-CLIENT-SECRET-EXPOSED"` and
+  `_FINDING_RULES["cross_origin_policy"] = "CG-CORS-CREDENTIALED-WILDCARD"` (single-rule strings;
+  the slice-2 set-normalization in `_evaluate` handles both str and set values already).
+- Five-state via the existing coverage machinery: **FAIL** when a changed in-scope file carries
+  the finding; **UNKNOWN** when a changed in-scope file failed/has no analysis record;
+  **NOT_APPLICABLE** when no in-scope file changed; **PASS** on analyzed-clean positive evidence.
+- Coverage already tracks `*.py` (VERIFIED_GLOBS) and — since Python's analyzer finds these —
+  the web globs must be covered too. Web files are in `SOURCE_GLOBS` but only `*.py` is in
+  `VERIFIED_GLOBS`, so a changed `.ts`/`.js` currently reads `UNSUPPORTED` for source analysis.
+  This slice must ensure the two web capabilities can reach PASS/FAIL on web files rather than
+  perpetual UNKNOWN/NOT_SUPPORTED. **The plan pins how** (e.g. the JS analyzer already produces
+  File nodes and findings, so treat web globs as verified for these capabilities' coverage
+  lookup, mirroring how slice 2 added `CONFIG_GLOBS` to the coverage verified set) — without
+  making the unrelated `source_analysis_support` capability claim JS is fully verified.
+
+> This coverage subtlety is the load-bearing correctness point (as it was in slice 2): a web
+> file that could not be analyzed must read UNKNOWN, and an analyzed-clean one must be able to
+> PASS. The plan resolves it explicitly and tests it.
+
+## Error handling
+
+- A `.py`/`.js` that fails to parse → the analyzer's existing containment (`CG-FILE-UNREADABLE`
+  / `PY-SYNTAX`) → coverage FAILED → UNKNOWN, never a silent PASS.
+- A `cors(` call whose options CyberGraph cannot resolve (dynamic origin, a variable) → no
+  finding (precision-first; an unresolved config is not asserted insecure). Documented recall gap.
+- A `NEXT_PUBLIC_` name that is ambiguous (not clearly secret) → no finding.
+
+## Testing
+
+- **Python CORS units:** credentialed wildcard → finding; scoped origins → none; wildcard
+  without credentials → none; `allow_origin_regex=".*"` + credentials → finding.
+- **JS CORS units:** `cors({origin:"*", credentials:true})` → finding; `cors({origin:["https://x"]})`
+  → none; bare `cors()` middleware → finding (pinned); scoped → none.
+- **Next.js units:** `process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY` → finding; `NEXT_PUBLIC_API_URL`
+  → none; a non-`NEXT_PUBLIC_` secret (server-side, `process.env.STRIPE_SECRET_KEY`) → none for
+  this rule (it is not a client-boundary leak).
+- **Capability five-state** for both `cross_origin_policy` and `client_secret_boundary`.
+- **End-to-end:** `cybergraph check` returns REVIEW on a diff that opens credentialed-wildcard
+  CORS, and on a diff that adds a `NEXT_PUBLIC_` secret; a scoped/clean change ACCEPTs.
+- **Mutation harness:** two seeded fail-opens (a CORS/credentialed finding read as PASS; a web
+  file that failed analysis read PASS instead of UNKNOWN), each red under its guard test.
+- Full suite green; ruff clean; `run_precision.py`/`run_eval.py` unchanged (they exercise the
+  Python security corpus, which this slice's new rules do not alter — confirm the CORS rule does
+  not fire on any corpus fixture).
+
+## Global constraints (inherited, unchanged)
+
+- Python 3.10–3.13. **Zero runtime dependencies**; standard library only (`ast`, `re`).
+- Ruff line-length 100; `from __future__ import annotations` in every file.
+- No network; no API keys on any default path.
+- **Precision over recall:** an ambiguous or unresolved config yields no finding; document the
+  recall gap rather than risk a false alarm.
+- Commits authored `Laraib <lxh417bham@gmail.com>` only; no `Co-Authored-By`, no AI attribution.
+  Many small commits; never squash. Push only to `https://github.com/AQ-Labs/cybergraph`.
+
+## Roadmap alignment — what this does NOT touch
+
+Builds CORS + the `NEXT_PUBLIC_` secret boundary and activates the two capabilities. Deliberately
+excluded: wildcard-CORS-without-credentials (deferred medium-severity), server-only-import-into-
+client-component (needs import-graph analysis), the non-Python verdict upgrade, the declarative
+trio (shipped in slice 2), and any new CLI command. `secret_server_only` policy and the typed
+authorization ontology remain future work.
+
+## Success criteria
+
+1. FastAPI credentialed-wildcard CORS → `CG-CORS-CREDENTIALED-WILDCARD`; scoped or
+   non-credentialed is clean.
+2. Express `cors()` credentialed-wildcard (and the bare-`cors()` all-origins case) → the same
+   rule; a scoped `cors({origin:[…]})` is clean.
+3. `NEXT_PUBLIC_<secret-name>` → `CG-CLIENT-SECRET-EXPOSED`; a public-by-design `NEXT_PUBLIC_`
+   name and a server-side secret are clean.
+4. `client_secret_boundary` is `supported=True`; `cross_origin_policy` is added and supported;
+   both return FAIL→REVIEW on a changed file that regresses, PASS on analyzed-clean,
+   NOT_APPLICABLE off-scope, UNKNOWN on unparsed — and a changed web file can actually reach
+   PASS/FAIL (not perpetual UNKNOWN).
+5. `cybergraph check` returns REVIEW end-to-end on both regressions (so the hooks catch them).
+6. Full suite green; ruff clean; the mutation harness catches both seeded fail-opens;
+   `run_precision.py`/`run_eval.py` unchanged.

--- a/docs/superpowers/specs/2026-08-10-cors-client-boundary-design.md
+++ b/docs/superpowers/specs/2026-08-10-cors-client-boundary-design.md
@@ -64,21 +64,30 @@ the existing analyzers' `Finding(...)` shape):
   all-matching pattern such as `".*"`/`"*"`) **and** `allow_credentials=True`. Because
   `python.py` is AST-based, read the keyword arguments precisely: the finding requires BOTH the
   wildcard-origin keyword and the credentials-true keyword on the same call. Neither alone fires.
-- **JavaScript / Express (`javascript.py`):** a `cors({ … })` call with `origin: "*"` or
-  `origin: true` **and** `credentials: true`, or a bare `cors()` (no options → allows all
-  origins) used as middleware. `javascript.py` is line/regex-based; match the `cors(` call and
-  its option object conservatively, requiring both signals (or the bare-`cors()` all-origins
-  case, which is credential-permissive by default in common setups — pinned in the plan).
+- **JavaScript / Express (`javascript.py`):** a `cors({ … })` call whose options object sets
+  `origin: "*"` / `origin: '*'` / `origin: true` **and** `credentials: true`. Both signals are
+  required. `javascript.py` is line/regex-based; match the `cors(` call and its option object
+  conservatively. **A bare `cors()` is CLEAN** — it defaults `credentials: false`, i.e. a
+  wildcard origin *without* credentials, which Decision 2 declares clean; flagging it would
+  contradict the credentialed-wildcard-only rule. (Erratum: an earlier draft of this spec said
+  a bare `cors()` should flag; that was inconsistent with Decision 2 and is corrected here — the
+  implementation does not flag it.)
 - Evidence is the call's line; the CWE is 942 (permissive cross-domain policy).
 
 ### Next.js client-secret boundary (`CG-CLIENT-SECRET-EXPOSED`, CWE-200)
 
 - In `javascript.py`: a `NEXT_PUBLIC_`-prefixed identifier (typically `process.env.NEXT_PUBLIC_…`,
-  but any `NEXT_PUBLIC_<NAME>` token) whose `<NAME>` matches the secret heuristic
-  (`SECRET`/`KEY`/`TOKEN`/`PASSWORD`/`PASSWD`/`APIKEY`, case-insensitive — reuse/extend the
-  existing `SECRET_MARKERS` logic). `NEXT_PUBLIC_` inlines the value into the browser bundle, so
-  a secret-named one is a definite leak. `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_APP_NAME`, etc. are
-  public by design → no finding. CWE-200 (exposure of sensitive information).
+  but any `NEXT_PUBLIC_<NAME>` token) whose `<NAME>` contains, as a whole `_`-delimited **segment**
+  (not a substring), a secret keyword. Two tiers: a strong-secret segment
+  (`SECRET`/`TOKEN`/`PASSWORD`/`PASSWD`/`PRIVATE`/`CREDENTIAL(S)`) always flags; a key-like
+  segment (`KEY`/`APIKEY`) flags **only when the name has no public-by-design marker segment**
+  (`PUBLIC`/`PUBLISHABLE`). This keeps `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` and
+  `NEXT_PUBLIC_PUBLIC_KEY` clean (a Stripe publishable key is *designed* to ship to the browser)
+  while `NEXT_PUBLIC_API_KEY` / `NEXT_PUBLIC_STRIPE_SECRET_KEY` flag. Segment-matching (not
+  substring) is why `NEXT_PUBLIC_TURNKEY_URL` / `MONKEY` / `KEYBOARD` are clean.
+  `NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_APP_NAME`, etc. are public by design → no finding.
+  `NEXT_PUBLIC_` inlines the value into the browser bundle, so a strong-secret-named one is a
+  definite leak. CWE-200 (exposure of sensitive information).
 
 ## Verdict integration — one activation, one new capability
 
@@ -117,7 +126,7 @@ the existing analyzers' `Finding(...)` shape):
 - **Python CORS units:** credentialed wildcard → finding; scoped origins → none; wildcard
   without credentials → none; `allow_origin_regex=".*"` + credentials → finding.
 - **JS CORS units:** `cors({origin:"*", credentials:true})` → finding; `cors({origin:["https://x"]})`
-  → none; bare `cors()` middleware → finding (pinned); scoped → none.
+  → none; bare `cors()` middleware → **none** (credentials default off); scoped → none.
 - **Next.js units:** `process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY` → finding; `NEXT_PUBLIC_API_URL`
   → none; a non-`NEXT_PUBLIC_` secret (server-side, `process.env.STRIPE_SECRET_KEY`) → none for
   this rule (it is not a client-boundary leak).
@@ -152,8 +161,8 @@ authorization ontology remain future work.
 
 1. FastAPI credentialed-wildcard CORS → `CG-CORS-CREDENTIALED-WILDCARD`; scoped or
    non-credentialed is clean.
-2. Express `cors()` credentialed-wildcard (and the bare-`cors()` all-origins case) → the same
-   rule; a scoped `cors({origin:[…]})` is clean.
+2. Express `cors({origin:"*"/true, credentials:true})` → the same rule; a scoped
+   `cors({origin:[…]})` and a bare `cors()` (credentials default off) are clean.
 3. `NEXT_PUBLIC_<secret-name>` → `CG-CLIENT-SECRET-EXPOSED`; a public-by-design `NEXT_PUBLIC_`
    name and a server-side secret are clean.
 4. `client_secret_boundary` is `supported=True`; `cross_origin_policy` is added and supported;

--- a/src/cybergraph/analysis/javascript.py
+++ b/src/cybergraph/analysis/javascript.py
@@ -79,12 +79,24 @@ SECRET_EXPOSURE_SINKS = {
 _CORS_CALL_RE = re.compile(r"\bcors\s*\(\s*\{")
 _ORIGIN_ALL_RE = re.compile(r"""origin\s*:\s*(?:['"]\*['"]|true)""")
 _CREDENTIALS_TRUE_RE = re.compile(r"credentials\s*:\s*true")
-_NEXT_PUBLIC_RE = re.compile(
-    r"NEXT_PUBLIC_[A-Za-z0-9_]*"
-    r"(?:SECRET|APIKEY|API_KEY|TOKEN|PASSWORD|PASSWD|PRIVATE|_KEY|KEY)"
-    r"[A-Za-z0-9_]*",
-    re.IGNORECASE,
-)
+_NEXT_PUBLIC_RE = re.compile(r"NEXT_PUBLIC_[A-Za-z0-9_]+")
+_SECRET_SEGMENTS = {
+    "SECRET",
+    "KEY",
+    "TOKEN",
+    "PASSWORD",
+    "PASSWD",
+    "APIKEY",
+    "PRIVATE",
+    "CREDENTIAL",
+    "CREDENTIALS",
+}
+
+
+def _next_public_is_secret(name: str) -> bool:
+    # name like "NEXT_PUBLIC_STRIPE_SECRET_KEY" -> segments after the prefix
+    segments = name.upper().split("_")
+    return any(seg in _SECRET_SEGMENTS for seg in segments)
 
 
 def analyze_javascript_file(
@@ -364,15 +376,31 @@ def _language(path: Path) -> str:
 
 
 def _brace_object(source: str, open_index: int) -> tuple[str, int]:
-    """From the '{' at open_index, return (object_text, end_index) at its match."""
+    """From the '{' at open_index, return (object_text, end_index) at its match.
+
+    String-literal-aware: braces inside quoted strings (single, double, or
+    backtick, with backslash escapes) do not affect the depth count.
+    """
     depth = 0
-    for i in range(open_index, len(source)):
-        if source[i] == "{":
+    quote: str | None = None
+    i = open_index
+    while i < len(source):
+        c = source[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"`":
+            quote = c
+        elif c == "{":
             depth += 1
-        elif source[i] == "}":
+        elif c == "}":
             depth -= 1
             if depth == 0:
                 return source[open_index : i + 1], i
+        i += 1
     return source[open_index:], len(source)
 
 
@@ -405,6 +433,8 @@ def _add_js_web_findings(
     # Next.js: a NEXT_PUBLIC_ name that looks like a secret -> inlined into the bundle.
     seen: set[int] = set()
     for m in _NEXT_PUBLIC_RE.finditer(source):
+        if not _next_public_is_secret(m.group(0)):
+            continue
         line_no = _line_of(source, m.start())
         if line_no in seen:
             continue

--- a/src/cybergraph/analysis/javascript.py
+++ b/src/cybergraph/analysis/javascript.py
@@ -80,23 +80,34 @@ _CORS_CALL_RE = re.compile(r"\bcors\s*\(\s*\{")
 _ORIGIN_ALL_RE = re.compile(r"""origin\s*:\s*(?:['"]\*['"]|true)""")
 _CREDENTIALS_TRUE_RE = re.compile(r"credentials\s*:\s*true")
 _NEXT_PUBLIC_RE = re.compile(r"NEXT_PUBLIC_[A-Za-z0-9_]+")
-_SECRET_SEGMENTS = {
+_STRONG_SECRET_SEGMENTS = {
     "SECRET",
-    "KEY",
     "TOKEN",
     "PASSWORD",
     "PASSWD",
-    "APIKEY",
     "PRIVATE",
     "CREDENTIAL",
     "CREDENTIALS",
 }
+_KEYLIKE_SEGMENTS = {"KEY", "APIKEY"}
+_PUBLIC_MARKER_SEGMENTS = {"PUBLIC", "PUBLISHABLE"}
 
 
 def _next_public_is_secret(name: str) -> bool:
-    # name like "NEXT_PUBLIC_STRIPE_SECRET_KEY" -> segments after the prefix
-    segments = name.upper().split("_")
-    return any(seg in _SECRET_SEGMENTS for seg in segments)
+    # name like "NEXT_PUBLIC_STRIPE_SECRET_KEY" -> segments after the prefix.
+    # A strong secret segment always flags. A key-like segment only flags when
+    # the name has no public-by-design marker (e.g. Stripe publishable keys are
+    # meant to ship to the browser and should not false-flag). The NEXT_PUBLIC_
+    # prefix itself is stripped first so its own literal "PUBLIC" segment can't
+    # be mistaken for an explicit public-by-design marker on the suffix.
+    upper = name.upper()
+    suffix = upper[len("NEXT_PUBLIC_"):] if upper.startswith("NEXT_PUBLIC_") else upper
+    segments = set(suffix.split("_"))
+    if _STRONG_SECRET_SEGMENTS & segments:
+        return True
+    if _KEYLIKE_SEGMENTS & segments and not (_PUBLIC_MARKER_SEGMENTS & segments):
+        return True
+    return False
 
 
 def analyze_javascript_file(

--- a/src/cybergraph/analysis/javascript.py
+++ b/src/cybergraph/analysis/javascript.py
@@ -76,6 +76,16 @@ SECRET_EXPOSURE_SINKS = {
     "child_process.exec",
 }
 
+_CORS_CALL_RE = re.compile(r"\bcors\s*\(\s*\{")
+_ORIGIN_ALL_RE = re.compile(r"""origin\s*:\s*(?:['"]\*['"]|true)""")
+_CREDENTIALS_TRUE_RE = re.compile(r"credentials\s*:\s*true")
+_NEXT_PUBLIC_RE = re.compile(
+    r"NEXT_PUBLIC_[A-Za-z0-9_]*"
+    r"(?:SECRET|APIKEY|API_KEY|TOKEN|PASSWORD|PASSWD|PRIVATE|_KEY|KEY)"
+    r"[A-Za-z0-9_]*",
+    re.IGNORECASE,
+)
+
 
 def analyze_javascript_file(
     path: Path,
@@ -218,6 +228,7 @@ def analyze_javascript_file(
                     )
 
     _add_imports(lines, rel, edges)
+    _add_js_web_findings(source, lines, rel, findings)
     return nodes, edges, findings
 
 
@@ -350,3 +361,65 @@ def _is_secret_exposure(call_name: str) -> bool:
 
 def _language(path: Path) -> str:
     return "typescript" if path.suffix.lower() in {".ts", ".tsx"} else "javascript"
+
+
+def _brace_object(source: str, open_index: int) -> tuple[str, int]:
+    """From the '{' at open_index, return (object_text, end_index) at its match."""
+    depth = 0
+    for i in range(open_index, len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[open_index : i + 1], i
+    return source[open_index:], len(source)
+
+
+def _line_of(source: str, index: int) -> int:
+    return source.count("\n", 0, index) + 1
+
+
+def _add_js_web_findings(
+    source: str, lines: list[str], rel: str, findings: list[Finding]
+) -> None:
+    # CORS: cors({ ... origin:*/true ... credentials:true ... })
+    for m in _CORS_CALL_RE.finditer(source):
+        obj, _end = _brace_object(source, m.end() - 1)
+        if _ORIGIN_ALL_RE.search(obj) and _CREDENTIALS_TRUE_RE.search(obj):
+            line_no = _line_of(source, m.start())
+            if is_inline_suppressed(lines, line_no, "CG-CORS-CREDENTIALED-WILDCARD"):
+                continue
+            findings.append(
+                Finding(
+                    rule_id="CG-CORS-CREDENTIALED-WILDCARD",
+                    severity="high",
+                    message="CORS allows any origin with credentials "
+                            "(origin '*'/true + credentials: true)",
+                    file_path=rel,
+                    line_start=line_no,
+                    cwe="CWE-942",
+                    evidence=lines[line_no - 1].strip() if 0 < line_no <= len(lines) else "",
+                )
+            )
+    # Next.js: a NEXT_PUBLIC_ name that looks like a secret -> inlined into the bundle.
+    seen: set[int] = set()
+    for m in _NEXT_PUBLIC_RE.finditer(source):
+        line_no = _line_of(source, m.start())
+        if line_no in seen:
+            continue
+        seen.add(line_no)
+        if is_inline_suppressed(lines, line_no, "CG-CLIENT-SECRET-EXPOSED"):
+            continue
+        findings.append(
+            Finding(
+                rule_id="CG-CLIENT-SECRET-EXPOSED",
+                severity="high",
+                message=f"`{m.group(0)}` ships a secret to the browser bundle "
+                        "(NEXT_PUBLIC_ is inlined client-side)",
+                file_path=rel,
+                line_start=line_no,
+                cwe="CWE-200",
+                evidence=lines[line_no - 1].strip() if 0 < line_no <= len(lines) else "",
+            )
+        )

--- a/src/cybergraph/analysis/python.py
+++ b/src/cybergraph/analysis/python.py
@@ -165,6 +165,7 @@ def analyze_python_file(
                     edges.append(Edge(EDGE_SANITIZES, key, call_name, rel, line_no))
 
     _add_django_url_routes(tree, rel, nodes, edges)
+    _add_cors_findings(tree, rel, lines, findings)
     _add_imports(tree, rel, edges)
     return nodes, edges, findings
 
@@ -508,6 +509,62 @@ def _add_django_url_routes(tree: ast.AST, rel: str, nodes: list[Node], edges: li
         view_name = _callable_name(call.args[1])
         if view_name:
             edges.append(Edge("CALLS", key, view_name, rel, line_no))
+
+
+def _cors_allows_all(origins: ast.AST | None, regex: ast.AST | None) -> bool:
+    if isinstance(origins, (ast.List, ast.Tuple)):
+        if any(isinstance(e, ast.Constant) and e.value == "*" for e in origins.elts):
+            return True
+    if isinstance(origins, ast.Constant) and origins.value == "*":
+        return True
+    if isinstance(regex, ast.Constant) and isinstance(regex.value, str):
+        if regex.value in {".*", "^.*$", "*", ".*$", "^.*", "(.*)"}:
+            return True
+    return False
+
+
+def _kw_is_true(node: ast.AST | None) -> bool:
+    return isinstance(node, ast.Constant) and node.value is True
+
+
+def _add_cors_findings(
+    tree: ast.AST, rel: str, lines: list[str], findings: list[Finding]
+) -> None:
+    """Flag a FastAPI/Starlette CORS middleware allowing any origin WITH credentials.
+
+    The credentialed wildcard is the real vulnerability: any site can make
+    authenticated cross-origin requests. A scoped origin list, or a wildcard
+    without credentials, is not flagged (precision over recall).
+    """
+    for call in (n for n in ast.walk(tree) if isinstance(n, ast.Call)):
+        name = _callable_name(call.func)
+        is_cors = name == "CORSMiddleware" or (
+            name.endswith("add_middleware")
+            and call.args
+            and _callable_name(call.args[0]) == "CORSMiddleware"
+        )
+        if not is_cors:
+            continue
+        kw = {k.arg: k.value for k in call.keywords if k.arg}
+        if not _cors_allows_all(kw.get("allow_origins"), kw.get("allow_origin_regex")):
+            continue
+        if not _kw_is_true(kw.get("allow_credentials")):
+            continue
+        line_no = getattr(call, "lineno", 1)
+        if is_inline_suppressed(lines, line_no, "CG-CORS-CREDENTIALED-WILDCARD"):
+            continue
+        findings.append(
+            Finding(
+                rule_id="CG-CORS-CREDENTIALED-WILDCARD",
+                severity="high",
+                message="CORS allows any origin with credentials "
+                        "(allow_origins '*' + allow_credentials=True)",
+                file_path=rel,
+                line_start=line_no,
+                cwe="CWE-942",
+                evidence=lines[line_no - 1].strip() if 0 < line_no <= len(lines) else "",
+            )
+        )
 
 
 def classify_name(

--- a/src/cybergraph/security/capability.py
+++ b/src/cybergraph/security/capability.py
@@ -46,6 +46,9 @@ SOURCE_GLOBS = (
 # The subset with a Phase 1 analyzer that produces findings.
 VERIFIED_GLOBS = PYTHON_GLOBS
 
+# CORS misconfiguration is checked in both the Python (FastAPI) and web layers.
+CORS_GLOBS = PYTHON_GLOBS + WEB_GLOBS
+
 # Declarative config surfaces with a Phase-2 posture analyzer. Kept narrow so a
 # changed config file that is analyzed-and-clean can PASS and an unparsed one
 # reads UNKNOWN -- broad globs (e.g. every *.yaml) would make unrelated changes
@@ -77,9 +80,10 @@ CAPABILITIES: tuple[Capability, ...] = (
                "New routes from the internet to sensitive code", PYTHON_GLOBS, True),
     Capability("source_analysis_support",
                "Languages CyberGraph can read", SOURCE_GLOBS, True),
-    Capability("client_secret_boundary", "Secrets reaching the browser", WEB_GLOBS, False),
+    Capability("client_secret_boundary", "Secrets reaching the browser", WEB_GLOBS, True),
     Capability("cloud_configuration",
                "Cloud and database configuration", CONFIG_GLOBS, True),
+    Capability("cross_origin_policy", "Cross-origin resource sharing", CORS_GLOBS, True),
 )
 
 _BY_ID = {capability.id: capability for capability in CAPABILITIES}

--- a/src/cybergraph/security/checks.py
+++ b/src/cybergraph/security/checks.py
@@ -47,6 +47,8 @@ _FINDING_RULES = {
         "CG-IAC-PUBLIC-BUCKET", "CG-IAC-WILDCARD-IAM", "CG-IAC-OPEN-INGRESS",
         "CG-IAC-HARDCODED-SECRET",
     },
+    "client_secret_boundary": "CG-CLIENT-SECRET-EXPOSED",
+    "cross_origin_policy": "CG-CORS-CREDENTIALED-WILDCARD",
 }
 
 _BY_ID = {capability.id: capability for capability in CAPABILITIES}

--- a/src/cybergraph/security/coverage.py
+++ b/src/cybergraph/security/coverage.py
@@ -17,7 +17,7 @@ from fnmatch import fnmatch
 from pathlib import Path
 
 from cybergraph.graph import GraphStore
-from cybergraph.security.capability import CONFIG_GLOBS, SOURCE_GLOBS, VERIFIED_GLOBS
+from cybergraph.security.capability import CONFIG_GLOBS, SOURCE_GLOBS, VERIFIED_GLOBS, WEB_GLOBS
 
 STATUS_ANALYZED = "analyzed"
 STATUS_FAILED = "failed"
@@ -67,7 +67,9 @@ def assess_coverage(
     for file in sources:
         if file in failed:
             results.append(FileCoverage(file, STATUS_FAILED, "the file could not be read"))
-        elif not any(fnmatch(file, pattern) for pattern in VERIFIED_GLOBS + CONFIG_GLOBS):
+        elif not any(
+            fnmatch(file, pattern) for pattern in VERIFIED_GLOBS + CONFIG_GLOBS + WEB_GLOBS
+        ):
             results.append(
                 FileCoverage(file, STATUS_UNSUPPORTED, "no analyzer for this language yet")
             )

--- a/tests/test_js_cors_nextjs.py
+++ b/tests/test_js_cors_nextjs.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cybergraph.analysis.javascript import analyze_javascript_file
+
+
+def _run(tmp_path: Path, name: str, src: str):
+    p = tmp_path / name
+    p.write_text(src, encoding="utf-8")
+    _n, _e, findings = analyze_javascript_file(p, tmp_path)
+    return [f.rule_id for f in findings]
+
+
+def test_express_credentialed_wildcard_cors_is_flagged(tmp_path):
+    src = "const cors = require('cors');\napp.use(cors({ origin: '*', credentials: true }));\n"
+    assert "CG-CORS-CREDENTIALED-WILDCARD" in _run(tmp_path, "server.js", src)
+
+
+def test_express_origin_true_with_credentials_is_flagged(tmp_path):
+    src = "app.use(cors({ origin: true, credentials: true }));\n"
+    assert "CG-CORS-CREDENTIALED-WILDCARD" in _run(tmp_path, "server.js", src)
+
+
+def test_scoped_cors_is_clean(tmp_path):
+    src = "app.use(cors({ origin: ['https://app.example.com'], credentials: true }));\n"
+    assert "CG-CORS-CREDENTIALED-WILDCARD" not in _run(tmp_path, "server.js", src)
+
+
+def test_bare_cors_is_clean(tmp_path):
+    src = "app.use(cors());\n"
+    assert "CG-CORS-CREDENTIALED-WILDCARD" not in _run(tmp_path, "server.js", src)
+
+
+def test_next_public_secret_is_flagged(tmp_path):
+    src = "const k = process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY;\n"
+    assert "CG-CLIENT-SECRET-EXPOSED" in _run(tmp_path, "config.ts", src)
+
+
+def test_next_public_url_is_clean(tmp_path):
+    src = "const u = process.env.NEXT_PUBLIC_API_URL;\n"
+    assert "CG-CLIENT-SECRET-EXPOSED" not in _run(tmp_path, "config.ts", src)
+
+
+def test_server_side_secret_is_not_a_client_boundary_finding(tmp_path):
+    src = "const k = process.env.STRIPE_SECRET_KEY;\n"
+    assert "CG-CLIENT-SECRET-EXPOSED" not in _run(tmp_path, "server.ts", src)

--- a/tests/test_js_cors_nextjs.py
+++ b/tests/test_js_cors_nextjs.py
@@ -45,3 +45,26 @@ def test_next_public_url_is_clean(tmp_path):
 def test_server_side_secret_is_not_a_client_boundary_finding(tmp_path):
     src = "const k = process.env.STRIPE_SECRET_KEY;\n"
     assert "CG-CLIENT-SECRET-EXPOSED" not in _run(tmp_path, "server.ts", src)
+
+
+def test_next_public_key_substring_names_are_clean(tmp_path):
+    src = (
+        "const a = process.env.NEXT_PUBLIC_TURNKEY_URL;\n"
+        "const b = process.env.NEXT_PUBLIC_MONKEY_ISLAND;\n"
+        "const c = process.env.NEXT_PUBLIC_KEYBOARD_LAYOUT;\n"
+    )
+    assert "CG-CLIENT-SECRET-EXPOSED" not in _run(tmp_path, "config.ts", src)
+
+
+def test_next_public_api_key_is_flagged(tmp_path):
+    src = "const k = process.env.NEXT_PUBLIC_API_KEY;\n"
+    assert "CG-CLIENT-SECRET-EXPOSED" in _run(tmp_path, "config.ts", src)
+
+
+def test_brace_string_with_stray_brace_does_not_false_flag(tmp_path):
+    src = (
+        "app.use(cors({ origin: '*', credentials: false, "
+        "fmt: 'status { code' }));\n"
+        "otherMiddleware({ credentials: true });\n"
+    )
+    assert "CG-CORS-CREDENTIALED-WILDCARD" not in _run(tmp_path, "server.js", src)

--- a/tests/test_js_cors_nextjs.py
+++ b/tests/test_js_cors_nextjs.py
@@ -61,6 +61,24 @@ def test_next_public_api_key_is_flagged(tmp_path):
     assert "CG-CLIENT-SECRET-EXPOSED" in _run(tmp_path, "config.ts", src)
 
 
+def test_publishable_key_is_clean(tmp_path):
+    src = (
+        "const a = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;\n"
+        "const b = process.env.NEXT_PUBLIC_PUBLIC_KEY;\n"
+    )
+    assert "CG-CLIENT-SECRET-EXPOSED" not in _run(tmp_path, "config.ts", src)
+
+
+def test_public_but_strong_secret_still_flags(tmp_path):
+    src = "const k = process.env.NEXT_PUBLIC_PUBLIC_SECRET_KEY;\n"
+    assert "CG-CLIENT-SECRET-EXPOSED" in _run(tmp_path, "config.ts", src)
+
+
+def test_api_key_still_flags(tmp_path):
+    src = "const k = process.env.NEXT_PUBLIC_API_KEY;\n"
+    assert "CG-CLIENT-SECRET-EXPOSED" in _run(tmp_path, "config.ts", src)
+
+
 def test_brace_string_with_stray_brace_does_not_false_flag(tmp_path):
     src = (
         "app.use(cors({ origin: '*', credentials: false, "

--- a/tests/test_python_cors.py
+++ b/tests/test_python_cors.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cybergraph.analysis.python import analyze_python_file
+
+
+def _run(tmp_path: Path, src: str):
+    p = tmp_path / "main.py"
+    p.write_text(src, encoding="utf-8")
+    _nodes, _edges, findings = analyze_python_file(p, tmp_path)
+    return [f.rule_id for f in findings]
+
+
+CRED_WILDCARD = """from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+app = FastAPI()
+app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True)
+"""
+
+SCOPED = """from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+app = FastAPI()
+app.add_middleware(
+    CORSMiddleware, allow_origins=["https://app.example.com"], allow_credentials=True
+)
+"""
+
+WILDCARD_NO_CREDS = """from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+app = FastAPI()
+app.add_middleware(CORSMiddleware, allow_origins=["*"])
+"""
+
+REGEX_ALL = """from starlette.middleware.cors import CORSMiddleware
+app.add_middleware(CORSMiddleware, allow_origin_regex=".*", allow_credentials=True)
+"""
+
+
+def test_credentialed_wildcard_is_flagged(tmp_path):
+    assert _run(tmp_path, CRED_WILDCARD) == ["CG-CORS-CREDENTIALED-WILDCARD"]
+
+
+def test_scoped_origin_is_clean(tmp_path):
+    assert "CG-CORS-CREDENTIALED-WILDCARD" not in _run(tmp_path, SCOPED)
+
+
+def test_wildcard_without_credentials_is_clean(tmp_path):
+    assert "CG-CORS-CREDENTIALED-WILDCARD" not in _run(tmp_path, WILDCARD_NO_CREDS)
+
+
+def test_regex_all_origins_with_credentials_is_flagged(tmp_path):
+    assert _run(tmp_path, REGEX_ALL) == ["CG-CORS-CREDENTIALED-WILDCARD"]

--- a/tests/test_web_capabilities.py
+++ b/tests/test_web_capabilities.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from cybergraph.security.capability import CAPABILITIES, FAIL
+from cybergraph.security.check import check_change
+from cybergraph.security.verdict import STATE_REVIEW
+
+
+def _cap(cid):
+    return next(c for c in CAPABILITIES if c.id == cid)
+
+
+def test_both_web_capabilities_supported():
+    assert _cap("client_secret_boundary").supported is True
+    assert _cap("cross_origin_policy").supported is True
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for a in (["init", "-q"], ["config", "user.email", "t@e.com"], ["config", "user.name", "t"]):
+        subprocess.run(["git", "-C", str(repo), *a], check=True)
+    (repo / "README.md").write_text("# x\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "base"], check=True)
+    return repo
+
+
+def test_python_credentialed_cors_reviews(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "main.py").write_text(
+        "from fastapi.middleware.cors import CORSMiddleware\n"
+        "app.add_middleware(CORSMiddleware, allow_origins=['*'], allow_credentials=True)\n",
+        encoding="utf-8",
+    )
+    verdict = check_change(repo, mode="worktree")
+    assert verdict.state == STATE_REVIEW
+    assert any(c.capability_id == "cross_origin_policy" and c.status == FAIL
+               for c in verdict.checks)
+
+
+def test_next_public_secret_reviews(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "config.ts").write_text(
+        "export const k = process.env.NEXT_PUBLIC_STRIPE_SECRET_KEY;\n", encoding="utf-8"
+    )
+    verdict = check_change(repo, mode="worktree")
+    assert verdict.state == STATE_REVIEW
+    assert any(c.capability_id == "client_secret_boundary" and c.status == FAIL
+               for c in verdict.checks)

--- a/tests/test_web_capabilities.py
+++ b/tests/test_web_capabilities.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
-from cybergraph.security.capability import CAPABILITIES, FAIL
+from cybergraph.security.capability import CAPABILITIES, FAIL, PASS
 from cybergraph.security.check import check_change
 from cybergraph.security.verdict import STATE_REVIEW
 
@@ -38,6 +38,16 @@ def test_python_credentialed_cors_reviews(tmp_path):
     verdict = check_change(repo, mode="worktree")
     assert verdict.state == STATE_REVIEW
     assert any(c.capability_id == "cross_origin_policy" and c.status == FAIL
+               for c in verdict.checks)
+
+
+def test_clean_web_file_passes_both_web_capabilities(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "app.ts").write_text("export const x = 1;\n", encoding="utf-8")
+    verdict = check_change(repo, mode="worktree")
+    assert any(c.capability_id == "cross_origin_policy" and c.status == PASS
+               for c in verdict.checks)
+    assert any(c.capability_id == "client_secret_boundary" and c.status == PASS
                for c in verdict.checks)
 
 


### PR DESCRIPTION
## What this does

Phase-2 slice 3 — the two *in-code* web exposures deferred from config-posture (slice 2). Extends the existing Python/JS analyzers and activates two capabilities so a change that introduces either returns REVIEW from `cybergraph check` (and therefore the client hooks).

- **CORS** (`CG-CORS-CREDENTIALED-WILDCARD`, CWE-942) — in **both** `python.py` (FastAPI `add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True)` / `allow_origin_regex=".*"`) and `javascript.py` (Express `cors({ origin: "*"|true, credentials: true })`). Only the **credentialed-wildcard combo** is flagged — a scoped origin list, a wildcard *without* credentials, and a bare `cors()` (credentials default off) are all clean.
- **Next.js client-secret boundary** (`CG-CLIENT-SECRET-EXPOSED`, CWE-200) — a `NEXT_PUBLIC_<NAME>` whose name ships a secret into the browser bundle.
- **Two capabilities**: activate the declared-but-absent `client_secret_boundary` (WEB globs), add `cross_origin_policy` (Python+web globs — CORS lives in both). A one-line coverage change lets a *clean* web file reach PASS for these two capabilities without making `source_analysis_support` claim JS is fully verified (JS stays inventory-grade there).

> **Stacked on #44 (config-posture).** Base is `feat/config-posture` so the diff shows only this slice. I'll rebase onto `main` and retarget once #44 merges.

## Precision — the cardinal value, defended hard

The adversarial review loop caught **three false-positive vectors** before merge (a verification tool's false alarm is worse than a miss), each now a red-under-mutation regression test:

1. `NEXT_PUBLIC_` matched `KEY` as a *substring* → `NEXT_PUBLIC_TURNKEY_URL` / `MONKEY` / `KEYBOARD` false-flagged. Fixed: whole-`_`-segment matching.
2. The CORS brace-matcher counted `{` inside string literals → a `{` in a log-format string desynced it and false-flagged a `credentials:false` call. Fixed: string-aware brace scan.
3. A `KEY` segment flagged **public-by-design** keys → `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` (ubiquitous in Next.js+Stripe) false-flagged. Fixed: two-tier classifier — strong-secret segments always flag; key-like segments flag only absent a `PUBLIC`/`PUBLISHABLE` marker; the `NEXT_PUBLIC_` prefix is stripped before splitting so its own `PUBLIC` can't unflag everything.

## Verification

- Full suite **1235 passed, 1 skipped**; ruff clean on every touched file.
- Mutation harness **37/37 CAUGHT**, including two new CORS/client-secret fail-opens.
- `run_precision` gate passed; `run_eval` **1.0 / 1.0 / 1.0**; `CG-CORS-CREDENTIALED-WILDCARD` fires on **0 of 44** precision-corpus fixtures.
- No uncertainty→ACCEPT leak: an unparsed/unresolved web file or CORS config → UNKNOWN (REVIEW), never a silent ACCEPT.

## Out of scope (documented)

Wildcard-CORS-*without*-credentials (deferred medium-severity), server-only-value-imported-into-a-client-component (needs import-graph analysis). A `KEY`-heuristic recall/precision tradeoff is documented in the spec.
