### PR TITLE
feat: JS/TS core-four verdicts (non-Python upgrade, slice 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ CyberGraph is designed to connect those dots.
 - **CORS & client secrets** — a CORS policy allowing any origin *with credentials*
   (FastAPI / Express), and secrets shipped to the browser via `NEXT_PUBLIC_`. A change
   that introduces either is a REVIEW.
+- **JS/TS SQL/command/code/path verdicts** — Express/Node sink arguments are graded SAFE/UNSAFE/UNKNOWN
+  from construction provenance (literal vs. tainted-variable vs. unresolved), not just inventoried.
 - **Cross-file, interprocedural attack paths** (route → service → repository → sink) with confidence, sanitizer-barrier flags, taint/data-reachability, risk scores, and fix guidance; a `--shallow` mode reproduces intra-function traversal for comparison.
 - **Interactive, offline HTML report** built for first-time readers: a dark-mode-first neon graph explorer (glowing, security-typed nodes with a light/dark toggle), NODE/EDGE/ZONE explainer cards, a guided first view that opens on the top attack path with a plain-language narrative, a security-zones view (Attack Surface → Guards → Logic → Sensitive Sinks), search, layer/severity filters, a details panel with source drill-down, and entrypoint→sink path highlighting (Cytoscape.js, fully inlined).
 - **Exec-first report posture**: an A–F security grade with a one-line verdict and severity-distribution bar, a since-last-scan delta strip (new/regressed/fixed), findings grouped into expandable rule cards, an honest findings-cap footer, and a print stylesheet for clean PDF export.

--- a/benchmark/mutation_harness.py
+++ b/benchmark/mutation_harness.py
@@ -533,16 +533,35 @@ MUTATIONS: list[Mutation] = [
         id="D9-js-unresolved-var-reads-safe",
         disaster="D9",
         file="cybergraph/analysis/js_provenance.py",
-        old="        if any(n in tainted_names for n in names):\n"
-        "            return VERDICT_UNSAFE\n"
-        "        return VERDICT_UNKNOWN",
-        new="        if any(n in tainted_names for n in names):\n"
-        "            return VERDICT_UNSAFE\n"
-        "        return VERDICT_SAFE",
+        old="        if names or unresolved:\n"
+        "            # a candidate variable (resolved or not) or an operand we could not\n"
+        "            # prove literal -> never read as safe\n"
+        "            return VERDICT_UNKNOWN",
+        new="        if names or unresolved:\n"
+        "            # a candidate variable (resolved or not) or an operand we could not\n"
+        "            # prove literal -> never read as safe\n"
+        "            return VERDICT_SAFE",
         tests=(
             "tests/test_js_provenance.py::test_assess_sql_unresolved_variable_is_unknown_not_safe",
         ),
         note="a JS variable CyberGraph cannot resolve must read UNKNOWN, never SAFE",
+    ),
+    Mutation(
+        id="D9-js-concat-operand-reads-safe",
+        disaster="D9",
+        file="cybergraph/analysis/js_provenance.py",
+        old="        idents = _IDENT_RE.findall(p)\n"
+        "        if not idents:\n"
+        "            unresolved = True\n"
+        "            continue",
+        new="        m = _IDENT_RE.match(p)\n"
+        "        if m is None:\n"
+        "            continue\n"
+        "        idents = [m.group(0)]",
+        tests=("tests/test_js_provenance.py::test_assess_paren_tainted_operand_is_unsafe",),
+        note="a '+' operand not led by an identifier character (e.g. `(id)`, `[id]`, "
+        "`(id || 1)`) must still have its identifiers found; matching only from the "
+        "operand's start silently drops the name and the construction reads safe",
     ),
 ]
 

--- a/benchmark/mutation_harness.py
+++ b/benchmark/mutation_harness.py
@@ -517,6 +517,33 @@ MUTATIONS: list[Mutation] = [
         tests=("tests/test_js_cors_nextjs.py::test_next_public_secret_is_flagged",),
         note="a NEXT_PUBLIC_ secret must be flagged, never missed",
     ),
+    # -- D9: the JS verdict assessor must never fail open --------------------
+    Mutation(
+        id="D9-js-tainted-sqli-reads-safe",
+        disaster="D9",
+        file="cybergraph/analysis/js_provenance.py",
+        old="        if any(n in tainted_names for n in names):\n"
+        "            return VERDICT_UNSAFE",
+        new="        if any(n in tainted_names for n in names):\n"
+        "            return VERDICT_SAFE",
+        tests=("tests/test_js_provenance.py::test_assess_sql_tainted_variable_is_unsafe",),
+        note="a tainted JS sink argument must not read safe",
+    ),
+    Mutation(
+        id="D9-js-unresolved-var-reads-safe",
+        disaster="D9",
+        file="cybergraph/analysis/js_provenance.py",
+        old="        if any(n in tainted_names for n in names):\n"
+        "            return VERDICT_UNSAFE\n"
+        "        return VERDICT_UNKNOWN",
+        new="        if any(n in tainted_names for n in names):\n"
+        "            return VERDICT_UNSAFE\n"
+        "        return VERDICT_SAFE",
+        tests=(
+            "tests/test_js_provenance.py::test_assess_sql_unresolved_variable_is_unknown_not_safe",
+        ),
+        note="a JS variable CyberGraph cannot resolve must read UNKNOWN, never SAFE",
+    ),
 ]
 
 

--- a/docs/CRITICAL_AUDIT.md
+++ b/docs/CRITICAL_AUDIT.md
@@ -314,6 +314,16 @@ the CI SARIF filter until each language gets its own Phase-2 sink registry/predi
 the project takes on a parsing dependency, which is the tradeoff already recorded above
 against §3.2's zero-dependency moat).
 
+**Note (2026-08-11): resolved for JS SQL/command/code/path (slice 1 of the non-Python
+upgrade); Go/Java/C# and other JS classes remain inventory-grade.** Without a JS parser, a
+structural, statement-local classifier (`analysis/js_provenance.py`) now grades the four core
+sink argument classes (SQL, command, code-exec, path) for JavaScript/TypeScript as SAFE
+(all-literal/constant construction only), UNSAFE (a construction containing a variable that
+line-based intra-function taint confirms), or UNKNOWN (a variable it cannot resolve — never
+SAFE) rather than emitting the flat `CG-JS-SINK-CALL` inventory row. This is one language and
+four sink classes only: Go, Java, and C# are unchanged, and other JS/TS sink classes (beyond
+SQL/command/code/path) still fall back to the pre-rewrite inventory rule. §4.5 stays OPEN.
+
 ### 4.6 MEDIUM — benchmark claims drift from the committed artifact
 
 | | `benchmark/README.md` | `benchmark/results.json` |

--- a/docs/superpowers/plans/2026-08-11-js-verdicts-core-four.md
+++ b/docs/superpowers/plans/2026-08-11-js-verdicts-core-four.md
@@ -1,0 +1,713 @@
+# JS/TS Verdicts — the Core Four — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn JavaScript/TypeScript from inventory-grade `CG-JS-SINK-CALL` into real safe/unsafe/unknown verdicts for the four sink classes CyberGraph already verifies in Python (SQL, command, code-exec, path), so a JS injection reviews under the same capability as Python — precisely, with only an all-literal/constant argument ever reading SAFE.
+
+**Architecture:** A per-language sink registry in `sinks.py`, a new lightweight `js_provenance.py` (argument extraction + construction classification + per-class assessment, reusing the LITERAL/COMPOSED/OPAQUE vocabulary and `VERDICT_*`), `javascript.py` routing the four classes through it to emit graded findings, and a one-line broadening of the four capabilities' `covers`. No `checks.py` change (the rule ids are already mapped; coverage already treats web files as analyzed via `WEB_GLOBS` from #45).
+
+**Tech Stack:** Python 3.10–3.13, standard library only (`re`). Existing `sinks.Sink`/`lookup_sink`, `predicates.VERDICT_*`, `provenance.LITERAL/COMPOSED/OPAQUE`, the capability/coverage/checks machinery, the taint `javascript.py` already computes.
+
+## Global Constraints
+
+- **Zero runtime dependencies**; standard library only — **no JS parser** (tree-sitter/esprima). The classifier is lightweight/structural and fail-safe.
+- Python 3.10–3.13. `from __future__ import annotations` first line of any new file.
+- Ruff line-length 100; run `ruff check` on every touched file — clean.
+- No network; no API keys on any default path.
+- **Precision over recall (cardinal):** only an all-literal/constant construction is SAFE. A construction containing a variable is UNSAFE (taint-confirmed user input) or UNKNOWN (unresolved) — **never SAFE**, and never a confident UNSAFE on an unresolved variable. Anything the classifier cannot read → UNKNOWN.
+- Findings carry `rule_id`, `severity`, `message`, `file_path`, `line_start`, `cwe`, `evidence`; honor `is_inline_suppressed`.
+- Commits `Laraib <lxh417bham@gmail.com>` only (repo-local config already carries it — do **not** pass `-c user.email=`); no `Co-Authored-By`, no AI attribution. Many small commits; never squash. Push only to `https://github.com/AQ-Labs/cybergraph`.
+- Branch `feat/js-verdicts-core-four` is stacked on `feat/cors-client-boundary` (#45); do not rebase during implementation.
+
+---
+
+## File Structure
+
+- `src/cybergraph/security/sinks.py` (modify) — add `_JAVASCRIPT`; register in `_BY_LANGUAGE`.
+- `src/cybergraph/analysis/js_provenance.py` (create) — arg extraction, construction classifier, per-class assessor.
+- `src/cybergraph/analysis/javascript.py` (modify) — route the four sink classes through the assessor.
+- `src/cybergraph/security/capability.py` (modify) — broaden four capabilities' `covers` to `+WEB_GLOBS`.
+- Tests: `tests/test_sinks_javascript.py`, `tests/test_js_provenance.py`, `tests/test_js_verdicts_e2e.py` (create).
+- `benchmark/mutation_harness.py` (modify) — two seeded fail-opens.
+- `README.md`, `docs/CRITICAL_AUDIT.md` (modify) — document; update §4.5 note.
+
+---
+
+## Task 1: JS sink registry in `sinks.py`
+
+**Files:**
+- Modify: `src/cybergraph/security/sinks.py`
+- Test: `tests/test_sinks_javascript.py` (create)
+
+**Interfaces:**
+- Produces: `_JAVASCRIPT: tuple[Sink, ...]` and `_BY_LANGUAGE["javascript"] = _JAVASCRIPT`, so `lookup_sink(name, "javascript")` resolves JS sinks to Python's rule ids.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_sinks_javascript.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from cybergraph.security.sinks import lookup_sink
+
+
+@pytest.mark.parametrize("call_name,rule_id,vuln", [
+    ("db.query", "CG-SQL-EXEC", "sql"),
+    ("pool.query", "CG-SQL-EXEC", "sql"),
+    ("knex.raw", "CG-SQL-EXEC", "sql"),
+    ("connection.execute", "CG-SQL-EXEC", "sql"),
+    ("child_process.exec", "CG-CMD-EXEC", "command"),
+    ("execSync", "CG-CMD-EXEC", "command"),
+    ("eval", "CG-CODE-EXEC", "code"),
+    ("Function", "CG-CODE-EXEC", "code"),
+    ("fs.readFile", "CG-PATH-TRAVERSAL", "path"),
+    ("fsp.writeFile", "CG-PATH-TRAVERSAL", "path"),
+])
+def test_javascript_sinks_resolve(call_name, rule_id, vuln):
+    sink = lookup_sink(call_name, "javascript")
+    assert sink is not None, call_name
+    assert sink.rule_id == rule_id
+    assert sink.vuln_class == vuln
+
+
+def test_non_sink_js_name_is_none():
+    assert lookup_sink("res.render", "javascript") is None
+    assert lookup_sink("console.log", "javascript") is None
+
+
+def test_python_lookups_unchanged():
+    assert lookup_sink("os.system", "python").rule_id == "CG-CMD-EXEC"
+    assert lookup_sink("db.query", "python") is None  # JS sink not registered for python
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/test_sinks_javascript.py -v` — Expected: FAIL (JS sinks return None).
+
+- [ ] **Step 3: Implement the registry**
+
+In `sinks.py`, add after `_PYTHON`:
+
+```python
+_JS_SQL = "sends this value to the database as part of a query"
+_JS_CMD = "runs a system command built from this value"
+
+_JAVASCRIPT: tuple[Sink, ...] = (
+    # SQL — receivers (db/pool/knex/connection) are unresolvable → bare on the method name.
+    Sink("query", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _JS_SQL, "sql", bare=True),
+    Sink("execute", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _JS_SQL, "sql", bare=True),
+    Sink("raw", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _JS_SQL, "sql", bare=True),
+    # Command — exec/execSync spawn a shell (inherent); spawn/execFile take argv (conditional).
+    Sink("child_process.exec", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _JS_CMD,
+         "command", shell=SHELL_INHERENT),
+    Sink("exec", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _JS_CMD, "command",
+         bare=True, shell=SHELL_INHERENT),
+    Sink("execSync", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _JS_CMD, "command",
+         bare=True, shell=SHELL_INHERENT),
+    Sink("spawn", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _JS_CMD, "command",
+         bare=True, shell=SHELL_CONDITIONAL),
+    Sink("execFile", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _JS_CMD, "command",
+         bare=True, shell=SHELL_CONDITIONAL),
+    # Code
+    Sink("eval", "CG-CODE-EXEC", "CWE-95", SEVERITY_CRITICAL,
+         "runs this value as program code", "code"),
+    Sink("Function", "CG-CODE-EXEC", "CWE-95", SEVERITY_CRITICAL,
+         "runs this value as program code", "code"),
+    # Path — fs / fs.promises receivers unresolvable → bare on the method name.
+    Sink("readFile", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("readFileSync", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("writeFile", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("writeFileSync", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("createReadStream", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+)
+```
+
+Change `_BY_LANGUAGE` to `{"python": _PYTHON, "javascript": _JAVASCRIPT}`.
+
+> `bare=True` matches on the final dotted segment (per `lookup_sink`), so `db.query`/`pool.query` → `query`, `fs.readFile`/`fsp.readFile` → `readFile`. `eval`/`Function` are unqualified builtins (non-bare, exact). Confirm `test_non_sink_js_name_is_none` still holds — `res.render`/`console.log` have no matching entry.
+
+- [ ] **Step 4: Run tests + ruff**
+
+Run: `pytest tests/test_sinks_javascript.py -v` — Expected: PASS. Run: `ruff check src/cybergraph/security/sinks.py tests/test_sinks_javascript.py` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/security/sinks.py tests/test_sinks_javascript.py
+git commit -m "feat(sinks): register JS/TS core-four sinks with Python's rule ids"
+```
+
+---
+
+## Task 2: `js_provenance.py` — argument extraction, classifier, assessor
+
+**Files:**
+- Create: `src/cybergraph/analysis/js_provenance.py`
+- Test: `tests/test_js_provenance.py` (create)
+
+**Interfaces:**
+- Consumes: `sinks.Sink`/`SHELL_INHERENT`/`SHELL_CONDITIONAL`, `predicates.VERDICT_SAFE/UNSAFE/UNKNOWN`, `provenance.LITERAL/COMPOSED/OPAQUE`.
+- Produces:
+  - `extract_first_arg(source: str, open_paren: int) -> str | None` — balanced, string-aware first-argument text; `None` if unbalanced/unreadable.
+  - `classify(arg_text: str) -> str` — `LITERAL` / `COMPOSED` / `OPAQUE`.
+  - `variable_names(arg_text: str) -> list[str]` — identifiers introduced by `${…}` interpolation or `+` concatenation (excluding string-literal parts).
+  - `assess(sink: Sink, arg_text: str | None, tainted_names: set[str]) -> str` — the `VERDICT_*`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_js_provenance.py`:
+
+```python
+from __future__ import annotations
+
+from cybergraph.analysis.js_provenance import (
+    assess, classify, extract_first_arg, variable_names,
+)
+from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNKNOWN, VERDICT_UNSAFE
+from cybergraph.security.sinks import lookup_sink
+
+
+def _sink(name):
+    return lookup_sink(name, "javascript")
+
+
+def test_extract_first_arg_balanced_and_string_aware():
+    src = "db.query(`SELECT ${x}`, [y])"
+    open_paren = src.index("(")
+    assert extract_first_arg(src, open_paren) == "`SELECT ${x}`"
+    # a ')' inside a string must not end the arg early
+    src2 = "exec('echo )')"
+    assert extract_first_arg(src2, src2.index("(")) == "'echo )'"
+    # unbalanced -> None
+    assert extract_first_arg("db.query(`oops", 8) is None
+
+
+def test_classify():
+    assert classify("'SELECT 1'") == "literal"
+    assert classify('"static"') == "literal"
+    assert classify("`no interpolation`") == "literal"
+    assert classify("`SELECT ${x}`") == "composed"
+    assert classify("'SELECT ' + name") == "composed"
+    assert classify("someVar") == "opaque"
+    assert classify("build()") == "opaque"
+
+
+def test_variable_names():
+    assert variable_names("`SELECT ${name} FROM t`") == ["name"]
+    assert variable_names("'a' + b + 'c'") == ["b"]
+    assert variable_names("`only literals`") == []
+
+
+def test_assess_sql_literal_is_safe():
+    assert assess(_sink("db.query"), "'SELECT 1'", set()) == VERDICT_SAFE
+
+
+def test_assess_sql_tainted_variable_is_unsafe():
+    assert assess(_sink("db.query"), "`SELECT ${id}`", {"id"}) == VERDICT_UNSAFE
+
+
+def test_assess_sql_unresolved_variable_is_unknown_not_safe():
+    # a variable taint can't confirm must NOT read safe (JS taint is weaker than Python's)
+    assert assess(_sink("db.query"), "`SELECT ${id}`", set()) == VERDICT_UNKNOWN
+
+
+def test_assess_sql_all_literal_template_is_safe():
+    assert assess(_sink("db.query"), "`SELECT 1 FROM t`", set()) == VERDICT_SAFE
+
+
+def test_assess_opaque_is_unknown():
+    assert assess(_sink("db.query"), "buildQuery()", set()) == VERDICT_UNKNOWN
+
+
+def test_assess_unreadable_arg_is_unknown():
+    assert assess(_sink("db.query"), None, set()) == VERDICT_UNKNOWN
+
+
+def test_assess_code_eval_literal_safe_variable_unsafe():
+    assert assess(_sink("eval"), "'1 + 1'", set()) == VERDICT_SAFE
+    assert assess(_sink("eval"), "userCode", {"userCode"}) == VERDICT_UNSAFE
+    assert assess(_sink("eval"), "userCode", set()) == VERDICT_UNKNOWN
+
+
+def test_assess_command_inherent_shell_tainted_unsafe():
+    assert assess(_sink("child_process.exec"), "`ls ${dir}`", {"dir"}) == VERDICT_UNSAFE
+    assert assess(_sink("child_process.exec"), "`ls ${dir}`", set()) == VERDICT_UNKNOWN
+    assert assess(_sink("child_process.exec"), "'ls -la'", set()) == VERDICT_SAFE
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/test_js_provenance.py -v` — Expected: FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Implement `js_provenance.py`**
+
+Create `src/cybergraph/analysis/js_provenance.py`:
+
+```python
+"""Lightweight construction provenance for JavaScript/TypeScript sink arguments.
+
+No JS parser: a structural, statement-local classifier over the argument text,
+fail-safe on anything it cannot read. It reuses the engine's vocabulary
+(LITERAL/COMPOSED/OPAQUE and VERDICT_*) but is deliberately more conservative
+than the Python predicates: because JS taint is weaker (intra-function,
+line-based), only an all-literal/constant construction is SAFE. A construction
+that contains a variable is UNSAFE when taint confirms it is user-controlled and
+UNKNOWN otherwise -- never SAFE, and never a confident UNSAFE on an unresolved
+variable.
+"""
+
+from __future__ import annotations
+
+import re
+
+from cybergraph.analysis.provenance import COMPOSED, LITERAL, OPAQUE
+from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNKNOWN, VERDICT_UNSAFE
+from cybergraph.security.sinks import Sink
+
+_IDENT_RE = re.compile(r"[A-Za-z_$][\w$]*")
+_STRING_ONLY_RE = re.compile(r"""^\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*$""")
+# a template literal with no interpolation hole
+_TEMPLATE_NO_INTERP_RE = re.compile(r"^\s*`[^`]*`\s*$")
+_INTERP_RE = re.compile(r"\$\{([^}]*)\}")
+_JS_KEYWORDS = {"true", "false", "null", "undefined", "this"}
+
+
+def extract_first_arg(source: str, open_paren: int) -> str | None:
+    """Return the first top-level argument's source text, or None if unbalanced.
+
+    String-aware (skips ()/,/quotes inside string and template literals) so a
+    ')' or ',' inside a literal does not end the argument early.
+    """
+    depth = 0
+    quote: str | None = None
+    start = -1
+    i = open_paren
+    while i < len(source):
+        c = source[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"`":
+            quote = c
+        elif c == "(":
+            depth += 1
+            if depth == 1:
+                start = i + 1
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return source[start:i].strip() or None
+        elif c == "," and depth == 1:
+            return source[start:i].strip() or None
+        i += 1
+    return None  # unbalanced -> caller treats as UNKNOWN
+
+
+def classify(arg_text: str) -> str:
+    s = arg_text.strip()
+    if _STRING_ONLY_RE.match(s) and "${" not in s:
+        return LITERAL
+    if s.startswith("`") and "${" in s:
+        return COMPOSED
+    if "+" in s and ("'" in s or '"' in s or "`" in s):
+        return COMPOSED
+    return OPAQUE
+
+
+def variable_names(arg_text: str) -> list[str]:
+    """Identifiers introduced by ${...} interpolation or a + operand, minus literals."""
+    names: list[str] = []
+    for hole in _INTERP_RE.findall(arg_text):
+        m = _IDENT_RE.search(hole)
+        if m and m.group(0) not in _JS_KEYWORDS:
+            names.append(m.group(0))
+    if "+" in arg_text:
+        # operands that are not string literals
+        for part in _split_plus(arg_text):
+            p = part.strip()
+            if p and not (p[0] in "'\"`"):
+                m = _IDENT_RE.match(p)
+                if m and m.group(0) not in _JS_KEYWORDS and not p[0].isdigit():
+                    names.append(m.group(0))
+    # de-dup, preserve order
+    seen: set[str] = set()
+    out = []
+    for n in names:
+        if n not in seen:
+            seen.add(n)
+            out.append(n)
+    return out
+
+
+def _split_plus(text: str) -> list[str]:
+    """Split on top-level '+', string/paren-aware."""
+    parts, depth, quote, buf = [], 0, None, []
+    i = 0
+    while i < len(text):
+        c = text[i]
+        if quote is not None:
+            buf.append(c)
+            if c == "\\":
+                if i + 1 < len(text):
+                    buf.append(text[i + 1])
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"`":
+            quote = c
+            buf.append(c)
+        elif c in "([{":
+            depth += 1
+            buf.append(c)
+        elif c in ")]}":
+            depth -= 1
+            buf.append(c)
+        elif c == "+" and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(c)
+        i += 1
+    parts.append("".join(buf))
+    return parts
+
+
+def assess(sink: Sink, arg_text: str | None, tainted_names: set[str]) -> str:
+    """Verdict for a JS sink call. Only an all-literal/constant construction is SAFE."""
+    if arg_text is None:
+        return VERDICT_UNKNOWN
+    construction = classify(arg_text)
+    if construction == LITERAL:
+        return VERDICT_SAFE
+    names = variable_names(arg_text)
+    if not names:
+        # composed of only literals (e.g. `'a' + 'b'`) -> safe
+        return VERDICT_SAFE
+    tainted = any(n in tainted_names for n in names)
+    if tainted:
+        return VERDICT_UNSAFE
+    return VERDICT_UNKNOWN
+```
+
+> Confirm the `LITERAL`/`COMPOSED`/`OPAQUE` string values imported from `provenance` (they are the lowercase strings `"literal"`/`"composed"`/`"opaque"` per the test). If the import names differ, adapt the import — do not redefine the constants. The command/shell nuance is intentionally simplified to the fail-safe rule (tainted → UNSAFE, unresolved variable → UNKNOWN, all-literal → SAFE); array-argv refinement is deferred (documented in the spec).
+
+- [ ] **Step 4: Run tests + ruff**
+
+Run: `pytest tests/test_js_provenance.py -v` — Expected: PASS. Run: `ruff check src/cybergraph/analysis/js_provenance.py tests/test_js_provenance.py` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/analysis/js_provenance.py tests/test_js_provenance.py
+git commit -m "feat(analysis): JS construction classifier and fail-safe sink assessor"
+```
+
+---
+
+## Task 3: Route JS sink calls through the assessor
+
+**Files:**
+- Modify: `src/cybergraph/analysis/javascript.py`
+- Test: `tests/test_js_verdicts_e2e.py` (create — analyzer-level)
+
+**Interfaces:**
+- Consumes: `lookup_sink`, `js_provenance.extract_first_arg`/`assess`, `predicates.VERDICT_*`, the existing per-call `tainted` map + `_tainted_source_for_line`.
+- Produces: for a sink call whose name resolves via `lookup_sink(call_name, "javascript")`, a graded finding — `sink.rule_id` (UNSAFE) / `sink.rule_id + "-UNVERIFIED"` (UNKNOWN) / none (SAFE) — **instead of** `CG-JS-SINK-CALL`. Names not in the registry keep emitting `CG-JS-SINK-CALL`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_js_verdicts_e2e.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from cybergraph.analysis.javascript import analyze_javascript_file
+
+
+def _rules(tmp_path: Path, name: str, src: str):
+    p = tmp_path / name
+    p.write_text(src, encoding="utf-8")
+    _n, _e, findings = analyze_javascript_file(p, tmp_path)
+    return [f.rule_id for f in findings]
+
+
+def test_parameterized_query_is_safe(tmp_path):
+    src = "function h(db,id){ return db.query('SELECT * FROM u WHERE id = ?', [id]); }\n"
+    rules = _rules(tmp_path, "a.js", src)
+    assert "CG-SQL-EXEC" not in rules
+    assert "CG-SQL-EXEC-UNVERIFIED" not in rules
+    assert "CG-JS-SINK-CALL" not in rules  # a registered sink no longer emits inventory
+
+
+def test_tainted_template_query_is_unsafe(tmp_path):
+    src = (
+        "function h(db, req){ const id = req.query.id;\n"
+        "  return db.query(`SELECT * FROM u WHERE id = ${id}`); }\n"
+    )
+    assert "CG-SQL-EXEC" in _rules(tmp_path, "a.js", src)
+
+
+def test_unresolved_variable_query_is_unverified(tmp_path):
+    src = "function h(db, id){ return db.query(`SELECT * FROM u WHERE id = ${id}`); }\n"
+    rules = _rules(tmp_path, "a.js", src)
+    assert "CG-SQL-EXEC-UNVERIFIED" in rules
+    assert "CG-SQL-EXEC" not in rules  # not a confident unsafe on an unproven variable
+
+
+def test_non_registry_sink_stays_inventory(tmp_path):
+    # res.render is in the legacy SINK_CALLS but not the verdict registry -> inventory-grade
+    rules = _rules(tmp_path, "a.js", "function h(res, x){ return res.render(x); }\n")
+    assert "CG-JS-SINK-CALL" in rules
+    assert "CG-SQL-EXEC" not in rules
+```
+
+> Note: the taint fixture uses `req.query.id` (an `INPUT_MARKERS` source) so `id` is tracked as user-controlled. Confirm against `javascript.py`'s taint how a name becomes tainted; adjust the fixture so `id` is genuinely in the per-line `tainted` set. If wiring the exact tainted-name set to the assessor proves intricate, pass the names the analyzer already resolves as user-controlled for that line.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/test_js_verdicts_e2e.py -v` — Expected: FAIL (still emits `CG-JS-SINK-CALL`).
+
+- [ ] **Step 3: Implement the routing**
+
+In `javascript.py`, add imports:
+
+```python
+from cybergraph.analysis.js_provenance import assess as assess_js_sink
+from cybergraph.analysis.js_provenance import extract_first_arg
+from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNKNOWN, VERDICT_UNSAFE
+from cybergraph.security.sinks import lookup_sink
+```
+
+Replace the sink-finding block (the `if _is_sink(call_name, custom_sinks):` body that appends `CG-JS-SINK-CALL`) with registry-first routing. Keep the `EDGE_REACHES_SINK`/`EDGE_TAINTS` edges as they are; change only the finding:
+
+```python
+            sink = lookup_sink(call_name, "javascript")
+            if sink is not None or _is_sink(call_name, custom_sinks):
+                edges.append(Edge(EDGE_REACHES_SINK, sink_source, call_name, rel, line_no))
+                if sink is not None:
+                    arg = extract_first_arg(source, call.end() - 1)
+                    tainted_names = set(tainted) | _line_tainted_names(line, tainted)
+                    verdict = assess_js_sink(sink, arg, tainted_names)
+                    finding = _js_verdict_finding(sink, verdict, rel, line_no, line)
+                    if finding is not None and not is_inline_suppressed(
+                        lines, line_no, finding.rule_id
+                    ):
+                        findings.append(finding)
+                elif not is_inline_suppressed(lines, line_no, "CG-JS-SINK-CALL"):
+                    findings.append(
+                        Finding(
+                            rule_id="CG-JS-SINK-CALL",
+                            severity="medium",
+                            message="JavaScript/TypeScript file reaches sensitive sink "
+                                    f"`{call_name}`",
+                            file_path=rel,
+                            line_start=line_no,
+                            cwe="CWE-20",
+                            evidence=line.strip(),
+                        )
+                    )
+                taint_source = source_key or _tainted_source_for_line(line, tainted)
+                if taint_source:
+                    edges.append(Edge(EDGE_TAINTS, taint_source, call_name, rel, line_no,
+                                      {"function": sink_source, "reason": "tainted argument"}))
+```
+
+Add helpers at module scope:
+
+```python
+def _line_tainted_names(line: str, tainted: dict) -> set[str]:
+    """Names on this line that the analyzer tracks as user-controlled."""
+    return {name for name in tainted if re.search(rf"\b{re.escape(name)}\b", line)}
+
+
+def _js_verdict_finding(sink, verdict, rel, line_no, line):
+    if verdict == VERDICT_SAFE:
+        return None
+    unsafe = verdict == VERDICT_UNSAFE
+    return Finding(
+        rule_id=sink.rule_id if unsafe else f"{sink.rule_id}-UNVERIFIED",
+        severity=sink.severity if unsafe else "medium",
+        message=(f"`{sink.name}` {sink.plain}" if unsafe
+                 else f"`{sink.name}` {sink.plain}, and CyberGraph could not confirm "
+                      "the value is safe"),
+        file_path=rel,
+        line_start=line_no,
+        cwe=sink.cwe,
+        evidence=line.strip(),
+    )
+```
+
+> `call.end() - 1` points at the `(` of the matched `name(`. `extract_first_arg` reads from `source` (multi-line safe). `set(tainted)` are the function-local tainted names; `_line_tainted_names` narrows to names literally present on the sink line (a cheap, conservative approximation — a name tainted elsewhere but not on this line is treated as unresolved → UNKNOWN, which is fail-safe). Confirm `source` and `tainted` are in scope at this point in `analyze_javascript_file` (they are: `source` at the top, `tainted` per-line above the call loop).
+
+- [ ] **Step 4: Run tests + ruff**
+
+Run: `pytest tests/test_js_verdicts_e2e.py tests/test_javascript.py -v` — Expected: PASS (adjust any prior `test_javascript.py` assertion that expected `CG-JS-SINK-CALL` for one of the now-graded sinks — a registered sink now emits the verdict rule; change the expectation, not the code). Run: `ruff check src/cybergraph/analysis/javascript.py tests/test_js_verdicts_e2e.py` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/analysis/javascript.py tests/test_js_verdicts_e2e.py
+git commit -m "feat(analysis): grade JS core-four sinks into real verdicts"
+```
+
+---
+
+## Task 4: Broaden the four capabilities to web globs
+
+**Files:**
+- Modify: `src/cybergraph/security/capability.py`
+- Test: `tests/test_js_verdicts_e2e.py` (append capability + end-to-end cases)
+
+**Interfaces:**
+- Produces: `sql_construction`, `command_execution`, `code_execution`, `path_access` with `covers = PYTHON_GLOBS + WEB_GLOBS`. `deserialization` stays `PYTHON_GLOBS`. `VERIFIED_GLOBS` unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_js_verdicts_e2e.py`:
+
+```python
+import subprocess
+
+from cybergraph.security.capability import CAPABILITIES, FAIL, NOT_SUPPORTED
+from cybergraph.security.check import check_change
+from cybergraph.security.verdict import STATE_REVIEW
+
+
+def _cap(cid):
+    return next(c for c in CAPABILITIES if c.id == cid)
+
+
+def test_four_capabilities_cover_web():
+    for cid in ("sql_construction", "command_execution", "code_execution", "path_access"):
+        assert any(g in _cap(cid).covers for g in ("*.ts", "*.js")), cid
+    assert "*.ts" not in _cap("deserialization").covers  # unchanged
+
+
+def _repo(tmp_path):
+    repo = tmp_path / "r"
+    repo.mkdir()
+    for a in (["init", "-q"], ["config", "user.email", "t@e.com"], ["config", "user.name", "t"]):
+        subprocess.run(["git", "-C", str(repo), *a], check=True)
+    (repo / "README.md").write_text("# x\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "base"], check=True)
+    return repo
+
+
+def test_js_sqli_reviews_under_sql_construction(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "h.ts").write_text(
+        "export function h(db, req){ const id = req.query.id;\n"
+        "  return db.query(`SELECT * FROM u WHERE id = ${id}`); }\n",
+        encoding="utf-8",
+    )
+    verdict = check_change(repo, mode="worktree")
+    assert verdict.state == STATE_REVIEW
+    assert any(c.capability_id == "sql_construction" and c.status == FAIL
+               for c in verdict.checks)
+
+
+def test_js_still_not_supported_overall(tmp_path):
+    # source_analysis_support stays NOT_SUPPORTED for JS (the tool doesn't overclaim)
+    repo = _repo(tmp_path)
+    (repo / "h.ts").write_text("export const x = 1;\n", encoding="utf-8")
+    verdict = check_change(repo, mode="worktree")
+    assert any(c.capability_id == "source_analysis_support" and c.status == NOT_SUPPORTED
+               for c in verdict.checks)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pytest tests/test_js_verdicts_e2e.py -k capabilities or reviews or not_supported -v` — Expected: FAIL (covers still Python-only).
+
+- [ ] **Step 3: Broaden the covers**
+
+In `capability.py`, change the four entries from `PYTHON_GLOBS` to `PYTHON_GLOBS + WEB_GLOBS`:
+
+```python
+    Capability("sql_construction", "Unsafe database queries", PYTHON_GLOBS + WEB_GLOBS, True),
+    Capability("command_execution", "Unsafe system commands", PYTHON_GLOBS + WEB_GLOBS, True),
+    Capability("code_execution", "Code run from user input", PYTHON_GLOBS + WEB_GLOBS, True),
+    Capability("path_access", "Files opened from user input", PYTHON_GLOBS + WEB_GLOBS, True),
+```
+
+Leave `deserialization`, `declared_login_rules`, `reachable_data_paths` on `PYTHON_GLOBS`, and `VERIFIED_GLOBS` unchanged.
+
+- [ ] **Step 4: Run tests + ruff**
+
+Run: `pytest tests/test_js_verdicts_e2e.py tests/test_capability.py tests/test_checks.py -v` — Expected: PASS (update any prior test asserting these four capabilities are Python-only relevance; change the expectation only). Run: `ruff check src/cybergraph/security/capability.py` — clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/security/capability.py tests/test_js_verdicts_e2e.py
+git commit -m "feat(verdict): the four injection capabilities now cover JS/TS"
+```
+
+---
+
+## Task 5: Mutation harness + docs + full verification
+
+**Files:**
+- Modify: `benchmark/mutation_harness.py`, `README.md`, `docs/CRITICAL_AUDIT.md`
+- Verification: full suite, ruff, harness, precision/eval.
+
+- [ ] **Step 1: Add the mutations**
+
+Append two `Mutation` entries to `MUTATIONS`. Match `old` strings to committed source verbatim.
+
+Mutation A — an interpolated-variable SQLi read as SAFE. Target `js_provenance.assess`'s tainted branch:
+- `old` = `    tainted = any(n in tainted_names for n in names)\n    if tainted:\n        return VERDICT_UNSAFE`
+- `new` = `    tainted = any(n in tainted_names for n in names)\n    if tainted:\n        return VERDICT_SAFE`
+- `tests` = `("tests/test_js_provenance.py::test_assess_sql_tainted_variable_is_unsafe",)`
+- id `D9-js-tainted-sqli-reads-safe`, disaster `D9`, note "a tainted JS sink argument must not read safe".
+
+Mutation B — an unresolved variable read as SAFE instead of UNKNOWN. Target the fall-through:
+- `old` = `    if tainted:\n        return VERDICT_UNSAFE\n    return VERDICT_UNKNOWN`
+- `new` = `    if tainted:\n        return VERDICT_UNSAFE\n    return VERDICT_SAFE`
+- `tests` = `("tests/test_js_provenance.py::test_assess_sql_unresolved_variable_is_unknown_not_safe",)`
+- id `D9-js-unresolved-var-reads-safe`, disaster `D9`, note "a JS variable CyberGraph cannot resolve must read UNKNOWN, never SAFE".
+
+Verify each `old` occurs exactly once. Run `python benchmark/mutation_harness.py` → both CAUGHT.
+
+- [ ] **Step 2: Docs**
+
+README: add a bullet noting JS/TS now earns real SQL/command/code/path verdicts (not just inventory). `docs/CRITICAL_AUDIT.md` §4.5: update the note to "resolved for JS SQL/command/code/path (slice 1 of the non-Python upgrade); Go/Java/C# and other JS classes remain inventory-grade" — do not mark §4.5 fully closed.
+
+- [ ] **Step 3: Full verification**
+
+Run: `pytest -q` — all pass. Run: `ruff check .` — no new errors beyond the pre-existing baseline. Run: `python benchmark/mutation_harness.py` — every mutation CAUGHT. Run: `python benchmark/run_precision.py` and `python benchmark/run_eval.py` — unchanged (1.0/1.0/1.0); **confirm the new JS handling did not change any Python-corpus result** (the JS registry is language-keyed, so Python lookups are unaffected — verify the numbers are identical).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add benchmark/mutation_harness.py README.md docs/CRITICAL_AUDIT.md
+git commit -m "test(js): seed JS verdict fail-open mutations; document the upgrade"
+```
+
+---
+
+## Notes for the executor
+
+- **Precision is cardinal.** Only an all-literal/constant construction is SAFE. A variable is UNSAFE (taint-confirmed) or UNKNOWN — never SAFE. When in doubt, UNKNOWN.
+- Confirm names/signatures against source before running each task's tests: `provenance.LITERAL/COMPOSED/OPAQUE` string values, `Sink` fields, `check_change`/`Verdict.checks`, and exactly how a name enters `javascript.py`'s per-line `tainted` map; adapt the test to reality, never the reverse.
+- The JS classifier is intentionally simple and fail-safe — resist adding clever resolution that could turn a variable SAFE. Array-argv/command-shell refinement and interprocedural taint are out of scope (later slices).
+- Do NOT add a JS parser dependency, JS-specific rule ids, or `*.js` to `VERIFIED_GLOBS`.

--- a/docs/superpowers/specs/2026-08-11-js-verdicts-core-four-design.md
+++ b/docs/superpowers/specs/2026-08-11-js-verdicts-core-four-design.md
@@ -86,14 +86,28 @@ paren matcher — the technique from #45's `_brace_object`, adapted to `(`/`)`):
   extracted → **OPAQUE** (fail-safe).
 - **Taint refinement:** reuse the function-local taint `javascript.py` already computes — whether
   an interpolated/concatenated identifier is a known user-controlled value.
-- **Per-class assessment** (mirrors `predicates`, JS-side):
-  - **SQL / path:** LITERAL → SAFE; COMPOSED with a tainted or plain variable → UNSAFE; OPAQUE →
-    UNKNOWN. A template whose interpolations are all literals/constants → SAFE (the
-    `f"... ORDER BY {ALLOWED}"` case, JS-side).
-  - **command:** an inherent-shell sink with any non-literal argument → UNSAFE; a conditional-shell
-    sink with array argv and no `shell: true` → SAFE for the shell mechanism; otherwise by
-    construction as above.
-  - **code:** `eval`/`Function` with a non-literal argument → UNSAFE; a literal → SAFE.
+- **Per-class assessment** (the *concept* mirrors `predicates`, but the safe/unknown split is
+  deliberately MORE conservative than Python's, because JS taint is weaker — intra-function and
+  line-based — so "untainted therefore safe" is not trustworthy here). Python trusts its strong
+  AST taint to clear an untainted-but-composed query; JS must not, or a real injection whose flow
+  the weaker taint missed would read SAFE. Therefore:
+  - **SQL / path:** an argument that is a literal, or a template/concatenation whose every part is
+    a literal or a resolvable constant → **SAFE**. A construction containing a variable that taint
+    confirms is user-controlled → **UNSAFE**. A construction containing a variable of *unknown*
+    provenance (taint neither confirms nor refutes) → **UNKNOWN** — never SAFE (JS can't vouch for
+    it) and never a confident UNSAFE (it might be an allowlisted constant). Opaque / unreadable →
+    **UNKNOWN**.
+  - **command:** an inherent-shell sink whose argument is anything but an all-literal/constant
+    string → UNSAFE when taint confirms user input, else UNKNOWN; a conditional-shell sink with an
+    array argv and no `shell: true` → SAFE for the shell mechanism (then assess the elements as
+    above); a string command with no resolvable shell status → UNKNOWN (platform-dependent, as in
+    Python's `_assess_command`).
+  - **code:** `eval` / `new Function` with an all-literal argument → SAFE; with a taint-confirmed
+    user value → UNSAFE; with a variable of unknown provenance → UNKNOWN.
+
+  The invariant across all four: **only an all-literal/constant construction is SAFE; any variable
+  is UNSAFE (taint-confirmed) or UNKNOWN (unresolved), never SAFE.** This is the concrete
+  expression of the judged-against sentence and the cardinal precision rule.
 - **Verdict → finding:** UNSAFE → the sink's `rule_id` at its severity; UNKNOWN → `rule_id` +
   `-UNVERIFIED` at reduced severity; SAFE → no finding. (Same mapping as Python's `_finding_for`.)
 
@@ -172,9 +186,10 @@ names outside the registry.
 
 1. `sinks.py` resolves the JS SQL/command/code/path sink names to Python's rule ids; Python
    lookups unchanged.
-2. The JS classifier maps literal → SAFE, interpolated/concatenated-with-a-variable → UNSAFE,
-   opaque/unreadable → UNKNOWN, per class (SQL/command/code/path), with the shell/argv and
-   only-literal-interpolation nuances correct.
+2. The JS classifier maps an all-literal/constant construction → SAFE, a variable that taint
+   confirms is user-controlled → UNSAFE, a variable of unknown provenance or an unreadable
+   argument → UNKNOWN, per class (SQL/command/code/path), with the shell/argv and
+   only-literal-interpolation nuances correct. No variable is ever SAFE.
 3. A JS injection on a changed `.ts`/`.js` → the matching capability FAIL → `cybergraph check`
    REVIEW; a parameterized/array-argv/literal change → SAFE → ACCEPT (end-to-end).
 4. `source_analysis_support` still reports JS NOT_SUPPORTED (the tool does not overclaim full JS

--- a/docs/superpowers/specs/2026-08-11-js-verdicts-core-four-design.md
+++ b/docs/superpowers/specs/2026-08-11-js-verdicts-core-four-design.md
@@ -1,0 +1,185 @@
+# JS/TS Verdicts — the Core Four — Design (Phase 2, non-Python upgrade slice 1)
+
+**Status:** approved for planning
+**Slice:** the first of four per-language slices of the "non-Python verdict upgrade" — JavaScript/
+TypeScript, for the four sink classes CyberGraph already verifies in Python (SQL, command,
+code-exec, path). Go / Java / C# are later slices that replicate this proven shape.
+**Predecessors:** verdict-core (merged), client hooks (#43, merged), config-posture (#44, open),
+CORS + client boundary (#45, open). This branch is **stacked on `feat/cors-client-boundary`**
+(#45) because it broadens capabilities in `capability.py` and relies on the `WEB_GLOBS`
+coverage-verified change that #45 introduced. It rebases down the stack as each parent merges.
+
+## The sentence this slice is judged against
+
+> For the four sink classes CyberGraph already verifies in Python, a JavaScript/TypeScript sink
+> whose argument is a string literal earns SAFE (the finding is suppressed), one built from an
+> interpolated or concatenated variable earns UNSAFE (or UNKNOWN when the build cannot be read),
+> and JS graduates from inventory-grade `CG-JS-SINK-CALL` to the same real ACCEPT/REVIEW verdict
+> as Python — without a false alarm on a safe query and without a real injection ever reading safe.
+
+## Why this is the right first non-Python slice
+
+- JS/TS is the most common language in AI-generated code, and `javascript.py` already carries the
+  most infrastructure to build on: intra-function taint (`tainted_by_function`), `DataFlow`
+  nodes, `EDGE_TAINTS`/`EDGE_REACHES_SINK`, and a comments/strings-blanked `code_lines` view.
+- It proves the reusable shape — **register per-language sinks → extract the sink argument's
+  construction → map through the shared lattice → emit a graded verdict** — that Go/Java/C#
+  replicate, while reusing the engine's *concept* (the LITERAL/COMPOSED/OPAQUE lattice and the
+  `VERDICT_SAFE/UNSAFE/UNKNOWN` vocabulary) rather than duplicating its AST-bound implementation.
+
+## Decisions already made (do not re-litigate in planning)
+
+1. **Core four in one slice:** SQL, command, code-exec, path — parity with Python's verified
+   classes. XSS / SSRF / deserialization and interprocedural flow are later JS slices.
+2. **Unify, don't fork (confirmed).** JS emits the *same rule ids* as Python (`CG-SQL-EXEC`,
+   `CG-CMD-EXEC`, `CG-CODE-EXEC`, `CG-PATH-TRAVERSAL`, `-UNVERIFIED` for UNKNOWN), and the four
+   capabilities (`sql_construction`, `command_execution`, `code_execution`, `path_access`) have
+   their `covers` broadened from `PYTHON_GLOBS` to `PYTHON_GLOBS + WEB_GLOBS`. A JS SQL injection
+   then reviews under the *same* capability as Python. **`VERIFIED_GLOBS` is NOT changed** — JS
+   still lacks verdicts for other classes, so `source_analysis_support` stays honestly
+   NOT_SUPPORTED for JS; the tool claims exactly the four classes it now checks, not "JS is fully
+   verified." No JS-specific rule ids or parallel capabilities.
+3. **Fail-safe precision.** JS has no stdlib parser; the classifier assesses only when it can
+   confidently extract the argument. A confidently-literal argument → SAFE (suppress). Anything
+   it cannot read with confidence → **UNKNOWN** (`-UNVERIFIED` → REVIEW) — never SAFE, never a
+   confident-but-wrong UNSAFE. The failure mode is "flag for a human," never a silent pass.
+
+## Architecture
+
+```
+src/cybergraph/security/sinks.py        (modify)  add _JAVASCRIPT registry; _BY_LANGUAGE["javascript"]
+src/cybergraph/analysis/js_provenance.py(create)  JS construction classifier + per-class assessor
+src/cybergraph/analysis/javascript.py   (modify)  route the four sink classes through the assessor
+src/cybergraph/security/capability.py   (modify)  broaden the four capabilities' covers to +WEB_GLOBS
+```
+
+`checks.py` needs **no change**: `_FINDING_RULES` already maps the four capabilities to their rule
+ids, and coverage already treats web files as analyzed (`WEB_GLOBS` in the verified gate, from
+#45), so a JS finding on a changed `.ts` flows through the existing generic evaluator to FAIL/PASS.
+
+### The JS sink registry (`sinks.py`)
+
+Add `_JAVASCRIPT: tuple[Sink, ...]` and `_BY_LANGUAGE["javascript"] = _JAVASCRIPT`, reusing the
+`Sink(name, rule_id, cwe, severity, plain, vuln_class, bare, shell)` shape and Python's rule ids:
+
+- **SQL** (`CG-SQL-EXEC`, CWE-89): `query`, `execute`, `raw` (`bare=True` — receivers like
+  `db`/`knex`/`pool` can't be resolved without type inference, matching how Python treats
+  `cursor.execute`).
+- **Command** (`CG-CMD-EXEC`, CWE-78): `exec`, `execSync` (`shell` inherent — they spawn a shell),
+  `spawn`/`execFile`/`spawnSync` (`shell` conditional — array argv is safer).
+- **Code** (`CG-CODE-EXEC`, CWE-95): `eval`, `Function` (`new Function(...)`).
+- **Path** (`CG-PATH-TRAVERSAL`, CWE-22): `readFile`, `readFileSync`, `createReadStream`,
+  `writeFile`, `writeFileSync`, `unlink`, `readdir` (`bare=True` — `fs.`/`fsp.` receivers).
+
+`lookup_sink(call_name, "javascript")` then resolves these; the flat `SINK_CALLS`/`CG-JS-SINK-CALL`
+path in `javascript.py` is superseded for these names and retained only for sinks *not* in the
+registry (still inventory-grade).
+
+### The JS construction classifier + assessor (`js_provenance.py`)
+
+Statement-local, operating on the sink call's argument text (extracted with a string-aware
+paren matcher — the technique from #45's `_brace_object`, adapted to `(`/`)`):
+
+- **Construction:** a pure string literal, or a template literal with no `${}` → **LITERAL**; a
+  template with `${…}` interpolation or a `+` concatenation involving a non-literal → **COMPOSED**;
+  a bare identifier or a call result → **OPAQUE**; an argument that cannot be confidently
+  extracted → **OPAQUE** (fail-safe).
+- **Taint refinement:** reuse the function-local taint `javascript.py` already computes — whether
+  an interpolated/concatenated identifier is a known user-controlled value.
+- **Per-class assessment** (mirrors `predicates`, JS-side):
+  - **SQL / path:** LITERAL → SAFE; COMPOSED with a tainted or plain variable → UNSAFE; OPAQUE →
+    UNKNOWN. A template whose interpolations are all literals/constants → SAFE (the
+    `f"... ORDER BY {ALLOWED}"` case, JS-side).
+  - **command:** an inherent-shell sink with any non-literal argument → UNSAFE; a conditional-shell
+    sink with array argv and no `shell: true` → SAFE for the shell mechanism; otherwise by
+    construction as above.
+  - **code:** `eval`/`Function` with a non-literal argument → UNSAFE; a literal → SAFE.
+- **Verdict → finding:** UNSAFE → the sink's `rule_id` at its severity; UNKNOWN → `rule_id` +
+  `-UNVERIFIED` at reduced severity; SAFE → no finding. (Same mapping as Python's `_finding_for`.)
+
+### Capability broadening (`capability.py`)
+
+Change the `covers` of `sql_construction`, `command_execution`, `code_execution`, `path_access`
+from `PYTHON_GLOBS` to `PYTHON_GLOBS + WEB_GLOBS`. Nothing else in `capability.py` changes;
+`deserialization` stays Python-only (not in the JS core four). `VERIFIED_GLOBS` unchanged.
+
+## Verdict flow (end to end)
+
+```
+changed foo.ts  →  analyze_javascript_file  →  lookup_sink("db.query","javascript")
+   →  js_provenance: extract arg, classify construction × taint  →  VERDICT
+   →  UNSAFE: Finding(CG-SQL-EXEC, high, CWE-89, …)   UNKNOWN: CG-SQL-EXEC-UNVERIFIED   SAFE: none
+   →  check_change: sql_construction covers *.ts, coverage=ANALYZED, finding rule_id in {CG-SQL-EXEC}
+   →  FAIL  →  REVIEW   (and the client hooks surface it)
+```
+
+## Precision & the SARIF filter
+
+- The four classes now emit real `CG-*` rules (not `CG-JS-SINK-CALL`), so they upload to code
+  scanning; the CI filter still drops the remaining `*-SINK-CALL` inventory for JS sink names not
+  in the registry. Audit §4.5 is **partially** retired (four classes for JS); the note is updated,
+  not deleted.
+- A safe parameterized query (`db.query("SELECT … WHERE id = ?", [id])`) → LITERAL query arg →
+  SAFE → no finding. A confidently-unreadable argument → UNKNOWN → REVIEW.
+
+## Error handling
+
+- A `.js`/`.ts` that the analyzer cannot read → its existing containment path → coverage
+  FAILED → UNKNOWN (never a silent PASS).
+- An argument the paren matcher cannot balance (truncated/odd source) → OPAQUE → UNKNOWN, never
+  SAFE.
+- A sink call with no extractable argument → UNKNOWN.
+
+## Testing
+
+- **`js_provenance` units** per class: literal → SAFE; template/`+` with a variable → UNSAFE;
+  template with only-literal interpolations → SAFE; bare variable/opaque → UNKNOWN; tainted vs
+  untainted variable distinction; command shell-vs-argv; `eval`/`Function` literal-vs-not; path
+  join-of-literals vs user path. A parameterized query → SAFE.
+- **`sinks.py`**: `lookup_sink` resolves the JS names to the right rule ids/vuln classes; Python
+  lookups unchanged.
+- **Capability five-state** on a `.ts` change for the four capabilities (FAIL on a JS injection,
+  PASS on a clean analyzed JS file, NOT_APPLICABLE off-scope, UNKNOWN on an unreadable JS file);
+  `source_analysis_support` still NOT_SUPPORTED for JS (unchanged — the honesty check).
+- **End-to-end:** `cybergraph check` → REVIEW on a JS SQLi diff and on a JS `child_process.exec`
+  with an interpolated command; ACCEPT on a parameterized-query / array-argv diff.
+- **Mutation harness:** two seeded fail-opens — an interpolated-variable SQLi read as SAFE, and an
+  unreadable/opaque argument read as SAFE instead of UNKNOWN — each red under its guard test.
+- Full suite green; ruff clean; `run_precision.py`/`run_eval.py` unchanged (Python corpus), and
+  the new JS rules confirmed not to fire on any Python precision-corpus fixture.
+
+## Global constraints (inherited, unchanged)
+
+- Python 3.10–3.13. **Zero runtime dependencies**; standard library only (`re`) — no JS parser
+  (tree-sitter, esprima, etc.). The classifier is lightweight/structural, fail-safe on anything
+  it cannot read.
+- Ruff line-length 100; `from __future__ import annotations` in every file.
+- No network; no API keys on any default path.
+- **Precision over recall:** uncertainty resolves to UNKNOWN (REVIEW), never SAFE and never a
+  confident false UNSAFE.
+- Commits `Laraib <lxh417bham@gmail.com>` only; no `Co-Authored-By`, no AI attribution. Many small
+  commits; never squash. Push only to `https://github.com/AQ-Labs/cybergraph`.
+
+## Roadmap alignment — what this does NOT touch
+
+Builds JS verdicts for the four classes and broadens the four capabilities. Deliberately excluded:
+JS XSS/output-encoding, SSRF, deserialization; interprocedural/cross-file flow; adding `*.js` to
+`VERIFIED_GLOBS` (JS is not fully verified); Go/Java/C# (each a later slice replicating this
+shape); and `deserialization` for JS. The flat `CG-JS-SINK-CALL` inventory remains for JS sink
+names outside the registry.
+
+## Success criteria
+
+1. `sinks.py` resolves the JS SQL/command/code/path sink names to Python's rule ids; Python
+   lookups unchanged.
+2. The JS classifier maps literal → SAFE, interpolated/concatenated-with-a-variable → UNSAFE,
+   opaque/unreadable → UNKNOWN, per class (SQL/command/code/path), with the shell/argv and
+   only-literal-interpolation nuances correct.
+3. A JS injection on a changed `.ts`/`.js` → the matching capability FAIL → `cybergraph check`
+   REVIEW; a parameterized/array-argv/literal change → SAFE → ACCEPT (end-to-end).
+4. `source_analysis_support` still reports JS NOT_SUPPORTED (the tool does not overclaim full JS
+   verification); the four capabilities now cover web globs.
+5. The four classes emit real `CG-*` rules (uploadable), not `CG-JS-SINK-CALL`; other JS sinks
+   stay inventory.
+6. Full suite green; ruff clean; the mutation harness catches both seeded JS fail-opens;
+   `run_precision.py`/`run_eval.py` unchanged.

--- a/src/cybergraph/analysis/javascript.py
+++ b/src/cybergraph/analysis/javascript.py
@@ -220,7 +220,7 @@ def analyze_javascript_file(
                 edges.append(Edge(EDGE_REACHES_SINK, sink_source, call_name, rel, line_no))
                 if sink is not None:
                     arg = extract_first_arg(source, line_starts[line_no - 1] + call.end() - 1)
-                    tainted_names = set(tainted) | _line_tainted_names(line, tainted)
+                    tainted_names = set(tainted)
                     verdict = assess_js_sink(sink, arg, tainted_names)
                     finding = _js_verdict_finding(sink, verdict, rel, line_no, line)
                     if finding is not None and not is_inline_suppressed(
@@ -404,11 +404,6 @@ def _line_start_offsets(source: str) -> list[int]:
         offsets.append(offset)
         offset += len(segment)
     return offsets
-
-
-def _line_tainted_names(line: str, tainted: dict) -> set[str]:
-    """Names on this line that the analyzer tracks as user-controlled."""
-    return {name for name in tainted if re.search(rf"\b{re.escape(name)}\b", line)}
 
 
 def _js_verdict_finding(sink, verdict, rel, line_no, line):

--- a/src/cybergraph/analysis/javascript.py
+++ b/src/cybergraph/analysis/javascript.py
@@ -6,6 +6,8 @@ import re
 from pathlib import Path
 
 from cybergraph.analysis._source_text import strip_code
+from cybergraph.analysis.js_provenance import assess as assess_js_sink
+from cybergraph.analysis.js_provenance import extract_first_arg
 from cybergraph.graph import Edge, Finding, Node
 from cybergraph.security.ontology import (
     EDGE_EXPOSES_ENTRYPOINT,
@@ -17,6 +19,8 @@ from cybergraph.security.ontology import (
     EDGE_TAINTS,
     EDGE_USES_SECRET,
 )
+from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNSAFE
+from cybergraph.security.sinks import lookup_sink
 from cybergraph.suppressions import is_inline_suppressed
 
 FUNCTION_RE = re.compile(
@@ -119,6 +123,10 @@ def analyze_javascript_file(
     source = path.read_text(encoding="utf-8", errors="ignore")
     rel = path.relative_to(repo_root).as_posix()
     lines = source.splitlines()
+    # Absolute offset (into `source`) of the start of each line in `lines`, so a
+    # per-line regex match position can be translated into a `source` index --
+    # needed for `extract_first_arg`, which must read across line breaks.
+    line_starts = _line_start_offsets(source)
     # Code view with comments and string literals blanked (template interpolation
     # holes kept as code), aligned 1:1 with `lines`, so an input marker in a
     # comment or a string cannot fabricate a taint source.
@@ -207,9 +215,19 @@ def analyze_javascript_file(
             if _is_declaration_call(line, call.start()):
                 continue
             edges.append(Edge("CALLS", sink_source, call_name, rel, line_no))
-            if _is_sink(call_name, custom_sinks):
+            sink = lookup_sink(call_name, "javascript")
+            if sink is not None or _is_sink(call_name, custom_sinks):
                 edges.append(Edge(EDGE_REACHES_SINK, sink_source, call_name, rel, line_no))
-                if not is_inline_suppressed(lines, line_no, "CG-JS-SINK-CALL"):
+                if sink is not None:
+                    arg = extract_first_arg(source, line_starts[line_no - 1] + call.end() - 1)
+                    tainted_names = set(tainted) | _line_tainted_names(line, tainted)
+                    verdict = assess_js_sink(sink, arg, tainted_names)
+                    finding = _js_verdict_finding(sink, verdict, rel, line_no, line)
+                    if finding is not None and not is_inline_suppressed(
+                        lines, line_no, finding.rule_id
+                    ):
+                        findings.append(finding)
+                elif not is_inline_suppressed(lines, line_no, "CG-JS-SINK-CALL"):
                     findings.append(
                         Finding(
                             rule_id="CG-JS-SINK-CALL",
@@ -370,6 +388,44 @@ def _classify_js_name(name: str) -> dict[str, bool]:
         "crypto_related": "hash" in lowered or "encrypt" in lowered or "sign" in lowered,
         "sink_related": "query" in lowered or "exec" in lowered,
     }
+
+
+def _line_start_offsets(source: str) -> list[int]:
+    """Absolute `source` offset of the first character of each `splitlines()` line.
+
+    `source.splitlines()` and `source.splitlines(keepends=True)` share identical
+    split points, differing only in whether each element keeps its trailing line
+    terminator -- so summing the keepends lengths reconstructs the exact offsets
+    the terminator-stripped `lines` started at.
+    """
+    offsets: list[int] = []
+    offset = 0
+    for segment in source.splitlines(keepends=True):
+        offsets.append(offset)
+        offset += len(segment)
+    return offsets
+
+
+def _line_tainted_names(line: str, tainted: dict) -> set[str]:
+    """Names on this line that the analyzer tracks as user-controlled."""
+    return {name for name in tainted if re.search(rf"\b{re.escape(name)}\b", line)}
+
+
+def _js_verdict_finding(sink, verdict, rel, line_no, line):
+    if verdict == VERDICT_SAFE:
+        return None
+    unsafe = verdict == VERDICT_UNSAFE
+    return Finding(
+        rule_id=sink.rule_id if unsafe else f"{sink.rule_id}-UNVERIFIED",
+        severity=sink.severity if unsafe else "medium",
+        message=(f"`{sink.name}` {sink.plain}" if unsafe
+                 else f"`{sink.name}` {sink.plain}, and CyberGraph could not confirm "
+                      "the value is safe"),
+        file_path=rel,
+        line_start=line_no,
+        cwe=sink.cwe,
+        evidence=line.strip(),
+    )
 
 
 def _is_sink(call_name: str, custom_sinks: tuple[str, ...] = ()) -> bool:

--- a/src/cybergraph/analysis/js_provenance.py
+++ b/src/cybergraph/analysis/js_provenance.py
@@ -1,0 +1,162 @@
+"""Lightweight construction provenance for JavaScript/TypeScript sink arguments.
+
+No JS parser: a structural, statement-local classifier over the argument text,
+fail-safe on anything it cannot read. It reuses the engine's vocabulary
+(LITERAL/COMPOSED/OPAQUE and VERDICT_*) but is deliberately more conservative
+than the Python predicates: because JS taint is weaker (intra-function,
+line-based), only an all-literal/constant construction is SAFE. A construction
+that contains a variable is UNSAFE when taint confirms it is user-controlled and
+UNKNOWN otherwise -- never SAFE, and never a confident UNSAFE on an unresolved
+variable.
+"""
+
+from __future__ import annotations
+
+import re
+
+from cybergraph.analysis.provenance import COMPOSED, LITERAL, OPAQUE
+from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNKNOWN, VERDICT_UNSAFE
+from cybergraph.security.sinks import Sink
+
+_IDENT_RE = re.compile(r"[A-Za-z_$][\w$]*")
+_STRING_ONLY_RE = re.compile(r"""^\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*$""")
+# a template literal with no interpolation hole
+_TEMPLATE_NO_INTERP_RE = re.compile(r"^\s*`[^`]*`\s*$")
+_INTERP_RE = re.compile(r"\$\{([^}]*)\}")
+_JS_KEYWORDS = {"true", "false", "null", "undefined", "this"}
+
+
+def extract_first_arg(source: str, open_paren: int) -> str | None:
+    """Return the first top-level argument's source text, or None if unbalanced.
+
+    String-aware (skips ()/,/quotes inside string and template literals) so a
+    ')' or ',' inside a literal does not end the argument early.
+    """
+    depth = 0
+    quote: str | None = None
+    start = -1
+    i = open_paren
+    while i < len(source):
+        c = source[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"`":
+            quote = c
+        elif c == "(":
+            depth += 1
+            if depth == 1:
+                start = i + 1
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return source[start:i].strip() or None
+        elif c == "," and depth == 1:
+            return source[start:i].strip() or None
+        i += 1
+    return None  # unbalanced -> caller treats as UNKNOWN
+
+
+def classify(arg_text: str) -> str:
+    s = arg_text.strip()
+    if _STRING_ONLY_RE.match(s) and "${" not in s:
+        return LITERAL
+    if s.startswith("`") and "${" in s:
+        return COMPOSED
+    if "+" in s and ("'" in s or '"' in s or "`" in s):
+        return COMPOSED
+    return OPAQUE
+
+
+def variable_names(arg_text: str) -> list[str]:
+    """Identifiers introduced by ${...} interpolation or a + operand, minus literals."""
+    names: list[str] = []
+    for hole in _INTERP_RE.findall(arg_text):
+        m = _IDENT_RE.search(hole)
+        if m and m.group(0) not in _JS_KEYWORDS:
+            names.append(m.group(0))
+    if "+" in arg_text:
+        # operands that are not string literals
+        for part in _split_plus(arg_text):
+            p = part.strip()
+            if p and p[0] not in "'\"`":
+                m = _IDENT_RE.match(p)
+                if m and m.group(0) not in _JS_KEYWORDS and not p[0].isdigit():
+                    names.append(m.group(0))
+    # de-dup, preserve order
+    seen: set[str] = set()
+    out = []
+    for n in names:
+        if n not in seen:
+            seen.add(n)
+            out.append(n)
+    return out
+
+
+def _split_plus(text: str) -> list[str]:
+    """Split on top-level '+', string/paren-aware."""
+    parts, depth, quote, buf = [], 0, None, []
+    i = 0
+    while i < len(text):
+        c = text[i]
+        if quote is not None:
+            buf.append(c)
+            if c == "\\":
+                if i + 1 < len(text):
+                    buf.append(text[i + 1])
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"`":
+            quote = c
+            buf.append(c)
+        elif c in "([{":
+            depth += 1
+            buf.append(c)
+        elif c in ")]}":
+            depth -= 1
+            buf.append(c)
+        elif c == "+" and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(c)
+        i += 1
+    parts.append("".join(buf))
+    return parts
+
+
+def assess(sink: Sink, arg_text: str | None, tainted_names: set[str]) -> str:
+    """Verdict for a JS sink call. Only an all-literal/constant construction is SAFE."""
+    if arg_text is None:
+        return VERDICT_UNKNOWN
+    construction = classify(arg_text)
+    if construction == LITERAL:
+        return VERDICT_SAFE
+    if construction == COMPOSED:
+        names = variable_names(arg_text)
+        if not names:
+            # composed of only literals (e.g. `'a' + 'b'`) -> safe
+            return VERDICT_SAFE
+        if any(n in tainted_names for n in names):
+            return VERDICT_UNSAFE
+        return VERDICT_UNKNOWN
+    # OPAQUE: `variable_names` only extracts identifiers introduced by `${...}`
+    # interpolation or a `+` operand, so it finds nothing in a bare identifier
+    # (no template, no `+`) even though the whole argument *is* one. Handle
+    # that shape directly: a bare identifier can be checked against taint; any
+    # other opaque expression (a call, member access, ...) has no name to
+    # check and must fail safe rather than read as unconditionally SAFE.
+    s = arg_text.strip()
+    match = _IDENT_RE.fullmatch(s)
+    if match and match.group(0) not in _JS_KEYWORDS and match.group(0) in tainted_names:
+        return VERDICT_UNSAFE
+    return VERDICT_UNKNOWN

--- a/src/cybergraph/analysis/js_provenance.py
+++ b/src/cybergraph/analysis/js_provenance.py
@@ -70,7 +70,7 @@ def classify(arg_text: str) -> str:
         return LITERAL
     if s.startswith("`") and "${" in s:
         return COMPOSED
-    if "+" in s and ("'" in s or '"' in s or "`" in s):
+    if len(_split_plus(s)) > 1:
         return COMPOSED
     return OPAQUE
 

--- a/src/cybergraph/analysis/js_provenance.py
+++ b/src/cybergraph/analysis/js_provenance.py
@@ -20,10 +20,12 @@ from cybergraph.security.sinks import Sink
 
 _IDENT_RE = re.compile(r"[A-Za-z_$][\w$]*")
 _STRING_ONLY_RE = re.compile(r"""^\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*$""")
-# a template literal with no interpolation hole
-_TEMPLATE_NO_INTERP_RE = re.compile(r"^\s*`[^`]*`\s*$")
+_NUMERIC_RE = re.compile(r"^[+-]?\d+(?:\.\d+)?$")
 _INTERP_RE = re.compile(r"\$\{([^}]*)\}")
 _JS_KEYWORDS = {"true", "false", "null", "undefined", "this"}
+# numeric/boolean/null constants -- proven literals even though "true"/"null" are
+# also excluded from candidate variable names as JS keywords
+_CONST_LITERAL_KEYWORDS = {"true", "false", "null"}
 
 
 def extract_first_arg(source: str, open_paren: int) -> str | None:
@@ -75,21 +77,61 @@ def classify(arg_text: str) -> str:
     return OPAQUE
 
 
+def _is_proven_literal_operand(operand: str) -> bool:
+    """True only for a construction that is positively known to be constant.
+
+    A string/template literal with no ``${}`` hole, or a numeric/boolean/null
+    constant. Anything else -- a bare identifier, a parenthesized expression, a
+    bracketed expression, a ternary, a call, member access -- is NOT proven
+    literal, even if it happens to contain no scannable identifier: absence of
+    a name must never be read as proof of literal-ness.
+    """
+    s = operand.strip()
+    if not s:
+        return False
+    if _STRING_ONLY_RE.match(s) and "${" not in s:
+        return True
+    if _NUMERIC_RE.match(s):
+        return True
+    if s in _CONST_LITERAL_KEYWORDS:
+        return True
+    return False
+
+
+def _plus_operand_candidates(arg_text: str) -> tuple[list[str], bool]:
+    """Candidate variable names from non-literal top-level ``+`` operands.
+
+    Also returns whether any operand is "unresolved": not a proven literal and
+    yet contains no identifier at all (e.g. `(1 + 1)` as an operand) -- such an
+    operand must never be silently treated as safe just because it has no name
+    to check.
+    """
+    names: list[str] = []
+    unresolved = False
+    for part in _split_plus(arg_text):
+        p = part.strip()
+        if not p or _is_proven_literal_operand(p):
+            continue
+        idents = _IDENT_RE.findall(p)
+        if not idents:
+            unresolved = True
+            continue
+        for ident in idents:
+            if ident not in _JS_KEYWORDS:
+                names.append(ident)
+    return names, unresolved
+
+
 def variable_names(arg_text: str) -> list[str]:
-    """Identifiers introduced by ${...} interpolation or a + operand, minus literals."""
+    """Identifiers introduced by ${...} interpolation or a non-literal + operand."""
     names: list[str] = []
     for hole in _INTERP_RE.findall(arg_text):
         m = _IDENT_RE.search(hole)
         if m and m.group(0) not in _JS_KEYWORDS:
             names.append(m.group(0))
     if "+" in arg_text:
-        # operands that are not string literals
-        for part in _split_plus(arg_text):
-            p = part.strip()
-            if p and p[0] not in "'\"`":
-                m = _IDENT_RE.match(p)
-                if m and m.group(0) not in _JS_KEYWORDS and not p[0].isdigit():
-                    names.append(m.group(0))
+        plus_names, _unresolved = _plus_operand_candidates(arg_text)
+        names.extend(plus_names)
     # de-dup, preserve order
     seen: set[str] = set()
     out = []
@@ -143,12 +185,17 @@ def assess(sink: Sink, arg_text: str | None, tainted_names: set[str]) -> str:
         return VERDICT_SAFE
     if construction == COMPOSED:
         names = variable_names(arg_text)
-        if not names:
-            # composed of only literals (e.g. `'a' + 'b'`) -> safe
-            return VERDICT_SAFE
+        unresolved = False
+        if "+" in arg_text:
+            _plus_names, unresolved = _plus_operand_candidates(arg_text)
         if any(n in tainted_names for n in names):
             return VERDICT_UNSAFE
-        return VERDICT_UNKNOWN
+        if names or unresolved:
+            # a candidate variable (resolved or not) or an operand we could not
+            # prove literal -> never read as safe
+            return VERDICT_UNKNOWN
+        # every operand is a proven literal/constant (e.g. `'a' + 'b'`) -> safe
+        return VERDICT_SAFE
     # OPAQUE: `variable_names` only extracts identifiers introduced by `${...}`
     # interpolation or a `+` operand, so it finds nothing in a bare identifier
     # (no template, no `+`) even though the whole argument *is* one. Handle

--- a/src/cybergraph/security/capability.py
+++ b/src/cybergraph/security/capability.py
@@ -70,11 +70,11 @@ class Capability:
 
 
 CAPABILITIES: tuple[Capability, ...] = (
-    Capability("sql_construction", "Unsafe database queries", PYTHON_GLOBS, True),
-    Capability("command_execution", "Unsafe system commands", PYTHON_GLOBS, True),
-    Capability("code_execution", "Code run from user input", PYTHON_GLOBS, True),
+    Capability("sql_construction", "Unsafe database queries", PYTHON_GLOBS + WEB_GLOBS, True),
+    Capability("command_execution", "Unsafe system commands", PYTHON_GLOBS + WEB_GLOBS, True),
+    Capability("code_execution", "Code run from user input", PYTHON_GLOBS + WEB_GLOBS, True),
     Capability("deserialization", "Unsafe data loading", PYTHON_GLOBS, True),
-    Capability("path_access", "Files opened from user input", PYTHON_GLOBS, True),
+    Capability("path_access", "Files opened from user input", PYTHON_GLOBS + WEB_GLOBS, True),
     Capability("declared_login_rules", "Your declared login rules", PYTHON_GLOBS, True),
     Capability("reachable_data_paths",
                "New routes from the internet to sensitive code", PYTHON_GLOBS, True),

--- a/src/cybergraph/security/sinks.py
+++ b/src/cybergraph/security/sinks.py
@@ -83,7 +83,44 @@ _PYTHON: tuple[Sink, ...] = (
          "opens a file whose path comes from this value", "path"),
 )
 
-_BY_LANGUAGE: dict[str, tuple[Sink, ...]] = {"python": _PYTHON}
+_JS_SQL = "sends this value to the database as part of a query"
+_JS_CMD = "runs a system command built from this value"
+
+_JAVASCRIPT: tuple[Sink, ...] = (
+    # SQL — receivers (db/pool/knex/connection) are unresolvable → bare on the method name.
+    Sink("query", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _JS_SQL, "sql", bare=True),
+    Sink("execute", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _JS_SQL, "sql", bare=True),
+    Sink("raw", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _JS_SQL, "sql", bare=True),
+    # Command — exec/execSync spawn a shell (inherent); spawn/execFile take argv (conditional).
+    Sink("child_process.exec", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _JS_CMD,
+         "command", shell=SHELL_INHERENT),
+    Sink("exec", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _JS_CMD, "command",
+         bare=True, shell=SHELL_INHERENT),
+    Sink("execSync", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _JS_CMD, "command",
+         bare=True, shell=SHELL_INHERENT),
+    Sink("spawn", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _JS_CMD, "command",
+         bare=True, shell=SHELL_CONDITIONAL),
+    Sink("execFile", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _JS_CMD, "command",
+         bare=True, shell=SHELL_CONDITIONAL),
+    # Code
+    Sink("eval", "CG-CODE-EXEC", "CWE-95", SEVERITY_CRITICAL,
+         "runs this value as program code", "code"),
+    Sink("Function", "CG-CODE-EXEC", "CWE-95", SEVERITY_CRITICAL,
+         "runs this value as program code", "code"),
+    # Path — fs / fs.promises receivers unresolvable → bare on the method name.
+    Sink("readFile", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("readFileSync", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("writeFile", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("writeFileSync", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("createReadStream", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+)
+
+_BY_LANGUAGE: dict[str, tuple[Sink, ...]] = {"python": _PYTHON, "javascript": _JAVASCRIPT}
 
 
 def all_sinks() -> tuple[Sink, ...]:

--- a/tests/test_capability.py
+++ b/tests/test_capability.py
@@ -22,7 +22,8 @@ def test_python_change_makes_python_capabilities_relevant():
 def test_typescript_change_makes_the_web_capability_relevant():
     rel = relevance(("web/page.tsx",))
     assert rel["client_secret_boundary"] is True
-    assert rel["sql_construction"] is False
+    assert rel["sql_construction"] is True  # the four injection capabilities now cover web too
+    assert rel["deserialization"] is False  # still Python-only
 
 
 def test_go_change_is_caught_by_general_source_support():

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -53,4 +53,7 @@ def test_vulnerable_express_example_builds() -> None:
 
     assert counts["findings"] >= 1  # the SQL sink in listUsers
     answer = answer_question(repo, "database query")
-    assert "db.query" in answer.lower() or "CG-JS-SINK-CALL" in answer
+    # db.query is now a registered sink graded to a real verdict (CG-SQL-EXEC), not
+    # the old flat CG-JS-SINK-CALL inventory finding.
+    assert "CG-SQL-EXEC" in answer
+    assert "query" in answer.lower()

--- a/tests/test_javascript_analyzer.py
+++ b/tests/test_javascript_analyzer.py
@@ -25,7 +25,9 @@ def test_javascript_analyzer_detects_express_routes_and_sinks(tmp_path: Path) ->
     assert any(edge.kind == "EXPOSES_ENTRYPOINT" for edge in edges)
     assert any(edge.kind == "REACHES_SINK" for edge in edges)
     assert any(edge.kind == "USES_SECRET" for edge in edges)
-    assert any(finding.rule_id == "CG-JS-SINK-CALL" for finding in findings)
+    # db.query is a registered sink; req.body.name is an unresolved member
+    # expression (not a bare tainted identifier) -> graded UNKNOWN, not inventory.
+    assert any(finding.rule_id == "CG-SQL-EXEC-UNVERIFIED" for finding in findings)
 
 
 def test_javascript_analyzer_respects_inline_finding_suppression(tmp_path: Path) -> None:
@@ -34,7 +36,7 @@ def test_javascript_analyzer_respects_inline_finding_suppression(tmp_path: Path)
     app = repo / "app.js"
     app.write_text(
         "function handler(req) {\n"
-        "  // cybergraph: ignore CG-JS-SINK-CALL accepted fixture query\n"
+        "  // cybergraph: ignore CG-SQL-EXEC-UNVERIFIED accepted fixture query\n"
         "  return db.query(req.body.name);\n"
         "}\n",
         encoding="utf-8",
@@ -79,7 +81,9 @@ def test_javascript_analyzer_detects_bare_eval_sink(tmp_path: Path) -> None:
 
     assert any(edge.kind == "CALLS" and edge.target == "eval" for edge in edges)
     assert any(edge.kind == "REACHES_SINK" and edge.target == "eval" for edge in edges)
-    assert any(finding.rule_id == "CG-JS-SINK-CALL" for finding in findings)
+    # eval is a registered sink; req.query.code is an unresolved member
+    # expression -> graded UNKNOWN, not inventory.
+    assert any(finding.rule_id == "CG-CODE-EXEC-UNVERIFIED" for finding in findings)
 
 
 def test_javascript_analyzer_emits_calls_for_named_express_handlers(tmp_path: Path) -> None:
@@ -156,7 +160,9 @@ def test_javascript_genuine_source_still_detected_and_reaches_sink(tmp_path: Pat
     assert _input_nodes(nodes), "genuine req.query must create an Input source"
     assert any(edge.kind == "READS_INPUT" for edge in edges)
     assert any(edge.kind == "TAINTS" for edge in edges)
-    assert any(f.rule_id == "CG-JS-SINK-CALL" for f in findings)
+    # db.query is a registered sink; `name` is a bare identifier the analyzer
+    # confirms tainted -> graded UNSAFE, not inventory.
+    assert any(f.rule_id == "CG-SQL-EXEC" for f in findings)
 
 
 def test_javascript_template_interpolation_source_is_detected(tmp_path: Path) -> None:

--- a/tests/test_js_provenance.py
+++ b/tests/test_js_provenance.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from cybergraph.analysis.js_provenance import (
+    assess,
+    classify,
+    extract_first_arg,
+    variable_names,
+)
+from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNKNOWN, VERDICT_UNSAFE
+from cybergraph.security.sinks import lookup_sink
+
+
+def _sink(name):
+    return lookup_sink(name, "javascript")
+
+
+def test_extract_first_arg_balanced_and_string_aware():
+    src = "db.query(`SELECT ${x}`, [y])"
+    open_paren = src.index("(")
+    assert extract_first_arg(src, open_paren) == "`SELECT ${x}`"
+    # a ')' inside a string must not end the arg early
+    src2 = "exec('echo )')"
+    assert extract_first_arg(src2, src2.index("(")) == "'echo )'"
+    # unbalanced -> None
+    assert extract_first_arg("db.query(`oops", 8) is None
+
+
+def test_classify():
+    assert classify("'SELECT 1'") == "literal"
+    assert classify('"static"') == "literal"
+    assert classify("`no interpolation`") == "literal"
+    assert classify("`SELECT ${x}`") == "composed"
+    assert classify("'SELECT ' + name") == "composed"
+    assert classify("someVar") == "opaque"
+    assert classify("build()") == "opaque"
+
+
+def test_variable_names():
+    assert variable_names("`SELECT ${name} FROM t`") == ["name"]
+    assert variable_names("'a' + b + 'c'") == ["b"]
+    assert variable_names("`only literals`") == []
+
+
+def test_assess_sql_literal_is_safe():
+    assert assess(_sink("db.query"), "'SELECT 1'", set()) == VERDICT_SAFE
+
+
+def test_assess_sql_tainted_variable_is_unsafe():
+    assert assess(_sink("db.query"), "`SELECT ${id}`", {"id"}) == VERDICT_UNSAFE
+
+
+def test_assess_sql_unresolved_variable_is_unknown_not_safe():
+    # a variable taint can't confirm must NOT read safe (JS taint is weaker than Python's)
+    assert assess(_sink("db.query"), "`SELECT ${id}`", set()) == VERDICT_UNKNOWN
+
+
+def test_assess_sql_all_literal_template_is_safe():
+    assert assess(_sink("db.query"), "`SELECT 1 FROM t`", set()) == VERDICT_SAFE
+
+
+def test_assess_opaque_is_unknown():
+    assert assess(_sink("db.query"), "buildQuery()", set()) == VERDICT_UNKNOWN
+
+
+def test_assess_unreadable_arg_is_unknown():
+    assert assess(_sink("db.query"), None, set()) == VERDICT_UNKNOWN
+
+
+def test_assess_code_eval_literal_safe_variable_unsafe():
+    assert assess(_sink("eval"), "'1 + 1'", set()) == VERDICT_SAFE
+    assert assess(_sink("eval"), "userCode", {"userCode"}) == VERDICT_UNSAFE
+    assert assess(_sink("eval"), "userCode", set()) == VERDICT_UNKNOWN
+
+
+def test_assess_command_inherent_shell_tainted_unsafe():
+    assert assess(_sink("child_process.exec"), "`ls ${dir}`", {"dir"}) == VERDICT_UNSAFE
+    assert assess(_sink("child_process.exec"), "`ls ${dir}`", set()) == VERDICT_UNKNOWN
+    assert assess(_sink("child_process.exec"), "'ls -la'", set()) == VERDICT_SAFE

--- a/tests/test_js_provenance.py
+++ b/tests/test_js_provenance.py
@@ -76,3 +76,25 @@ def test_assess_command_inherent_shell_tainted_unsafe():
     assert assess(_sink("child_process.exec"), "`ls ${dir}`", {"dir"}) == VERDICT_UNSAFE
     assert assess(_sink("child_process.exec"), "`ls ${dir}`", set()) == VERDICT_UNKNOWN
     assert assess(_sink("child_process.exec"), "'ls -la'", set()) == VERDICT_SAFE
+
+
+def test_classify_bare_concat_is_composed():
+    assert classify("cmd + userInput") == "composed"
+    assert classify("base + dir") == "composed"
+
+
+def test_assess_bare_concat_tainted_is_unsafe():
+    assert (
+        assess(_sink("child_process.exec"), "base + userInput", {"userInput"})
+        == VERDICT_UNSAFE
+    )
+
+
+def test_assess_bare_concat_untainted_is_unknown():
+    # a variable, unresolved -> UNKNOWN, never SAFE
+    assert assess(_sink("db.query"), "base + dir", set()) == VERDICT_UNKNOWN
+
+
+def test_arithmetic_in_call_is_not_composed():
+    # the '+' is inside parens, not top-level
+    assert classify("f(1 + 2)") == "opaque"

--- a/tests/test_js_provenance.py
+++ b/tests/test_js_provenance.py
@@ -98,3 +98,29 @@ def test_assess_bare_concat_untainted_is_unknown():
 def test_arithmetic_in_call_is_not_composed():
     # the '+' is inside parens, not top-level
     assert classify("f(1 + 2)") == "opaque"
+
+
+def test_assess_all_literal_concat_is_safe():
+    assert assess(_sink("db.query"), "'a' + 'b'", set()) == VERDICT_SAFE
+
+
+def test_assess_paren_tainted_operand_is_unsafe():
+    # a '+' operand that begins with '(' carries no leading identifier char, but
+    # a tainted variable inside it must still be found -- never read as safe
+    assert assess(_sink("db.query"), "'x = ' + (id)", {"id"}) == VERDICT_UNSAFE
+    assert assess(_sink("db.query"), "'x = ' + (id || 1)", {"id"}) == VERDICT_UNSAFE
+
+
+def test_assess_bracket_tainted_operand_is_unsafe():
+    assert assess(_sink("db.query"), "'x = ' + [id]", {"id"}) == VERDICT_UNSAFE
+
+
+def test_assess_ternary_tainted_operand_is_unsafe():
+    assert assess(_sink("db.query"), "'x = ' + (id ? id : 1)", {"id"}) == VERDICT_UNSAFE
+
+
+def test_assess_paren_untainted_operand_is_unknown_not_safe():
+    assert assess(_sink("db.query"), "'x = ' + (id)", set()) == VERDICT_UNKNOWN
+    assert assess(_sink("db.query"), "'x = ' + (id || 1)", set()) == VERDICT_UNKNOWN
+    assert assess(_sink("db.query"), "'x = ' + [id]", set()) == VERDICT_UNKNOWN
+    assert assess(_sink("db.query"), "'x = ' + (id ? id : 1)", set()) == VERDICT_UNKNOWN

--- a/tests/test_js_verdicts_e2e.py
+++ b/tests/test_js_verdicts_e2e.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 from cybergraph.analysis.javascript import analyze_javascript_file
+from cybergraph.security.capability import CAPABILITIES, FAIL, NOT_SUPPORTED
+from cybergraph.security.check import check_change
+from cybergraph.security.verdict import STATE_REVIEW
 
 
 def _rules(tmp_path: Path, name: str, src: str):
@@ -40,3 +44,46 @@ def test_non_registry_sink_stays_inventory(tmp_path):
     rules = _rules(tmp_path, "a.js", "function h(res, x){ return res.render(x); }\n")
     assert "CG-JS-SINK-CALL" in rules
     assert "CG-SQL-EXEC" not in rules
+
+
+def _cap(cid):
+    return next(c for c in CAPABILITIES if c.id == cid)
+
+
+def test_four_capabilities_cover_web():
+    for cid in ("sql_construction", "command_execution", "code_execution", "path_access"):
+        assert any(g in _cap(cid).covers for g in ("*.ts", "*.js")), cid
+    assert "*.ts" not in _cap("deserialization").covers  # unchanged
+
+
+def _repo(tmp_path):
+    repo = tmp_path / "r"
+    repo.mkdir()
+    for a in (["init", "-q"], ["config", "user.email", "t@e.com"], ["config", "user.name", "t"]):
+        subprocess.run(["git", "-C", str(repo), *a], check=True)
+    (repo / "README.md").write_text("# x\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "base"], check=True)
+    return repo
+
+
+def test_js_sqli_reviews_under_sql_construction(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "h.ts").write_text(
+        "export function h(db, req){ const id = req.query.id;\n"
+        "  return db.query(`SELECT * FROM u WHERE id = ${id}`); }\n",
+        encoding="utf-8",
+    )
+    verdict = check_change(repo, mode="worktree")
+    assert verdict.state == STATE_REVIEW
+    assert any(c.capability_id == "sql_construction" and c.status == FAIL
+               for c in verdict.checks)
+
+
+def test_js_still_not_supported_overall(tmp_path):
+    # source_analysis_support stays NOT_SUPPORTED for JS (the tool doesn't overclaim)
+    repo = _repo(tmp_path)
+    (repo / "h.ts").write_text("export const x = 1;\n", encoding="utf-8")
+    verdict = check_change(repo, mode="worktree")
+    assert any(c.capability_id == "source_analysis_support" and c.status == NOT_SUPPORTED
+               for c in verdict.checks)

--- a/tests/test_js_verdicts_e2e.py
+++ b/tests/test_js_verdicts_e2e.py
@@ -39,6 +39,21 @@ def test_unresolved_variable_query_is_unverified(tmp_path):
     assert "CG-SQL-EXEC" not in rules  # not a confident unsafe on an unproven variable
 
 
+def test_tainted_concat_operand_shapes_are_unsafe(tmp_path):
+    # each of these begins the '+' operand with '(', '[', or a ternary rather
+    # than a leading identifier character -- all must still confirm unsafe
+    idioms = [
+        "db.query('SELECT * FROM u WHERE id = ' + (id))",
+        "db.query('SELECT * FROM u WHERE id = ' + (id || 1))",
+        "db.query('SELECT * FROM u WHERE id = ' + [id])",
+        "db.query('SELECT ' + (id ? id : 1))",
+    ]
+    for i, call in enumerate(idioms):
+        src = f"function h(db, req){{ const id = req.query.id;\n  return {call}; }}\n"
+        rules = _rules(tmp_path, f"c{i}.js", src)
+        assert "CG-SQL-EXEC" in rules, call
+
+
 def test_non_registry_sink_stays_inventory(tmp_path):
     # res.render is in the legacy SINK_CALLS but not the verdict registry -> inventory-grade
     rules = _rules(tmp_path, "a.js", "function h(res, x){ return res.render(x); }\n")

--- a/tests/test_js_verdicts_e2e.py
+++ b/tests/test_js_verdicts_e2e.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cybergraph.analysis.javascript import analyze_javascript_file
+
+
+def _rules(tmp_path: Path, name: str, src: str):
+    p = tmp_path / name
+    p.write_text(src, encoding="utf-8")
+    _n, _e, findings = analyze_javascript_file(p, tmp_path)
+    return [f.rule_id for f in findings]
+
+
+def test_parameterized_query_is_safe(tmp_path):
+    src = "function h(db,id){ return db.query('SELECT * FROM u WHERE id = ?', [id]); }\n"
+    rules = _rules(tmp_path, "a.js", src)
+    assert "CG-SQL-EXEC" not in rules
+    assert "CG-SQL-EXEC-UNVERIFIED" not in rules
+    assert "CG-JS-SINK-CALL" not in rules  # a registered sink no longer emits inventory
+
+
+def test_tainted_template_query_is_unsafe(tmp_path):
+    src = (
+        "function h(db, req){ const id = req.query.id;\n"
+        "  return db.query(`SELECT * FROM u WHERE id = ${id}`); }\n"
+    )
+    assert "CG-SQL-EXEC" in _rules(tmp_path, "a.js", src)
+
+
+def test_unresolved_variable_query_is_unverified(tmp_path):
+    src = "function h(db, id){ return db.query(`SELECT * FROM u WHERE id = ${id}`); }\n"
+    rules = _rules(tmp_path, "a.js", src)
+    assert "CG-SQL-EXEC-UNVERIFIED" in rules
+    assert "CG-SQL-EXEC" not in rules  # not a confident unsafe on an unproven variable
+
+
+def test_non_registry_sink_stays_inventory(tmp_path):
+    # res.render is in the legacy SINK_CALLS but not the verdict registry -> inventory-grade
+    rules = _rules(tmp_path, "a.js", "function h(res, x){ return res.render(x); }\n")
+    assert "CG-JS-SINK-CALL" in rules
+    assert "CG-SQL-EXEC" not in rules

--- a/tests/test_sinks_javascript.py
+++ b/tests/test_sinks_javascript.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import pytest
+
+from cybergraph.security.sinks import lookup_sink
+
+
+@pytest.mark.parametrize("call_name,rule_id,vuln", [
+    ("db.query", "CG-SQL-EXEC", "sql"),
+    ("pool.query", "CG-SQL-EXEC", "sql"),
+    ("knex.raw", "CG-SQL-EXEC", "sql"),
+    ("connection.execute", "CG-SQL-EXEC", "sql"),
+    ("child_process.exec", "CG-CMD-EXEC", "command"),
+    ("execSync", "CG-CMD-EXEC", "command"),
+    ("eval", "CG-CODE-EXEC", "code"),
+    ("Function", "CG-CODE-EXEC", "code"),
+    ("fs.readFile", "CG-PATH-TRAVERSAL", "path"),
+    ("fsp.writeFile", "CG-PATH-TRAVERSAL", "path"),
+])
+def test_javascript_sinks_resolve(call_name, rule_id, vuln):
+    sink = lookup_sink(call_name, "javascript")
+    assert sink is not None, call_name
+    assert sink.rule_id == rule_id
+    assert sink.vuln_class == vuln
+
+
+def test_non_sink_js_name_is_none():
+    assert lookup_sink("res.render", "javascript") is None
+    assert lookup_sink("console.log", "javascript") is None
+
+
+def test_python_lookups_unchanged():
+    assert lookup_sink("os.system", "python").rule_id == "CG-CMD-EXEC"
+    assert lookup_sink("db.query", "python") is None  # JS sink not registered for python


### PR DESCRIPTION
## What this does

The first slice of the **non-Python verdict upgrade**: JavaScript/TypeScript graduates from inventory-grade `CG-JS-SINK-CALL` to real safe/unsafe/unknown verdicts for the four sink classes CyberGraph already verifies in Python — SQL, command, code-exec, path — reviewing under the *same* capabilities as Python.

- **JS sink registry** (`sinks.py`) reusing Python's rule ids: `db.query`/`knex.raw` → `CG-SQL-EXEC`, `child_process.exec` → `CG-CMD-EXEC`, `eval`/`Function` → `CG-CODE-EXEC`, `fs.*` → `CG-PATH-TRAVERSAL`.
- **`js_provenance.py`** — a stdlib-only construction classifier + assessor: extracts the sink argument (string-aware paren matcher, multi-line safe), classifies literal / composed / opaque, and grades it, refined by the taint `javascript.py` already tracks.
- **`javascript.py`** routes the four classes through the assessor and emits the graded verdict (`CG-SQL-EXEC` / `-UNVERIFIED` / suppressed), replacing the flat inventory finding for those names; other JS sinks stay inventory.
- **The four injection capabilities** (`sql_construction`, `command_execution`, `code_execution`, `path_access`) now `cover` web globs, so a JS injection → FAIL → REVIEW alongside Python. `VERIFIED_GLOBS` is deliberately **unchanged**: `source_analysis_support` still reports JS NOT_SUPPORTED — the tool claims exactly the four classes it verifies, never "JS is fully verified."

> **Stacked on #45** (base `feat/cors-client-boundary`, itself on #44). Rebases onto `main` and retargets as the parents merge.

## The cardinal rule — and how hard it was defended

**Only an all-literal/constant construction is SAFE. A variable is UNSAFE (taint-confirmed) or UNKNOWN (unresolved) — never SAFE.** This is deliberately more conservative than Python's predicates because JS taint is weaker (intra-function, line-based), so "untainted therefore safe" is not trustworthy here.

The review loop caught **four defects**, three of them real false-SAFEs (a real injection reading safe — the one thing this slice must never do), each now a red-under-mutation regression test:

1. an OPAQUE bare identifier (`db.query(userInput)`) read SAFE (`variable_names` returned `[]`);
2. a bare identifier concatenation (`exec(base + userInput)`) classified OPAQUE → under-graded;
3. a whole-file-vs-line **offset bug** made the classifier read the wrong line's argument;
4. **(final review)** a tainted operand not led by an identifier — `'…' + (id)`, `+ (id || 1)`, `+ [id]`, `+ (id ? id : 1)`, all common Express idioms — read SAFE. Fixed by requiring *positive* proof every operand is a literal/constant (never inferring "no name found ⇒ literal").

## Verification

- Full suite **1275 passed, 1 skipped**; ruff clean on touched files.
- Mutation harness **40/40 CAUGHT**, including three new JS fail-opens (tainted→safe, unresolved→safe, `+`-operand→safe).
- `run_precision`/`run_eval` **1.0 / 1.0 / 1.0**, byte-identical to before — the registry is language-keyed, so Python is untouched (verified).
- End-to-end: the vulnerable-express example's `db.query('…' + name)` (tainted `req.query.name`) now grades **UNSAFE → CG-SQL-EXEC**; a parameterized query → PASS.

## Out of scope (later slices)

JS XSS / SSRF / deserialization; interprocedural/cross-file taint; and Go / Java / C# (each a later slice replicating this proven shape). `CG-JS-SINK-CALL` inventory remains for JS sinks outside the four classes. Audit §4.5 is marked **partially** resolved (JS core-four), not closed.
