### PR TITLE
feat: re-land Go verdicts — SQL/command/path (revert of revert #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ CyberGraph is designed to connect those dots.
   that introduces either is a REVIEW.
 - **JS/TS SQL/command/code/path verdicts** — Express/Node sink arguments are graded SAFE/UNSAFE/UNKNOWN
   from construction provenance (literal vs. tainted-variable vs. unresolved), not just inventoried.
+  Go now earns the same treatment for its SQL/command/path sinks (`database/sql`, `os/exec`,
+  `os`/`io/ioutil`), fail-safe on anything a Go parser would be needed to read.
 - **Cross-file, interprocedural attack paths** (route → service → repository → sink) with confidence, sanitizer-barrier flags, taint/data-reachability, risk scores, and fix guidance; a `--shallow` mode reproduces intra-function traversal for comparison.
 - **Interactive, offline HTML report** built for first-time readers: a dark-mode-first neon graph explorer (glowing, security-typed nodes with a light/dark toggle), NODE/EDGE/ZONE explainer cards, a guided first view that opens on the top attack path with a plain-language narrative, a security-zones view (Attack Surface → Guards → Logic → Sensitive Sinks), search, layer/severity filters, a details panel with source drill-down, and entrypoint→sink path highlighting (Cytoscape.js, fully inlined).
 - **Exec-first report posture**: an A–F security grade with a one-line verdict and severity-distribution bar, a since-last-scan delta strip (new/regressed/fixed), findings grouped into expandable rule cards, an honest findings-cap footer, and a print stylesheet for clean PDF export.

--- a/benchmark/mutation_harness.py
+++ b/benchmark/mutation_harness.py
@@ -582,6 +582,79 @@ MUTATIONS: list[Mutation] = [
         "tainted userCmd, the command in a later argument than the shell program name) "
         "must not read safe",
     ),
+    # -- D9: the Go verdict assessor must never fail open --------------------
+    Mutation(
+        id="D9-go-tainted-sink-reads-safe",
+        disaster="D9",
+        file="cybergraph/analysis/go_provenance.py",
+        old="        if any(n in tainted_names for n in names):\n"
+        "            return VERDICT_UNSAFE",
+        new="        if any(n in tainted_names for n in names):\n"
+        "            return VERDICT_SAFE",
+        tests=("tests/test_go_provenance.py::test_assess_concat_tainted_unsafe",),
+        note="a tainted Go sink argument must not read safe",
+    ),
+    Mutation(
+        id="D9-go-unresolved-var-reads-safe",
+        disaster="D9",
+        file="cybergraph/analysis/go_provenance.py",
+        old="        if names or unresolved:\n"
+        "            # a candidate variable (resolved or not) or an operand we could not\n"
+        "            # prove literal -> never read as safe\n"
+        "            return VERDICT_UNKNOWN",
+        new="        if names or unresolved:\n"
+        "            # a candidate variable (resolved or not) or an operand we could not\n"
+        "            # prove literal -> never read as safe\n"
+        "            return VERDICT_SAFE",
+        tests=("tests/test_go_provenance.py::test_assess_sprintf_unresolved_unknown",),
+        note="a Go variable CyberGraph cannot resolve must read UNKNOWN, never SAFE",
+    ),
+    Mutation(
+        id="D9-go-operand-reads-safe",
+        disaster="D9",
+        file="cybergraph/analysis/go_provenance.py",
+        old="        idents = _IDENT_RE.findall(p)\n"
+        "        if not idents:\n"
+        "            unresolved = True\n"
+        "            continue",
+        new="        m = _IDENT_RE.match(p)\n"
+        "        if m is None:\n"
+        "            continue\n"
+        "        idents = [m.group(0)]",
+        tests=("tests/test_go_provenance.py::test_assess_non_leading_ident_operand_not_safe",),
+        note="a '+' operand not led by an identifier character (e.g. `(id)`) must still "
+        "have its identifiers found; matching only from the operand's start silently "
+        "drops the name and the construction reads safe",
+    ),
+    Mutation(
+        id="D9-go-sprintf-format-reads-safe",
+        disaster="D9",
+        file="cybergraph/analysis/go_provenance.py",
+        old="    args = _split_call_args(sprintf_text)\n"
+        "    return _operand_candidates(args)",
+        new="    args = _split_call_args(sprintf_text)\n"
+        "    return _operand_candidates(args[1:])",
+        tests=("tests/test_go_provenance.py::test_sprintf_variable_format_is_unsafe",),
+        note="fmt.Sprintf's FORMAT argument is a runtime value in Go, not a literal like "
+        "a JS template literal's leading piece; skipping it drops a tainted format "
+        "string (`fmt.Sprintf(userQuery)`) and the sink reads safe",
+    ),
+    Mutation(
+        id="D9-go-command-shell-reads-safe",
+        disaster="D9",
+        file="cybergraph/analysis/go_provenance.py",
+        old="    names, _unresolved = _operand_candidates(args)\n"
+        "    if any(n in tainted_names for n in names):\n"
+        "        return VERDICT_UNSAFE\n"
+        "    return VERDICT_UNKNOWN",
+        new="    names, _unresolved = _operand_candidates(args)\n"
+        "    if any(n in tainted_names for n in names):\n"
+        "        return VERDICT_SAFE\n"
+        "    return VERDICT_UNKNOWN",
+        tests=("tests/test_go_provenance.py::test_command_shell_form_tainted_is_unsafe",),
+        note="a taint-confirmed command argument (`exec.Command(\"sh\", \"-c\", userCmd)` "
+        "with tainted userCmd) must not read safe",
+    ),
 ]
 
 

--- a/docs/CRITICAL_AUDIT.md
+++ b/docs/CRITICAL_AUDIT.md
@@ -314,14 +314,15 @@ the CI SARIF filter until each language gets its own Phase-2 sink registry/predi
 the project takes on a parsing dependency, which is the tradeoff already recorded above
 against §3.2's zero-dependency moat).
 
-**Note (2026-08-11): resolved for JS SQL/command/code/path (slice 1 of the non-Python
-upgrade); Go/Java/C# and other JS classes remain inventory-grade.** Without a JS parser, a
-structural, statement-local classifier (`analysis/js_provenance.py`) now grades the four core
-sink argument classes (SQL, command, code-exec, path) for JavaScript/TypeScript as SAFE
-(all-literal/constant construction only), UNSAFE (a construction containing a variable that
-line-based intra-function taint confirms), or UNKNOWN (a variable it cannot resolve — never
-SAFE) rather than emitting the flat `CG-JS-SINK-CALL` inventory row. This is one language and
-four sink classes only: Go, Java, and C# are unchanged, and other JS/TS sink classes (beyond
+**Note (2026-08-11): resolved for JS (core four) and Go (SQL/command/path); Java/C# and
+other classes remain inventory-grade.** Without a JS or Go parser, a structural,
+statement-local classifier per language (`analysis/js_provenance.py`,
+`analysis/go_provenance.py`) now grades sink arguments as SAFE (all-literal/constant
+construction only), UNSAFE (a construction containing a variable that line-based
+intra-function taint confirms), or UNKNOWN (a variable it cannot resolve — never SAFE)
+rather than emitting the flat `CG-{JS,GO}-SINK-CALL` inventory row. JS covers four sink
+classes (SQL, command, code-exec, path); Go covers three (SQL, command, path — Go has no
+registered code-exec sink). Java and C# are unchanged, and other JS/TS sink classes (beyond
 SQL/command/code/path) still fall back to the pre-rewrite inventory rule. §4.5 stays OPEN.
 
 ### 4.6 MEDIUM — benchmark claims drift from the committed artifact

--- a/docs/superpowers/plans/2026-08-11-go-verdicts.md
+++ b/docs/superpowers/plans/2026-08-11-go-verdicts.md
@@ -1,0 +1,475 @@
+# Go Verdicts — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn Go from inventory-grade `CG-GO-SINK-CALL` into real safe/unsafe/unknown verdicts for SQL, command, and path, reusing Python's rule ids so a Go injection reviews under the same capability as Python — precisely, with only an all-literal/constant construction ever reading SAFE.
+
+**Architecture:** Port the JS slice's proven shape to Go — a `_GO` sink registry in `sinks.py`, a new `go_provenance.py` (construction classifier + fail-safe assessor, reusing the *proven, final* `js_provenance` logic incl. positive-literal-proof, adapted to Go strings and `fmt.Sprintf`), `go.py` routing the three classes through it, and a broadening of three capabilities. No `checks.py` change.
+
+**Tech Stack:** Python 3.10–3.13, standard library only (`re`). Existing `sinks.Sink`/`lookup_sink`, `predicates.VERDICT_*`, `provenance.LITERAL/COMPOSED/OPAQUE`, the capability/coverage machinery, and `go.py`'s existing intra-function taint. `src/cybergraph/analysis/js_provenance.py` is the reference implementation for the shared classifier logic.
+
+## Global Constraints
+
+- **Zero runtime dependencies**; standard library only (`re`) — no Go parser. The classifier is lightweight/structural and fail-safe.
+- Python 3.10–3.13. `from __future__ import annotations` first line of any new file.
+- Ruff line-length 100; run `ruff check` on every touched file — clean.
+- No network; no API keys on any default path.
+- **Precision over recall (cardinal):** only an all-literal/constant construction is SAFE. A construction containing a variable is UNSAFE (taint-confirmed) or UNKNOWN (unresolved) — **never SAFE**, never a confident UNSAFE on an unresolved variable. **Never infer "no candidate names ⇒ literal"** — require positive proof every operand/argument is a literal/constant (this is the exact false-SAFE the JS final review caught).
+- Findings carry the standard fields and honor `is_inline_suppressed`.
+- Commits `Laraib <lxh417bham@gmail.com>` only (repo-local config already carries it — do **not** pass `-c user.email=`); no `Co-Authored-By`, no AI attribution. Many small commits; never squash. Push only to `https://github.com/AQ-Labs/cybergraph`.
+- Branch `feat/go-verdicts` is stacked on `feat/js-verdicts-core-four`; do not rebase during implementation.
+
+---
+
+## File Structure
+
+- `src/cybergraph/security/sinks.py` (modify) — add `_GO`; register in `_BY_LANGUAGE`.
+- `src/cybergraph/analysis/go_provenance.py` (create) — Go classifier + assessor.
+- `src/cybergraph/analysis/go.py` (modify) — route the three sink classes through the assessor.
+- `src/cybergraph/security/capability.py` (modify) — `GO_GLOBS`; broaden three capabilities.
+- `src/cybergraph/security/coverage.py` (modify) — add `GO_GLOBS` to the verified gate.
+- Tests: `tests/test_sinks_go.py`, `tests/test_go_provenance.py`, `tests/test_go_verdicts_e2e.py` (create).
+- `benchmark/mutation_harness.py` (modify) — three seeded fail-opens.
+- `README.md`, `docs/CRITICAL_AUDIT.md` (modify) — document; extend §4.5 note.
+
+---
+
+## Task 1: Go sink registry in `sinks.py`
+
+**Files:** Modify `src/cybergraph/security/sinks.py`; Test `tests/test_sinks_go.py` (create).
+
+**Interfaces:** `_GO: tuple[Sink, ...]` and `_BY_LANGUAGE["go"] = _GO`, so `lookup_sink(name, "go")` resolves Go sinks (reuse the existing `_SQL`/`_CMD` plain-text constants — do not duplicate them).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_sinks_go.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from cybergraph.security.sinks import lookup_sink
+
+
+@pytest.mark.parametrize("call_name,rule_id,vuln", [
+    ("db.Query", "CG-SQL-EXEC", "sql"),
+    ("db.QueryRow", "CG-SQL-EXEC", "sql"),
+    ("tx.Exec", "CG-SQL-EXEC", "sql"),
+    ("db.QueryContext", "CG-SQL-EXEC", "sql"),
+    ("exec.Command", "CG-CMD-EXEC", "command"),
+    ("exec.CommandContext", "CG-CMD-EXEC", "command"),
+    ("os.Open", "CG-PATH-TRAVERSAL", "path"),
+    ("os.ReadFile", "CG-PATH-TRAVERSAL", "path"),
+    ("ioutil.WriteFile", "CG-PATH-TRAVERSAL", "path"),
+    ("os.Create", "CG-PATH-TRAVERSAL", "path"),
+])
+def test_go_sinks_resolve(call_name, rule_id, vuln):
+    sink = lookup_sink(call_name, "go")
+    assert sink is not None, call_name
+    assert sink.rule_id == rule_id
+    assert sink.vuln_class == vuln
+
+
+def test_go_non_sink_is_none():
+    assert lookup_sink("fmt.Sprintf", "go") is None  # construction, not a sink
+    assert lookup_sink("log.Println", "go") is None
+
+
+def test_other_languages_unchanged():
+    assert lookup_sink("os.system", "python").rule_id == "CG-CMD-EXEC"
+    assert lookup_sink("db.Query", "python") is None
+    assert lookup_sink("db.query", "javascript").rule_id == "CG-SQL-EXEC"
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+`pytest tests/test_sinks_go.py -v` — FAIL (Go sinks return None).
+
+- [ ] **Step 3: Implement**
+
+In `sinks.py`, add after `_JAVASCRIPT`:
+
+```python
+_GO: tuple[Sink, ...] = (
+    # SQL — db/tx receivers unresolvable → bare on the PascalCase method name.
+    Sink("Query", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("QueryRow", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("QueryContext", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("QueryRowContext", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("Exec", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("ExecContext", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    # Command — exec.Command(name, args…); shell only when name is sh/bash -c → conditional.
+    Sink("exec.Command", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _CMD, "command",
+         shell=SHELL_CONDITIONAL),
+    Sink("exec.CommandContext", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _CMD, "command",
+         shell=SHELL_CONDITIONAL),
+    # Path — os/ioutil receivers → bare on the PascalCase method name.
+    Sink("Open", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("OpenFile", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("ReadFile", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("WriteFile", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("Create", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+)
+```
+
+Change `_BY_LANGUAGE` to include `"go": _GO`.
+
+> `exec.Command` is registered as the full dotted name (non-bare, exact) so it resolves on `lookup_sink("exec.Command","go")`; `Command` alone is not bare (avoids matching unrelated `.Command()`). Confirm `test_go_non_sink_is_none` holds — `fmt.Sprintf`/`log.Println` have no entry.
+
+- [ ] **Step 4: Run + ruff**
+
+`pytest tests/test_sinks_go.py -v` → PASS. `ruff check src/cybergraph/security/sinks.py tests/test_sinks_go.py` → clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/security/sinks.py tests/test_sinks_go.py
+git commit -m "feat(sinks): register Go SQL/command/path sinks with Python's rule ids"
+```
+
+---
+
+## Task 2: `go_provenance.py` — classifier + assessor
+
+**Files:** Create `src/cybergraph/analysis/go_provenance.py`; Test `tests/test_go_provenance.py` (create).
+
+**Interfaces:** `extract_first_arg(source, open_paren) -> str | None`, `classify(arg_text) -> str`, `variable_names(arg_text) -> list[str]`, `assess(sink, arg_text, tainted_names) -> str`. Same contract and cardinal rule as `js_provenance`.
+
+**Approach:** START from `src/cybergraph/analysis/js_provenance.py` (the final, reviewed version — it already has the correct positive-literal-proof logic: `_is_proven_literal_operand`, `_plus_operand_candidates`, `_split_plus`, and the `assess` that only reads SAFE on proven literals). Port it to Go, changing only:
+1. **No `${}` template interpolation** in Go — drop the `_INTERP_RE` path.
+2. **`fmt.Sprintf` is Go's interpolation idiom** — add it as a COMPOSED form and extract its non-format arguments as candidate variables.
+3. **Go string literals** are interpreted `"…"` and raw `` `…` `` (backtick); no single-quote strings (single quotes are runes). Keep the string-aware matchers; `_STRING_ONLY_RE`/`_is_proven_literal_operand` already accept `"…"` and `` `…` ``.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_go_provenance.py`:
+
+```python
+from __future__ import annotations
+
+from cybergraph.analysis.go_provenance import assess, classify, extract_first_arg
+from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNKNOWN, VERDICT_UNSAFE
+from cybergraph.security.sinks import lookup_sink
+
+
+def _sink(name):
+    return lookup_sink(name, "go")
+
+
+def test_extract_first_arg_string_aware():
+    src = 'db.Query(fmt.Sprintf("SELECT %s", id), other)'
+    assert extract_first_arg(src, src.index("(")) == 'fmt.Sprintf("SELECT %s", id)'
+    assert extract_first_arg('db.Query(`raw ) str`)', 8) == '`raw ) str`'
+    assert extract_first_arg("db.Query(`oops", 8) is None
+
+
+def test_classify():
+    assert classify('"SELECT 1"') == "literal"
+    assert classify("`SELECT 1`") == "literal"
+    assert classify('"SELECT " + id') == "composed"
+    assert classify('fmt.Sprintf("SELECT %s", id)') == "composed"
+    assert classify("userVar") == "opaque"
+
+
+def test_assess_literal_safe():
+    assert assess(_sink("db.Query"), '"SELECT 1"', set()) == VERDICT_SAFE
+
+
+def test_assess_sprintf_tainted_unsafe():
+    assert assess(_sink("db.Query"), 'fmt.Sprintf("SELECT %s", id)', {"id"}) == VERDICT_UNSAFE
+
+
+def test_assess_sprintf_unresolved_unknown():
+    assert assess(_sink("db.Query"), 'fmt.Sprintf("SELECT %s", id)', set()) == VERDICT_UNKNOWN
+
+
+def test_assess_sprintf_all_literal_safe():
+    assert assess(_sink("db.Query"), 'fmt.Sprintf("SELECT %d", 1)', set()) == VERDICT_SAFE
+
+
+def test_assess_concat_tainted_unsafe():
+    assert assess(_sink("db.Query"), '"SELECT " + name', {"name"}) == VERDICT_UNSAFE
+
+
+def test_assess_non_leading_ident_operand_not_safe():
+    # the JS-lesson guard: an operand not led by an identifier must not read SAFE
+    assert assess(_sink("db.Query"), '"x = " + (id)', {"id"}) == VERDICT_UNSAFE
+    assert assess(_sink("db.Query"), '"x = " + (id)', set()) == VERDICT_UNKNOWN
+
+
+def test_assess_opaque_unknown():
+    assert assess(_sink("db.Query"), "buildQuery()", set()) == VERDICT_UNKNOWN
+
+
+def test_assess_unreadable_unknown():
+    assert assess(_sink("db.Query"), None, set()) == VERDICT_UNKNOWN
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+`pytest tests/test_go_provenance.py -v` — FAIL (`ModuleNotFoundError`).
+
+- [ ] **Step 3: Implement**
+
+Create `go_provenance.py` by porting `js_provenance.py`. Keep `extract_first_arg`, `_split_plus`, `_is_proven_literal_operand`, `_plus_operand_candidates`, and the `assess` structure verbatim (they are language-agnostic and carry the positive-literal-proof invariant). Changes:
+
+- `classify(arg_text)`:
+```python
+def classify(arg_text: str) -> str:
+    s = arg_text.strip()
+    if _STRING_ONLY_RE.match(s):            # "..." or `...`
+        return LITERAL
+    if s.startswith("fmt.Sprintf(") or len(_split_plus(s)) > 1:
+        return COMPOSED
+    return OPAQUE
+```
+- `variable_names(arg_text)` — no `${}` path; instead:
+```python
+def variable_names(arg_text: str) -> list[str]:
+    s = arg_text.strip()
+    if s.startswith("fmt.Sprintf(") and s.endswith(")"):
+        inner = extract_call_all_args(s)      # args of Sprintf
+        names, _unresolved = _args_candidates(inner[1:])  # skip the format literal
+        return _dedup(names)
+    plus_names, _unresolved = _plus_operand_candidates(arg_text)
+    return _dedup(plus_names)
+```
+  where `extract_call_all_args(sprintf_text)` splits the Sprintf argument list at top level (reuse a comma-split like `extract_first_arg`'s logic, but returning ALL args), and `_args_candidates(args)` applies `_is_proven_literal_operand` per arg (an all-literal Sprintf → no names). `assess` must also honor the "unresolved" flag from Sprintf args (a non-literal arg with no identifier → UNKNOWN, never SAFE), exactly as the `+` path does.
+- Drop `_INTERP_RE` and the JS `${}` handling.
+
+Keep `assess` returning: LITERAL → SAFE; else compute candidate names + unresolved; a tainted candidate → UNSAFE; any candidate or unresolved → UNKNOWN; all-proven-literal → SAFE; OPAQUE bare identifier → UNSAFE if tainted else UNKNOWN; `None` → UNKNOWN.
+
+> The exact port must preserve the invariant tested by `test_assess_non_leading_ident_operand_not_safe` and `test_assess_sprintf_unresolved_unknown`. If porting reveals a helper is JS-specific, adapt it; never weaken a test.
+
+- [ ] **Step 4: Run + ruff**
+
+`pytest tests/test_go_provenance.py -v` → PASS. `ruff check src/cybergraph/analysis/go_provenance.py tests/test_go_provenance.py` → clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/analysis/go_provenance.py tests/test_go_provenance.py
+git commit -m "feat(analysis): Go construction classifier and fail-safe sink assessor"
+```
+
+---
+
+## Task 3: Route Go sink calls through the assessor
+
+**Files:** Modify `src/cybergraph/analysis/go.py`; Test `tests/test_go_verdicts_e2e.py` (create).
+
+**Interfaces:** a Go sink resolving via `lookup_sink(call_name, "go")` (original case) → graded verdict (`sink.rule_id` / `+"-UNVERIFIED"` / none), replacing `CG-GO-SINK-CALL` for those names; non-registry legacy sinks keep `CG-GO-SINK-CALL`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_go_verdicts_e2e.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from cybergraph.analysis.go import analyze_go_file
+
+
+def _rules(tmp_path, src):
+    p = tmp_path / "main.go"
+    p.write_text(src, encoding="utf-8")
+    _n, _e, findings = analyze_go_file(p, tmp_path)
+    return [f.rule_id for f in findings]
+
+
+def test_parameterized_query_is_safe(tmp_path):
+    src = 'func h(db *sql.DB, id string) { db.Query("SELECT * FROM u WHERE id = $1", id) }\n'
+    rules = _rules(tmp_path, src)
+    assert "CG-SQL-EXEC" not in rules and "CG-SQL-EXEC-UNVERIFIED" not in rules
+    assert "CG-GO-SINK-CALL" not in rules  # a registered sink no longer emits inventory
+
+
+def test_sprintf_tainted_query_is_unsafe(tmp_path):
+    src = (
+        'func h(db *sql.DB, r *http.Request) {\n'
+        '  id := r.URL.Query().Get("id")\n'
+        '  db.Query(fmt.Sprintf("SELECT * FROM u WHERE id = %s", id))\n}\n'
+    )
+    assert "CG-SQL-EXEC" in _rules(tmp_path, src)
+
+
+def test_sprintf_unresolved_query_is_unverified(tmp_path):
+    src = 'func h(db *sql.DB, id string) { db.Query(fmt.Sprintf("SELECT %s", id)) }\n'
+    rules = _rules(tmp_path, src)
+    assert "CG-SQL-EXEC-UNVERIFIED" in rules and "CG-SQL-EXEC" not in rules
+```
+
+> Confirm how a name becomes tainted in `go.py` (the `INPUT_MARKERS` / `r.URL.Query()` path) so `test_sprintf_tainted_query_is_unsafe` genuinely exercises taint (→ UNSAFE), not merely UNKNOWN; adjust the fixture to `go.py`'s actual taint model if needed.
+
+- [ ] **Step 2: Run to verify it fails**
+
+`pytest tests/test_go_verdicts_e2e.py -v` — FAIL (emits `CG-GO-SINK-CALL`).
+
+- [ ] **Step 3: Implement the routing**
+
+In `go.py`, add imports (`from cybergraph.analysis.go_provenance import assess as assess_go_sink, extract_first_arg`; `from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNSAFE`; `from cybergraph.security.sinks import lookup_sink`) and a `_line_start_offsets(source)` helper + `_go_verdict_finding` (port both from `javascript.py` — the offset translation is the JS fix; the finding builder is identical). Replace the `if _is_sink(call_name, custom_sinks):` finding body with registry-first routing:
+
+```python
+            sink = lookup_sink(call_name, "go")
+            if sink is not None or _is_sink(call_name, custom_sinks):
+                edges.append(Edge(EDGE_REACHES_SINK, sink_source, call_name, rel, line_no))
+                if sink is not None:
+                    abs_off = line_starts[line_no - 1] + call.end() - 1
+                    arg = extract_first_arg(source, abs_off)
+                    verdict = assess_go_sink(sink, arg, set(tainted))
+                    finding = _go_verdict_finding(sink, verdict, rel, line_no, line)
+                    if finding is not None and not is_inline_suppressed(
+                        lines, line_no, finding.rule_id
+                    ):
+                        findings.append(finding)
+                elif not is_inline_suppressed(lines, line_no, "CG-GO-SINK-CALL"):
+                    findings.append(Finding(
+                        rule_id="CG-GO-SINK-CALL", severity="medium",
+                        message=f"Go file reaches sensitive sink `{call_name}`",
+                        file_path=rel, line_start=line_no, cwe="CWE-20",
+                        evidence=line.strip(),
+                    ))
+                taint_source = source_key or _tainted_source_for_line(line, tainted)
+                if taint_source:
+                    edges.append(Edge(EDGE_TAINTS, taint_source, call_name, rel, line_no,
+                                      {"function": sink_source, "reason": "tainted argument"}))
+```
+
+Compute `line_starts = _line_start_offsets(source)` once near the top of `analyze_go_file`. Use `set(tainted)` for the tainted-name set (function-local, matching the JS decision).
+
+> `call.end() - 1` is the intra-line index of the `(` (CALL_RE ends in `\(`); `line_starts[line_no-1]` is the absolute start of the line. Confirm `source`/`tainted`/`call` are in scope at the routing point (they are — `source` at the top, `tainted` per-line, `call` from `CALL_RE.finditer(line)`).
+
+- [ ] **Step 4: Run + ruff**
+
+`pytest tests/test_go_verdicts_e2e.py tests/test_go*.py -v` → PASS (update any prior `go` analyzer test expecting `CG-GO-SINK-CALL` for a now-graded sink — change the expectation, not the code). `ruff check src/cybergraph/analysis/go.py tests/test_go_verdicts_e2e.py` → clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/analysis/go.py tests/test_go_verdicts_e2e.py
+git commit -m "feat(analysis): grade Go SQL/command/path sinks into real verdicts"
+```
+
+---
+
+## Task 4: Broaden three capabilities to Go
+
+**Files:** Modify `src/cybergraph/security/capability.py`, `src/cybergraph/security/coverage.py`; Test `tests/test_go_verdicts_e2e.py` (append).
+
+**Interfaces:** `GO_GLOBS = ("*.go",)`; `sql_construction`, `command_execution`, `path_access` → `covers += GO_GLOBS`; `coverage` verified gate `+ GO_GLOBS`. `code_execution`, `deserialization`, `VERIFIED_GLOBS` unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_go_verdicts_e2e.py`:
+
+```python
+import subprocess
+
+from cybergraph.security.capability import CAPABILITIES, FAIL, NOT_SUPPORTED
+from cybergraph.security.check import check_change
+from cybergraph.security.verdict import STATE_REVIEW
+
+
+def _cap(cid):
+    return next(c for c in CAPABILITIES if c.id == cid)
+
+
+def test_three_capabilities_cover_go():
+    for cid in ("sql_construction", "command_execution", "path_access"):
+        assert "*.go" in _cap(cid).covers, cid
+    assert "*.go" not in _cap("code_execution").covers   # no Go code sink
+    assert "*.go" not in _cap("deserialization").covers
+
+
+def _repo(tmp_path):
+    repo = tmp_path / "r"; repo.mkdir()
+    for a in (["init","-q"],["config","user.email","t@e.com"],["config","user.name","t"]):
+        subprocess.run(["git","-C",str(repo),*a], check=True)
+    (repo / "README.md").write_text("# x\n", encoding="utf-8")
+    subprocess.run(["git","-C",str(repo),"add","."], check=True)
+    subprocess.run(["git","-C",str(repo),"commit","-q","-m","base"], check=True)
+    return repo
+
+
+def test_go_sqli_reviews_under_sql_construction(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "h.go").write_text(
+        'package m\nimport ("database/sql"; "fmt"; "net/http")\n'
+        'func h(db *sql.DB, r *http.Request) {\n'
+        '  id := r.URL.Query().Get("id")\n'
+        '  db.Query(fmt.Sprintf("SELECT * FROM u WHERE id = %s", id))\n}\n',
+        encoding="utf-8",
+    )
+    verdict = check_change(repo, mode="worktree")
+    assert verdict.state == STATE_REVIEW
+    assert any(c.capability_id == "sql_construction" and c.status == FAIL
+               for c in verdict.checks)
+
+
+def test_go_still_not_supported_overall(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "h.go").write_text("package m\nvar X = 1\n", encoding="utf-8")
+    verdict = check_change(repo, mode="worktree")
+    assert any(c.capability_id == "source_analysis_support" and c.status == NOT_SUPPORTED
+               for c in verdict.checks)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+`pytest tests/test_go_verdicts_e2e.py -k capabilities or reviews or not_supported -v` — FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `capability.py`: add `GO_GLOBS = ("*.go",)` near the other `*_GLOBS`; change the three capabilities to `PYTHON_GLOBS + WEB_GLOBS + GO_GLOBS`. Leave `code_execution` at `PYTHON_GLOBS + WEB_GLOBS`, `deserialization` at `PYTHON_GLOBS`, `VERIFIED_GLOBS` unchanged.
+
+In `coverage.py`: import `GO_GLOBS` and add it to the verified gate → `VERIFIED_GLOBS + CONFIG_GLOBS + WEB_GLOBS + GO_GLOBS`.
+
+- [ ] **Step 4: Run + ruff**
+
+`pytest tests/test_go_verdicts_e2e.py tests/test_capability.py tests/test_checks.py tests/test_coverage_report.py -v` → PASS (update any stale relevance expectation). `ruff check src/cybergraph/security/capability.py src/cybergraph/security/coverage.py` → clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cybergraph/security/capability.py src/cybergraph/security/coverage.py tests/test_go_verdicts_e2e.py
+git commit -m "feat(verdict): SQL/command/path capabilities now cover Go"
+```
+
+---
+
+## Task 5: Mutations + docs + full verification
+
+**Files:** Modify `benchmark/mutation_harness.py`, `README.md`, `docs/CRITICAL_AUDIT.md`.
+
+- [ ] **Step 1: Add three mutations** to `MUTATIONS` (match `old` strings to the CURRENT committed `go_provenance.py` verbatim; each `old` unique):
+  - `D9-go-tainted-sink-reads-safe` — flip the assessor's taint→UNSAFE branch to SAFE; test `tests/test_go_provenance.py::test_assess_concat_tainted_unsafe`.
+  - `D9-go-unresolved-var-reads-safe` — flip the unresolved→UNKNOWN branch to SAFE; test `test_assess_sprintf_unresolved_unknown`.
+  - `D9-go-sprintf-operand-reads-safe` — target the Sprintf/operand positive-literal-proof path so a non-literal Sprintf arg reads SAFE; test `test_assess_sprintf_tainted_unsafe` (or the non-leading-ident guard).
+  Run `python benchmark/mutation_harness.py` → all three CAUGHT.
+
+- [ ] **Step 2: Docs.** README: a bullet — Go now earns real SQL/command/path verdicts. `docs/CRITICAL_AUDIT.md` §4.5: extend the note to "resolved for JS (core four) and Go (SQL/command/path); Java/C# and other classes remain inventory-grade." Do NOT mark §4.5 fully closed.
+
+- [ ] **Step 3: Full verification.** `pytest -q` (all pass); `ruff check .` (no new errors beyond baseline); `python benchmark/mutation_harness.py` (all CAUGHT); `python benchmark/run_precision.py` + `python benchmark/run_eval.py` (unchanged 1.0/1.0/1.0; Python/JS corpora unaffected — the Go registry is language-keyed; verify identical).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add benchmark/mutation_harness.py README.md docs/CRITICAL_AUDIT.md
+git commit -m "test(go): seed Go verdict fail-open mutations; document the upgrade"
+```
+
+---
+
+## Notes for the executor
+
+- **Precision is cardinal.** Only an all-literal/constant construction is SAFE. Port the JS `assess`/positive-literal-proof logic exactly — do NOT re-derive a looser version. A Sprintf arg or `+` operand that is not provably literal must contribute candidates or force UNKNOWN, never SAFE.
+- Confirm names/signatures against source before running each task's tests (`provenance.LITERAL/…`, `Sink`, `check_change`/`Verdict.checks`, and how `go.py` taints a name); adapt the test to reality, never the reverse.
+- Do NOT add a Go parser dependency, Go-specific rule ids, `*.go` to `VERIFIED_GLOBS`, Go code-exec/template-injection detection, or interprocedural flow — all out of scope.

--- a/docs/superpowers/specs/2026-08-11-go-verdicts-design.md
+++ b/docs/superpowers/specs/2026-08-11-go-verdicts-design.md
@@ -1,0 +1,186 @@
+# Go Verdicts — Design (Non-Python upgrade, slice 2)
+
+**Status:** approved for planning
+**Slice:** the second per-language slice of the non-Python verdict upgrade — Go, for the injection
+classes Go actually has (SQL, command, path). Replicates the shape proven in slice 1 (JS/TS).
+**Predecessors:** the non-Python slice 1 (JS/TS core four, PR #46). This branch is **stacked on
+`feat/js-verdicts-core-four`** (it edits `sinks.py`, `capability.py`, `coverage.py` — the same
+files) and rebases down the stack as parents merge. Stack depth is now 5 (main ← #44 ← #45 ← #46
+← this).
+
+## The sentence this slice is judged against
+
+> Go graduates from inventory `CG-GO-SINK-CALL` to real safe/unsafe/unknown verdicts for the
+> injection classes Go actually has — SQL, command, path — reusing Python's rule ids and
+> reviewing under the same capabilities, with only an all-literal/constant construction ever
+> reading SAFE and no real injection ever reading safe.
+
+## Why this is the right slice
+
+- It is a near-direct port of the JS shape: `go.py` (259 lines) already tracks intra-function
+  taint (`tainted_by_function`, `_tainted_source_for_line`, `EDGE_TAINTS`, `DataFlow` nodes,
+  Go `INPUT_MARKERS` such as `url.query`/`formvalue`/`r.URL`) and emits flat `CG-GO-SINK-CALL`
+  inventory — the same scaffolding `javascript.py` had. The verdict engine's *concept* (the
+  construction lattice + `VERDICT_*` + the language-keyed `sinks.py`) is reused; only the
+  Go-specific construction extraction is new.
+- It validates the "replicate the proven shape" thesis for the remaining languages (Java, C#).
+
+## Decisions already made (do not re-litigate in planning)
+
+1. **Three classes: SQL, command, path.** Code-exec is excluded — Go has no `eval`/`Function`
+   equivalent, so there is no Go code sink (the same justified exclusion as JS-`deserialization`).
+   Go server-side template injection (`text/template` misused for HTML output) is a distinct class
+   like Python's `CG-TEMPLATE-INJECT` and is out of scope (matches JS not doing XSS this early).
+2. **Reuse Python's rule ids and broaden the existing capabilities** — `CG-SQL-EXEC`,
+   `CG-CMD-EXEC`, `CG-PATH-TRAVERSAL`; broaden `sql_construction`, `command_execution`,
+   `path_access` to include `GO_GLOBS`. Do NOT broaden `code_execution` (no Go code sink).
+   `VERIFIED_GLOBS` stays Python-only → `source_analysis_support` stays honestly NOT_SUPPORTED
+   for Go (the tool claims exactly the three classes it verifies, not "Go is fully verified").
+3. **Cardinal rule, with positive-literal-proof from the start.** Only an all-literal/constant
+   construction is SAFE. A construction containing a variable is UNSAFE (taint-confirmed user
+   input) or UNKNOWN (unresolved) — never SAFE, and never a confident UNSAFE on an unresolved
+   variable. **Never infer "no candidate names found ⇒ all-literal ⇒ SAFE"** — this is the exact
+   false-SAFE the JS final review caught (`'…' + (id)`); the Go classifier requires positive proof
+   that every operand/argument is a literal or constant, and any operand it cannot prove literal
+   contributes its identifiers as candidate variables plus an "unresolved" flag.
+
+## Architecture — port the JS shape to Go
+
+```
+src/cybergraph/security/sinks.py        (modify)  add _GO registry; _BY_LANGUAGE["go"]
+src/cybergraph/analysis/go_provenance.py(create)  Go construction classifier + assessor
+src/cybergraph/analysis/go.py           (modify)  route the three sink classes through the assessor
+src/cybergraph/security/capability.py   (modify)  GO_GLOBS; broaden 3 capabilities' covers
+src/cybergraph/security/coverage.py     (modify)  add GO_GLOBS to the verified gate
+```
+
+`checks.py` needs **no change** (the three capabilities already map to the rule ids).
+
+### The Go sink registry (`sinks.py`)
+
+Add `_GO: tuple[Sink, ...]` and `_BY_LANGUAGE["go"] = _GO`, reusing `Sink(name, rule_id, cwe,
+severity, plain, vuln_class, bare, shell)` and Python's rule ids. **Go identifiers are PascalCase
+and exported methods are unqualified-receiver**, so entries are `bare=True` on the PascalCase
+method name, and the routing passes the *original-case* call name to `lookup_sink` (NOT the
+lowercased form `go.py` uses for its legacy substring `_is_sink`):
+
+- **SQL** (`CG-SQL-EXEC`, CWE-89): `Query`, `QueryRow`, `QueryContext`, `QueryRowContext`, `Exec`,
+  `ExecContext` (bare — `db`/`tx` receivers).
+- **Command** (`CG-CMD-EXEC`, CWE-78): `exec.Command`, `exec.CommandContext` (`shell` conditional
+  — Go's `exec.Command(name, args…)` runs no shell unless `name` is `sh`/`bash` with `-c`; the
+  shell case is `exec.Command("sh","-c", cmd)`).
+- **Path** (`CG-PATH-TRAVERSAL`, CWE-22): `Open`, `OpenFile`, `ReadFile`, `WriteFile`, `Create`
+  (bare — `os`/`ioutil` receivers).
+
+**`fmt.Sprintf` is NOT a sink here** — it is a *construction* mechanism. When a sink's argument
+is a `fmt.Sprintf(…)` call, the classifier treats it as COMPOSED (below). (The legacy
+`fmt.sprintf` entry in `go.py`'s `SINK_CALLS` may remain for inventory of other flows, but it does
+not produce a verdict.)
+
+### The Go construction classifier + assessor (`go_provenance.py`)
+
+Statement-local, operating on the sink's first argument text (extracted with the string-aware
+paren matcher ported from `js_provenance.extract_first_arg`, adapted to Go string literals:
+interpreted `"…"` and raw `` `…` `` strings). Reuse `provenance.LITERAL/COMPOSED/OPAQUE` and
+`predicates.VERDICT_*`.
+
+- **Construction:**
+  - an interpreted or raw string literal → **LITERAL**;
+  - a `"…" + x` concatenation, OR a `fmt.Sprintf(fmtLiteral, args…)` call → **COMPOSED**;
+  - a bare identifier or other call → **OPAQUE**;
+  - unreadable/unbalanced → **OPAQUE** (fail-safe).
+- **Candidate variables (positive-literal-proof):** for a `+` concatenation, every operand that is
+  not a *proven* literal (string/raw-string/numeric/`true`/`false`/`nil`) contributes all its
+  identifiers as candidates, plus an "unresolved" flag if it has none; for `fmt.Sprintf`, the
+  format-string literal is skipped and every subsequent argument is assessed the same way.
+- **Taint refinement:** reuse `go.py`'s function-local taint (a candidate name known
+  user-controlled).
+- **Assessment (per class, same as JS):** LITERAL / all-proven-literal → SAFE; a candidate that
+  taint confirms → UNSAFE; a candidate of unknown provenance or an unresolved operand → UNKNOWN;
+  OPAQUE bare identifier → UNSAFE if tainted else UNKNOWN. **Command:** the shell case
+  (`exec.Command("sh"/"bash", "-c", <non-literal>)`) → UNSAFE when tainted; an argv form with a
+  literal program name and per-arg assessment otherwise; unresolved → UNKNOWN.
+- **Verdict → finding:** UNSAFE → `sink.rule_id`; UNKNOWN → `sink.rule_id + "-UNVERIFIED"`; SAFE →
+  none. (Same mapping as JS/Python `_finding_for`.)
+
+### `go.py` routing
+
+Gate on **registry OR legacy** (as in JS): `sink = lookup_sink(call_name, "go"); if sink is not
+None or _is_sink(call_name):`. A registry hit → graded verdict via the assessor (extract arg from
+`source` at the call's `(`, offset-translated from the per-line match, as the JS offset fix does);
+else → the existing `CG-GO-SINK-CALL` inventory. Preserve the `EDGE_REACHES_SINK`/`EDGE_TAINTS`
+edges. A registered sink emits EITHER a verdict OR inventory, never both.
+
+### Capability & coverage
+
+- `capability.py`: add `GO_GLOBS = ("*.go",)`; change `sql_construction`, `command_execution`,
+  `path_access` covers to `PYTHON_GLOBS + WEB_GLOBS + GO_GLOBS`. Leave `code_execution`
+  (`PYTHON_GLOBS + WEB_GLOBS`), `deserialization`, and `VERIFIED_GLOBS` unchanged.
+- `coverage.py`: add `GO_GLOBS` to the verified gate (`VERIFIED_GLOBS + CONFIG_GLOBS + WEB_GLOBS +
+  GO_GLOBS`) so a clean, analyzed `.go` file reaches PASS instead of perpetual UNKNOWN — without
+  changing `source_analysis_support` (which decides NOT_SUPPORTED via `unverified_source_files`
+  and pre-filters, unchanged).
+
+## Precision & the SARIF filter
+
+The three classes now emit real `CG-*` rules (uploadable); the filter still drops the remaining
+`*-SINK-CALL` inventory for Go sink names outside the registry. Audit §4.5 note extended to "JS +
+Go core classes." A parameterized `db.Query("… WHERE id = $1", id)` → LITERAL query → SAFE; a
+`fmt.Sprintf`/`+` with a tainted arg → UNSAFE; an unresolved arg → UNKNOWN.
+
+## Error handling
+
+- A `.go` file the analyzer cannot read → its containment path → coverage FAILED → UNKNOWN.
+- An argument the paren matcher cannot balance → OPAQUE → UNKNOWN, never SAFE.
+- A `fmt.Sprintf` with no arguments beyond the format string → all-literal → SAFE (a constant).
+
+## Testing
+
+- **`go_provenance` units** per class: literal → SAFE; `"…" + tainted` → UNSAFE; `fmt.Sprintf`
+  with a tainted arg → UNSAFE; `fmt.Sprintf` all-literal → SAFE; unresolved variable → UNKNOWN;
+  `"…" + (nonLeadingIdentOperand)` → not SAFE (the JS-lesson guard); opaque → UNKNOWN; `exec.Command`
+  shell-vs-argv.
+- **`sinks.py`**: `lookup_sink` resolves the Go PascalCase names to the right rule ids; other
+  languages unchanged.
+- **Capability five-state** on a `.go` change for the three capabilities; `source_analysis_support`
+  still NOT_SUPPORTED for Go; `code_execution` NOT_APPLICABLE/PASS on a Go change (no Go code sink).
+- **End-to-end:** `cybergraph check` → REVIEW on a Go SQLi (`db.Query(fmt.Sprintf("… %s", userID))`
+  with tainted `userID`) and a `exec.Command("sh","-c", userCmd)`; ACCEPT on a parameterized query.
+- **Mutation harness:** three seeded fail-opens (a tainted Go sink arg read SAFE; an unresolved
+  variable read SAFE; a `+`/`Sprintf` non-literal operand read SAFE), each red under its guard test.
+- Full suite green; ruff clean; `run_precision.py`/`run_eval.py` unchanged (Python corpus — the Go
+  registry is language-keyed, so Python is unaffected; verify identical).
+
+## Global constraints (inherited, unchanged)
+
+- Python 3.10–3.13. **Zero runtime dependencies**; standard library only (`re`) — no Go parser.
+  The classifier is lightweight/structural and fail-safe.
+- Ruff line-length 100; `from __future__ import annotations` in every file.
+- No network; no API keys on any default path.
+- **Precision over recall:** only an all-literal/constant construction is SAFE; a variable is
+  UNSAFE (taint-confirmed) or UNKNOWN; uncertainty → UNKNOWN.
+- Commits `Laraib <lxh417bham@gmail.com>` only; no `Co-Authored-By`, no AI attribution. Many small
+  commits; never squash. Push only to `https://github.com/AQ-Labs/cybergraph`.
+
+## Roadmap alignment — what this does NOT touch
+
+Builds Go verdicts for SQL/command/path and broadens three capabilities. Deliberately excluded:
+Go template injection, code-exec (no Go eval), interprocedural/cross-file flow, adding `*.go` to
+`VERIFIED_GLOBS` (Go is not fully verified), and Java/C# (later slices replicating this shape).
+`CG-GO-SINK-CALL` inventory remains for Go sink names outside the registry.
+
+## Success criteria
+
+1. `sinks.py` resolves the Go PascalCase SQL/command/path sink names to Python's rule ids (bare,
+   original-case); other languages unchanged.
+2. The Go classifier maps an all-literal/constant construction (incl. an all-literal `fmt.Sprintf`)
+   → SAFE, a taint-confirmed variable (in a `+`, a `Sprintf` arg, a non-leading-identifier operand,
+   or a bare identifier) → UNSAFE, an unresolved variable/unreadable arg → UNKNOWN. No variable is
+   ever SAFE.
+3. A Go injection on a changed `.go` → the matching capability FAIL → `cybergraph check` REVIEW; a
+   parameterized/all-literal change → SAFE → ACCEPT (end-to-end).
+4. `source_analysis_support` still reports Go NOT_SUPPORTED; the three capabilities cover Go;
+   `code_execution` does not.
+5. The three classes emit real `CG-*` rules, not `CG-GO-SINK-CALL`; other Go sinks stay inventory.
+6. Full suite green; ruff clean; the mutation harness catches all three seeded Go fail-opens;
+   `run_precision.py`/`run_eval.py` unchanged.

--- a/src/cybergraph/analysis/go.py
+++ b/src/cybergraph/analysis/go.py
@@ -13,6 +13,9 @@ import re
 from pathlib import Path
 
 from cybergraph.analysis._source_text import strip_code
+from cybergraph.analysis.go_provenance import assess as assess_go_sink
+from cybergraph.analysis.go_provenance import assess_command as assess_go_command
+from cybergraph.analysis.go_provenance import extract_all_args, extract_first_arg
 from cybergraph.graph import Edge, Finding, Node
 from cybergraph.security.ontology import (
     EDGE_EXPOSES_ENTRYPOINT,
@@ -23,6 +26,8 @@ from cybergraph.security.ontology import (
     EDGE_TAINTS,
     EDGE_USES_SECRET,
 )
+from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNSAFE
+from cybergraph.security.sinks import lookup_sink
 from cybergraph.suppressions import is_inline_suppressed
 
 FUNC_RE = re.compile(
@@ -68,6 +73,10 @@ def analyze_go_file(
 ) -> tuple[list[Node], list[Edge], list[Finding]]:
     source = path.read_text(encoding="utf-8", errors="ignore")
     lines = source.splitlines()
+    # Absolute offset (into `source`) of the start of each line in `lines`, so a
+    # per-line regex match position can be translated into a `source` index --
+    # needed for `extract_first_arg`, which must read across line breaks.
+    line_starts = _line_start_offsets(source)
     # Code view with comments and string literals blanked, so an input marker in
     # a comment or a string cannot fabricate a taint source. Aligned 1:1 with
     # `lines`; a marker is only believed where it survives on real code.
@@ -155,8 +164,48 @@ def analyze_go_file(
                         {"reason": "secret passed to exposure sink"},
                     )
                 )
-            if _is_sink(call_name, custom_sinks):
+            sink = lookup_sink(call_name, "go")
+            abs_off = line_starts[line_no - 1] + call.end() - 1
+            if sink is not None and _is_empty_call(source, abs_off):
+                # A registry sink call with an empty argument list is not a real
+                # sink invocation -- every real sink (`db.Query(sql)`,
+                # `exec.Command(name)`, `os.Open(path)`) takes >=1 argument. This
+                # is how a zero-arg reader that happens to share a bare sink's
+                # name (e.g. net/http's `r.URL.Query()`) is told apart from an
+                # actual call to that sink: skip it entirely, not even a
+                # CG-GO-SINK-CALL inventory entry -- it is not a sink call.
+                continue
+            if sink is not None or _is_sink(call_name, custom_sinks):
                 edges.append(Edge(EDGE_REACHES_SINK, sink_source, call_name, rel, line_no))
+                if sink is not None:
+                    if sink.vuln_class == "command":
+                        # Command sinks take argv, not a single string: grading
+                        # only the first argument would see just the program
+                        # name (the literal `"sh"` in `exec.Command("sh",
+                        # "-c", userCmd)`) and never the tainted argument that
+                        # follows it. Assess the whole argument list instead.
+                        args = extract_all_args(source, abs_off)
+                        verdict = assess_go_command(sink, args, set(tainted))
+                    else:
+                        arg = extract_first_arg(source, abs_off)
+                        verdict = assess_go_sink(sink, arg, set(tainted))
+                    finding = _go_verdict_finding(sink, verdict, rel, line_no, line)
+                    if finding is not None and not is_inline_suppressed(
+                        lines, line_no, finding.rule_id
+                    ):
+                        findings.append(finding)
+                elif not is_inline_suppressed(lines, line_no, "CG-GO-SINK-CALL"):
+                    findings.append(
+                        Finding(
+                            rule_id="CG-GO-SINK-CALL",
+                            severity="medium",
+                            message=f"Go file reaches sensitive sink `{call_name}`",
+                            file_path=rel,
+                            line_start=line_no,
+                            cwe="CWE-20",
+                            evidence=line.strip(),
+                        )
+                    )
                 taint_source = source_key or _tainted_source_for_line(line, tainted)
                 if taint_source:
                     edges.append(
@@ -167,18 +216,6 @@ def analyze_go_file(
                             rel,
                             line_no,
                             {"function": sink_source, "reason": "tainted argument"},
-                        )
-                    )
-                if not is_inline_suppressed(lines, line_no, "CG-GO-SINK-CALL"):
-                    findings.append(
-                        Finding(
-                            rule_id="CG-GO-SINK-CALL",
-                            severity="medium",
-                            message=f"Go file reaches sensitive sink `{call_name}`",
-                            file_path=rel,
-                            line_start=line_no,
-                            cwe="CWE-20",
-                            evidence=line.strip(),
                         )
                     )
 
@@ -245,6 +282,54 @@ def _classify_go_name(name: str) -> dict[str, bool]:
         "crypto_related": "hash" in lowered or "encrypt" in lowered or "sign" in lowered,
         "sink_related": "query" in lowered or "exec" in lowered,
     }
+
+
+def _line_start_offsets(source: str) -> list[int]:
+    """Absolute `source` offset of the first character of each `splitlines()` line.
+
+    `source.splitlines()` and `source.splitlines(keepends=True)` share identical
+    split points, differing only in whether each element keeps its trailing line
+    terminator -- so summing the keepends lengths reconstructs the exact offsets
+    the terminator-stripped `lines` started at.
+    """
+    offsets: list[int] = []
+    offset = 0
+    for segment in source.splitlines(keepends=True):
+        offsets.append(offset)
+        offset += len(segment)
+    return offsets
+
+
+def _go_verdict_finding(sink, verdict, rel, line_no, line):
+    if verdict == VERDICT_SAFE:
+        return None
+    unsafe = verdict == VERDICT_UNSAFE
+    return Finding(
+        rule_id=sink.rule_id if unsafe else f"{sink.rule_id}-UNVERIFIED",
+        severity=sink.severity if unsafe else "medium",
+        message=(f"`{sink.name}` {sink.plain}" if unsafe
+                 else f"`{sink.name}` {sink.plain}, and CyberGraph could not confirm "
+                      "the value is safe"),
+        file_path=rel,
+        line_start=line_no,
+        cwe=sink.cwe,
+        evidence=line.strip(),
+    )
+
+
+def _is_empty_call(source: str, open_paren: int) -> bool:
+    """True if the call's argument list, starting at `source[open_paren]` (a
+    ``(``), is empty -- i.e. the next non-whitespace character is ``)``.
+
+    Deliberately simpler than `extract_first_arg`: it only needs to tell an
+    empty `()` apart from a non-empty one, not classify the argument, so it
+    does not need to be string/paren-aware -- whitespace cannot hide a `)`
+    inside a string literal or nested expression, only precede the real one.
+    """
+    i = open_paren + 1
+    while i < len(source) and source[i].isspace():
+        i += 1
+    return i < len(source) and source[i] == ")"
 
 
 def _is_sink(call_name: str, custom_sinks: tuple[str, ...] = ()) -> bool:

--- a/src/cybergraph/analysis/go_provenance.py
+++ b/src/cybergraph/analysis/go_provenance.py
@@ -1,0 +1,360 @@
+"""Lightweight construction provenance for Go sink arguments.
+
+No Go parser: a structural, statement-local classifier over the argument text,
+fail-safe on anything it cannot read. It reuses the engine's vocabulary
+(LITERAL/COMPOSED/OPAQUE and VERDICT_*) but is deliberately more conservative
+than the Python predicates: because Go taint is weaker (intra-function,
+line-based), only an all-literal/constant construction is SAFE. A construction
+that contains a variable is UNSAFE when taint confirms it is user-controlled and
+UNKNOWN otherwise -- never SAFE, and never a confident UNSAFE on an unresolved
+variable.
+
+Go has no template-literal interpolation; its idiom is ``fmt.Sprintf(fmt, ...)``,
+so a Sprintf call is treated the way a JS template literal is treated: COMPOSED,
+with its non-format arguments as candidate variables.
+"""
+
+from __future__ import annotations
+
+import re
+
+from cybergraph.analysis.provenance import COMPOSED, LITERAL, OPAQUE
+from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNKNOWN, VERDICT_UNSAFE
+from cybergraph.security.sinks import Sink
+
+_IDENT_RE = re.compile(r"[A-Za-z_]\w*")
+_STRING_ONLY_RE = re.compile(r"""^\s*(?:'[^']*'|"[^"]*"|`[^`]*`)\s*$""")
+_NUMERIC_RE = re.compile(r"^[+-]?\d+(?:\.\d+)?$")
+# Go keywords that are also constant literals (booleans, the nil pointer) --
+# proven literals, and also excluded from candidate variable names.
+_GO_KEYWORDS = frozenset({"true", "false", "nil"})
+_CONST_LITERAL_KEYWORDS = _GO_KEYWORDS
+
+
+def extract_first_arg(source: str, open_paren: int) -> str | None:
+    """Return the first top-level argument's source text, or None if unbalanced.
+
+    String-aware (skips ()/,/quotes inside interpreted and raw string literals)
+    so a ')' or ',' inside a literal does not end the argument early.
+    """
+    depth = 0
+    quote: str | None = None
+    start = -1
+    i = open_paren
+    while i < len(source):
+        c = source[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"`":
+            quote = c
+        elif c == "(":
+            depth += 1
+            if depth == 1:
+                start = i + 1
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return source[start:i].strip() or None
+        elif c == "," and depth == 1:
+            return source[start:i].strip() or None
+        i += 1
+    return None  # unbalanced -> caller treats as UNKNOWN
+
+
+def extract_all_args(source: str, open_paren: int) -> list[str]:
+    """Return every top-level argument's source text, or [] if unbalanced.
+
+    Command-class sinks (`exec.Command`, `exec.CommandContext`) take argv, not
+    a single string, so grading them on `extract_first_arg` alone only ever
+    sees the program name -- for the Go shell idiom, the literal `"sh"` -- and
+    never the tainted argument that follows it. This walks the same
+    string/paren-aware scan as `extract_first_arg` but keeps collecting past
+    the first top-level comma instead of stopping there.
+    """
+    depth = 0
+    quote: str | None = None
+    start = -1
+    args: list[str] = []
+    i = open_paren
+    while i < len(source):
+        c = source[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"`":
+            quote = c
+        elif c == "(":
+            depth += 1
+            if depth == 1:
+                start = i + 1
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                tail = source[start:i].strip()
+                if tail or args:
+                    args.append(tail)
+                return args
+        elif c == "," and depth == 1:
+            args.append(source[start:i].strip())
+            start = i + 1
+        i += 1
+    return []  # unbalanced -> caller treats as UNKNOWN
+
+
+def classify(arg_text: str) -> str:
+    s = arg_text.strip()
+    if _STRING_ONLY_RE.match(s):
+        return LITERAL
+    if s.startswith("fmt.Sprintf(") or len(_split_plus(s)) > 1:
+        return COMPOSED
+    return OPAQUE
+
+
+def _is_proven_literal_operand(operand: str) -> bool:
+    """True only for a construction that is positively known to be constant.
+
+    A string literal (interpreted ``"..."`` or raw `` `...` ``), or a
+    numeric/boolean/nil constant. Anything else -- a bare identifier, a
+    parenthesized expression, a bracketed expression, a call, a selector -- is
+    NOT proven literal, even if it happens to contain no scannable identifier:
+    absence of a name must never be read as proof of literal-ness.
+    """
+    s = operand.strip()
+    if not s:
+        return False
+    if _STRING_ONLY_RE.match(s):
+        return True
+    if _NUMERIC_RE.match(s):
+        return True
+    if s in _CONST_LITERAL_KEYWORDS:
+        return True
+    return False
+
+
+def _operand_candidates(operands: list[str]) -> tuple[list[str], bool]:
+    """Candidate variable names from non-literal operands.
+
+    Also returns whether any operand is "unresolved": not a proven literal and
+    yet contains no identifier at all (e.g. `(1 + 1)` as an operand) -- such an
+    operand must never be silently treated as safe just because it has no name
+    to check.
+    """
+    names: list[str] = []
+    unresolved = False
+    for part in operands:
+        p = part.strip()
+        if not p or _is_proven_literal_operand(p):
+            continue
+        idents = _IDENT_RE.findall(p)
+        if not idents:
+            unresolved = True
+            continue
+        for ident in idents:
+            if ident not in _GO_KEYWORDS:
+                names.append(ident)
+    return names, unresolved
+
+
+def _plus_operand_candidates(arg_text: str) -> tuple[list[str], bool]:
+    """Candidate variable names from non-literal top-level ``+`` operands."""
+    return _operand_candidates(_split_plus(arg_text))
+
+
+def _sprintf_operand_candidates(sprintf_text: str) -> tuple[list[str], bool]:
+    """Candidate variable names from ALL of a ``fmt.Sprintf(...)`` call's arguments.
+
+    Unlike a JS template literal, whose leading piece is always a literal
+    fragment of the source text, Go's format argument is a normal runtime
+    value: ``fmt.Sprintf(userQuery)`` and ``fmt.Sprintf("SELECT * FROM " +
+    tbl, "x")`` both carry a non-literal format. So every argument -- format
+    included -- is assessed with the same positive-literal-proof logic; a
+    format that genuinely is a string literal is a proven literal and is
+    skipped by `_is_proven_literal_operand` on its own, with no special-casing
+    needed here.
+    """
+    args = _split_call_args(sprintf_text)
+    return _operand_candidates(args)
+
+
+def variable_names(arg_text: str) -> list[str]:
+    """Identifiers from a fmt.Sprintf argument list or a non-literal + operand."""
+    s = arg_text.strip()
+    if s.startswith("fmt.Sprintf(") and s.endswith(")"):
+        names, _unresolved = _sprintf_operand_candidates(s)
+        return _dedup(names)
+    names, _unresolved = _plus_operand_candidates(arg_text)
+    return _dedup(names)
+
+
+def _dedup(names: list[str]) -> list[str]:
+    """De-dup a list of names, preserving first-seen order."""
+    seen: set[str] = set()
+    out = []
+    for n in names:
+        if n not in seen:
+            seen.add(n)
+            out.append(n)
+    return out
+
+
+def _split_plus(text: str) -> list[str]:
+    """Split on top-level '+', string/paren-aware."""
+    parts, depth, quote, buf = [], 0, None, []
+    i = 0
+    while i < len(text):
+        c = text[i]
+        if quote is not None:
+            buf.append(c)
+            if c == "\\":
+                if i + 1 < len(text):
+                    buf.append(text[i + 1])
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"`":
+            quote = c
+            buf.append(c)
+        elif c in "([{":
+            depth += 1
+            buf.append(c)
+        elif c in ")]}":
+            depth -= 1
+            buf.append(c)
+        elif c == "+" and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(c)
+        i += 1
+    parts.append("".join(buf))
+    return parts
+
+
+def _split_call_args(s: str) -> list[str]:
+    """Top-level, comma-separated arguments of the first ``(...)`` call in s.
+
+    Mirrors ``extract_first_arg``'s string/paren-aware scan, but returns every
+    top-level argument instead of stopping at the first. Used to split
+    ``fmt.Sprintf(...)``'s argument list.
+    """
+    open_paren = s.index("(")
+    depth = 0
+    quote: str | None = None
+    start = -1
+    args: list[str] = []
+    i = open_paren
+    while i < len(s):
+        c = s[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"`":
+            quote = c
+        elif c == "(":
+            depth += 1
+            if depth == 1:
+                start = i + 1
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                args.append(s[start:i].strip())
+                return args
+        elif c == "," and depth == 1:
+            args.append(s[start:i].strip())
+            start = i + 1
+        i += 1
+    return args  # unbalanced -> caller treats as best-effort partial list
+
+
+def assess(sink: Sink, arg_text: str | None, tainted_names: set[str]) -> str:
+    """Verdict for a Go sink call. Only an all-literal/constant construction is SAFE."""
+    if arg_text is None:
+        return VERDICT_UNKNOWN
+    construction = classify(arg_text)
+    if construction == LITERAL:
+        return VERDICT_SAFE
+    if construction == COMPOSED:
+        s = arg_text.strip()
+        if s.startswith("fmt.Sprintf(") and s.endswith(")"):
+            names, unresolved = _sprintf_operand_candidates(s)
+        else:
+            names, unresolved = _plus_operand_candidates(arg_text)
+        if any(n in tainted_names for n in names):
+            return VERDICT_UNSAFE
+        if names or unresolved:
+            # a candidate variable (resolved or not) or an operand we could not
+            # prove literal -> never read as safe
+            return VERDICT_UNKNOWN
+        # every operand is a proven literal/constant (e.g. `fmt.Sprintf("%d", 1)`)
+        return VERDICT_SAFE
+    # OPAQUE: candidates are only extracted from a `fmt.Sprintf(...)` call or a
+    # `+` operand, so nothing is found in a bare identifier (no Sprintf, no `+`)
+    # even though the whole argument *is* one. Handle that shape directly: a
+    # bare identifier can be checked against taint; any other opaque expression
+    # (a call, selector, ...) has no name to check and must fail safe rather
+    # than read as unconditionally SAFE.
+    s = arg_text.strip()
+    match = _IDENT_RE.fullmatch(s)
+    if match and match.group(0) not in _GO_KEYWORDS and match.group(0) in tainted_names:
+        return VERDICT_UNSAFE
+    return VERDICT_UNKNOWN
+
+
+def assess_command(sink: Sink, args: list[str] | None, tainted_names: set[str]) -> str:
+    """Verdict for a Go command sink (`exec.Command`/`exec.CommandContext`) over ALL arguments.
+
+    `assess` grades a sink on its first argument alone, which is right for a
+    single SQL/path string but wrong for argv: it would see only the program
+    name and miss a tainted argument anywhere else in the call. This assesses
+    the whole argument list instead, reusing `_operand_candidates` /
+    `_is_proven_literal_operand` so the same positive-literal-proof invariant
+    holds -- a non-literal argument with no scannable identifier is
+    unresolved, never silently SAFE.
+
+    Verdict rule, fail-safe throughout:
+    - no arguments (unreadable call) -> UNKNOWN.
+    - every argument is a proven literal/constant -> SAFE.
+    - the shell form -- argv[0] is a shell (`sh`/`bash`/`/bin/sh`/`/bin/bash`)
+      with a `-c` argument present -- and some argument is not a proven
+      literal -> UNSAFE if a candidate name is taint-confirmed, else UNKNOWN.
+    - otherwise (argv form, or any other shape) and some argument is not a
+      proven literal -> UNSAFE if a candidate name is taint-confirmed, else
+      UNKNOWN.
+
+    The shell and non-shell branches compute identically: taint confirmation
+    over every argument's candidate names is what decides UNSAFE vs. UNKNOWN
+    in both, because this phase does not yet distinguish argument-injection
+    severity by argv position. In neither branch is a non-literal argument
+    ever read as SAFE, which is the false-SAFE this function exists to close.
+    """
+    if not args:
+        return VERDICT_UNKNOWN
+    if all(_is_proven_literal_operand(a) for a in args):
+        return VERDICT_SAFE
+    names, _unresolved = _operand_candidates(args)
+    if any(n in tainted_names for n in names):
+        return VERDICT_UNSAFE
+    return VERDICT_UNKNOWN

--- a/src/cybergraph/security/capability.py
+++ b/src/cybergraph/security/capability.py
@@ -36,6 +36,7 @@ _REVIEW_STATES = frozenset({FAIL, UNKNOWN, NOT_SUPPORTED})
 
 PYTHON_GLOBS = ("*.py",)
 WEB_GLOBS = ("*.ts", "*.tsx", "*.js", "*.jsx", "*.vue", "*.svelte", "*.mjs", "*.cjs")
+GO_GLOBS = ("*.go",)
 
 # Every extension CyberGraph recognises as executable source, supported or not.
 SOURCE_GLOBS = (
@@ -70,11 +71,14 @@ class Capability:
 
 
 CAPABILITIES: tuple[Capability, ...] = (
-    Capability("sql_construction", "Unsafe database queries", PYTHON_GLOBS + WEB_GLOBS, True),
-    Capability("command_execution", "Unsafe system commands", PYTHON_GLOBS + WEB_GLOBS, True),
+    Capability("sql_construction", "Unsafe database queries",
+               PYTHON_GLOBS + WEB_GLOBS + GO_GLOBS, True),
+    Capability("command_execution", "Unsafe system commands",
+               PYTHON_GLOBS + WEB_GLOBS + GO_GLOBS, True),
     Capability("code_execution", "Code run from user input", PYTHON_GLOBS + WEB_GLOBS, True),
     Capability("deserialization", "Unsafe data loading", PYTHON_GLOBS, True),
-    Capability("path_access", "Files opened from user input", PYTHON_GLOBS + WEB_GLOBS, True),
+    Capability("path_access", "Files opened from user input",
+               PYTHON_GLOBS + WEB_GLOBS + GO_GLOBS, True),
     Capability("declared_login_rules", "Your declared login rules", PYTHON_GLOBS, True),
     Capability("reachable_data_paths",
                "New routes from the internet to sensitive code", PYTHON_GLOBS, True),

--- a/src/cybergraph/security/coverage.py
+++ b/src/cybergraph/security/coverage.py
@@ -17,7 +17,13 @@ from fnmatch import fnmatch
 from pathlib import Path
 
 from cybergraph.graph import GraphStore
-from cybergraph.security.capability import CONFIG_GLOBS, SOURCE_GLOBS, VERIFIED_GLOBS, WEB_GLOBS
+from cybergraph.security.capability import (
+    CONFIG_GLOBS,
+    GO_GLOBS,
+    SOURCE_GLOBS,
+    VERIFIED_GLOBS,
+    WEB_GLOBS,
+)
 
 STATUS_ANALYZED = "analyzed"
 STATUS_FAILED = "failed"
@@ -68,7 +74,8 @@ def assess_coverage(
         if file in failed:
             results.append(FileCoverage(file, STATUS_FAILED, "the file could not be read"))
         elif not any(
-            fnmatch(file, pattern) for pattern in VERIFIED_GLOBS + CONFIG_GLOBS + WEB_GLOBS
+            fnmatch(file, pattern)
+            for pattern in VERIFIED_GLOBS + CONFIG_GLOBS + WEB_GLOBS + GO_GLOBS
         ):
             results.append(
                 FileCoverage(file, STATUS_UNSUPPORTED, "no analyzer for this language yet")

--- a/src/cybergraph/security/sinks.py
+++ b/src/cybergraph/security/sinks.py
@@ -120,7 +120,37 @@ _JAVASCRIPT: tuple[Sink, ...] = (
          "opens a file whose path comes from this value", "path", bare=True),
 )
 
-_BY_LANGUAGE: dict[str, tuple[Sink, ...]] = {"python": _PYTHON, "javascript": _JAVASCRIPT}
+_GO: tuple[Sink, ...] = (
+    # SQL — db/tx receivers unresolvable → bare on the PascalCase method name.
+    Sink("Query", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("QueryRow", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("QueryContext", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("QueryRowContext", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("Exec", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("ExecContext", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    # Command — exec.Command(name, args…); shell only when name is sh/bash -c → conditional.
+    Sink("exec.Command", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _CMD, "command",
+         shell=SHELL_CONDITIONAL),
+    Sink("exec.CommandContext", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _CMD, "command",
+         shell=SHELL_CONDITIONAL),
+    # Path — os/ioutil receivers → bare on the PascalCase method name.
+    Sink("Open", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("OpenFile", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("ReadFile", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("WriteFile", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("Create", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+)
+
+_BY_LANGUAGE: dict[str, tuple[Sink, ...]] = {
+    "python": _PYTHON,
+    "javascript": _JAVASCRIPT,
+    "go": _GO,
+}
 
 
 def all_sinks() -> tuple[Sink, ...]:

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -124,13 +124,15 @@ def test_unrelated_go_failure_does_not_taint_a_python_capability():
 
     A failed `.go` file must not drag an unrelated Python capability to
     UNKNOWN -- only failures within that capability's own declared scope count.
+    Uses `deserialization`, which stays Python-only even after Go joined
+    `sql_construction`/`command_execution`/`path_access`.
     """
     coverage = (
         FileCoverage("app.py", "analyzed"),
         FileCoverage("main.go", "failed", "the file could not be read"),
     )
     results = _run(changed_files=("app.py", "main.go"), coverage=coverage)
-    assert _status(results, "sql_construction") == PASS
+    assert _status(results, "deserialization") == PASS
     assert _status(results, "source_analysis_support") == NOT_SUPPORTED
 
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -24,8 +24,18 @@ def test_unparseable_file_is_failed_not_clean(tmp_path: Path):
 
 
 def test_language_without_an_analyzer_is_unsupported(tmp_path: Path):
+    (tmp_path / "Main.java").write_text("class Main {}\n", encoding="utf-8")
+    assert _status(tmp_path, ("Main.java",)) == {"Main.java": "unsupported"}
+
+
+def test_go_is_analyzed_now_it_has_a_partial_analyzer(tmp_path: Path):
+    """Go joined the verified gate alongside Python/config/web (sql/command/path
+    sinks); it is no longer reported as a blind spot at the file-coverage level.
+    The stricter honesty guarantee -- Go is not a Phase-1 *verified* language --
+    still holds at the capability level, where `source_analysis_support` stays
+    NOT_SUPPORTED for Go (see test_go_verdicts_e2e.py)."""
     (tmp_path / "main.go").write_text("package main\n", encoding="utf-8")
-    assert _status(tmp_path, ("main.go",)) == {"main.go": "unsupported"}
+    assert _status(tmp_path, ("main.go",)) == {"main.go": "analyzed"}
 
 
 def test_deleted_file_is_missing_not_failed(tmp_path: Path):

--- a/tests/test_coverage_report.py
+++ b/tests/test_coverage_report.py
@@ -1,7 +1,7 @@
 import subprocess
 from pathlib import Path
 
-from cybergraph.security.capability import NOT_SUPPORTED, UNKNOWN
+from cybergraph.security.capability import UNKNOWN
 from cybergraph.security.coverage_report import (
     CAP_CHECKED,
     build_coverage_report,
@@ -46,11 +46,16 @@ def test_unparseable_python_makes_its_capabilities_unknown(tmp_path: Path):
     assert _cap(report, "sql_construction").status == UNKNOWN
 
 
-def test_go_file_makes_source_support_not_supported(tmp_path: Path):
+def test_go_file_is_checked_via_its_partial_analyzer(tmp_path: Path):
+    """Go now has a partial analyzer (sql/command/path sinks), like web already did --
+    this surface reports CAP_CHECKED, not NOT_SUPPORTED. The stricter honesty
+    guarantee (Go is not a Phase-1 *verified* language) still holds in the
+    verdict path, where `source_analysis_support` stays NOT_SUPPORTED for Go
+    (see test_go_verdicts_e2e.py::test_go_still_not_supported_overall)."""
     repo = _repo(tmp_path)
     (repo / "main.go").write_text("package main\n", encoding="utf-8")
     report = build_coverage_report(repo)
-    assert _cap(report, "source_analysis_support").status == NOT_SUPPORTED
+    assert _cap(report, "source_analysis_support").status == CAP_CHECKED
 
 
 def test_readme_only_change_establishes_an_empty_report(tmp_path: Path):

--- a/tests/test_go_provenance.py
+++ b/tests/test_go_provenance.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from cybergraph.analysis.go_provenance import (
+    assess,
+    assess_command,
+    classify,
+    extract_all_args,
+    extract_first_arg,
+)
+from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNKNOWN, VERDICT_UNSAFE
+from cybergraph.security.sinks import lookup_sink
+
+
+def _sink(name):
+    return lookup_sink(name, "go")
+
+
+def test_extract_first_arg_string_aware():
+    src = 'db.Query(fmt.Sprintf("SELECT %s", id), other)'
+    assert extract_first_arg(src, src.index("(")) == 'fmt.Sprintf("SELECT %s", id)'
+    assert extract_first_arg('db.Query(`raw ) str`)', 8) == '`raw ) str`'
+    assert extract_first_arg("db.Query(`oops", 8) is None
+
+
+def test_classify():
+    assert classify('"SELECT 1"') == "literal"
+    assert classify("`SELECT 1`") == "literal"
+    assert classify('"SELECT " + id') == "composed"
+    assert classify('fmt.Sprintf("SELECT %s", id)') == "composed"
+    assert classify("userVar") == "opaque"
+
+
+def test_assess_literal_safe():
+    assert assess(_sink("db.Query"), '"SELECT 1"', set()) == VERDICT_SAFE
+
+
+def test_assess_sprintf_tainted_unsafe():
+    assert assess(_sink("db.Query"), 'fmt.Sprintf("SELECT %s", id)', {"id"}) == VERDICT_UNSAFE
+
+
+def test_assess_sprintf_unresolved_unknown():
+    assert assess(_sink("db.Query"), 'fmt.Sprintf("SELECT %s", id)', set()) == VERDICT_UNKNOWN
+
+
+def test_assess_sprintf_all_literal_safe():
+    assert assess(_sink("db.Query"), 'fmt.Sprintf("SELECT %d", 1)', set()) == VERDICT_SAFE
+
+
+def test_assess_concat_tainted_unsafe():
+    assert assess(_sink("db.Query"), '"SELECT " + name', {"name"}) == VERDICT_UNSAFE
+
+
+def test_assess_non_leading_ident_operand_not_safe():
+    # the JS-lesson guard: an operand not led by an identifier must not read SAFE
+    assert assess(_sink("db.Query"), '"x = " + (id)', {"id"}) == VERDICT_UNSAFE
+    assert assess(_sink("db.Query"), '"x = " + (id)', set()) == VERDICT_UNKNOWN
+
+
+def test_assess_opaque_unknown():
+    assert assess(_sink("db.Query"), "buildQuery()", set()) == VERDICT_UNKNOWN
+
+
+def test_assess_unreadable_unknown():
+    assert assess(_sink("db.Query"), None, set()) == VERDICT_UNKNOWN
+
+
+# -- C1: fmt.Sprintf's FORMAT argument is a runtime value in Go, not a literal --
+
+
+def test_sprintf_variable_format_is_unsafe():
+    assert assess(
+        _sink("db.Query"), "fmt.Sprintf(userQuery)", {"userQuery"}
+    ) == VERDICT_UNSAFE
+    assert assess(
+        _sink("db.Query"), 'fmt.Sprintf("SELECT * FROM " + tbl)', {"tbl"}
+    ) == VERDICT_UNSAFE
+
+
+# -- C2: command sinks must be assessed over ALL arguments, not just argv[0] --
+
+
+def _cmd_sink():
+    return _sink("exec.Command")
+
+
+def test_command_shell_form_tainted_is_unsafe():
+    src = 'exec.Command("sh", "-c", userCmd)'
+    args = extract_all_args(src, src.index("("))
+    assert args == ['"sh"', '"-c"', "userCmd"]
+    assert assess_command(_cmd_sink(), args, {"userCmd"}) == VERDICT_UNSAFE
+
+
+def test_command_shell_form_unresolved_is_unknown():
+    src = 'exec.Command("sh", "-c", userCmd)'
+    args = extract_all_args(src, src.index("("))
+    assert assess_command(_cmd_sink(), args, set()) == VERDICT_UNKNOWN
+
+
+def test_command_all_literal_is_safe():
+    src = 'exec.Command("ls", "-la")'
+    args = extract_all_args(src, src.index("("))
+    assert assess_command(_cmd_sink(), args, set()) == VERDICT_SAFE
+
+
+def test_command_argv_tainted_is_unsafe_or_unknown():
+    src = 'exec.Command("git", userBranch)'
+    args = extract_all_args(src, src.index("("))
+    assert assess_command(_cmd_sink(), args, {"userBranch"}) in (
+        VERDICT_UNSAFE,
+        VERDICT_UNKNOWN,
+    )
+    assert assess_command(_cmd_sink(), args, {"userBranch"}) != VERDICT_SAFE

--- a/tests/test_go_verdicts_e2e.py
+++ b/tests/test_go_verdicts_e2e.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import subprocess
+
+from cybergraph.analysis.go import analyze_go_file
+from cybergraph.security.capability import CAPABILITIES, FAIL, NOT_SUPPORTED
+from cybergraph.security.check import check_change
+from cybergraph.security.verdict import STATE_REVIEW
+
+
+def _rules(tmp_path, src):
+    p = tmp_path / "main.go"
+    p.write_text(src, encoding="utf-8")
+    _n, _e, findings = analyze_go_file(p, tmp_path)
+    return [f.rule_id for f in findings]
+
+
+def test_parameterized_query_is_safe(tmp_path):
+    src = 'func h(db *sql.DB, id string) { db.Query("SELECT * FROM u WHERE id = $1", id) }\n'
+    rules = _rules(tmp_path, src)
+    assert "CG-SQL-EXEC" not in rules and "CG-SQL-EXEC-UNVERIFIED" not in rules
+    assert "CG-GO-SINK-CALL" not in rules  # a registered sink no longer emits inventory
+
+
+def test_sprintf_tainted_query_is_unsafe(tmp_path):
+    src = (
+        'func h(db *sql.DB, r *http.Request) {\n'
+        '  id := r.URL.Query().Get("id")\n'
+        '  db.Query(fmt.Sprintf("SELECT * FROM u WHERE id = %s", id))\n}\n'
+    )
+    assert "CG-SQL-EXEC" in _rules(tmp_path, src)
+
+
+def test_sprintf_unresolved_query_is_unverified(tmp_path):
+    src = 'func h(db *sql.DB, id string) { db.Query(fmt.Sprintf("SELECT %s", id)) }\n'
+    rules = _rules(tmp_path, src)
+    assert "CG-SQL-EXEC-UNVERIFIED" in rules and "CG-SQL-EXEC" not in rules
+
+
+def test_url_query_reader_is_not_a_sql_sink(tmp_path):
+    # `r.URL.Query()` (net/http's zero-arg query-param reader) shares its bare
+    # final segment with the SQL `Query` sink but takes no argument -- it must
+    # not be treated as reaching a sink at all, with no db call anywhere.
+    src = (
+        'func listUsers(w http.ResponseWriter, r *http.Request) {\n'
+        '  name := r.URL.Query().Get("name")\n'
+        '}\n'
+    )
+    rules = _rules(tmp_path, src)
+    assert "CG-SQL-EXEC" not in rules
+    assert "CG-SQL-EXEC-UNVERIFIED" not in rules
+    assert "CG-GO-SINK-CALL" not in rules
+
+
+def test_url_query_reader_and_real_sink_only_flags_the_sink(tmp_path):
+    # The same zero-arg reader alongside a genuine, tainted `db.Query(...)`
+    # call: only the real injection is flagged, and it is flagged exactly
+    # once (the reader itself must not add a second, spurious finding).
+    src = (
+        'func listUsers(w http.ResponseWriter, r *http.Request) {\n'
+        '  name := r.URL.Query().Get("name")\n'
+        '  db.Query("select * from users where name = \'" + name + "\'")\n'
+        '}\n'
+    )
+    rules = _rules(tmp_path, src)
+    assert rules.count("CG-SQL-EXEC") == 1
+    assert "CG-SQL-EXEC-UNVERIFIED" not in rules
+    assert "CG-GO-SINK-CALL" not in rules
+
+
+def _cap(cid):
+    return next(c for c in CAPABILITIES if c.id == cid)
+
+
+def test_three_capabilities_cover_go():
+    for cid in ("sql_construction", "command_execution", "path_access"):
+        assert "*.go" in _cap(cid).covers, cid
+    assert "*.go" not in _cap("code_execution").covers   # no Go code sink
+    assert "*.go" not in _cap("deserialization").covers
+
+
+def _repo(tmp_path):
+    repo = tmp_path / "r"
+    repo.mkdir()
+    for a in (["init", "-q"], ["config", "user.email", "t@e.com"], ["config", "user.name", "t"]):
+        subprocess.run(["git", "-C", str(repo), *a], check=True)
+    (repo / "README.md").write_text("# x\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "base"], check=True)
+    return repo
+
+
+def test_go_sqli_reviews_under_sql_construction(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "h.go").write_text(
+        'package m\nimport ("database/sql"; "fmt"; "net/http")\n'
+        'func h(db *sql.DB, r *http.Request) {\n'
+        '  id := r.URL.Query().Get("id")\n'
+        '  db.Query(fmt.Sprintf("SELECT * FROM u WHERE id = %s", id))\n}\n',
+        encoding="utf-8",
+    )
+    verdict = check_change(repo, mode="worktree")
+    assert verdict.state == STATE_REVIEW
+    assert any(c.capability_id == "sql_construction" and c.status == FAIL
+               for c in verdict.checks)
+
+
+def test_go_shell_command_injection_reviews(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "h.go").write_text(
+        'package m\nimport ("net/http"; "os/exec")\n'
+        'func h(w http.ResponseWriter, r *http.Request) {\n'
+        '  userCmd := r.URL.Query().Get("cmd")\n'
+        '  exec.Command("sh", "-c", userCmd)\n}\n',
+        encoding="utf-8",
+    )
+    _n, _e, findings = analyze_go_file(repo / "h.go", repo)
+    assert any(f.rule_id == "CG-CMD-EXEC" for f in findings)
+
+    verdict = check_change(repo, mode="worktree")
+    assert verdict.state == STATE_REVIEW
+    assert any(c.capability_id == "command_execution" and c.status == FAIL
+               for c in verdict.checks)
+
+
+def test_go_still_not_supported_overall(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "h.go").write_text("package m\nvar X = 1\n", encoding="utf-8")
+    verdict = check_change(repo, mode="worktree")
+    assert any(c.capability_id == "source_analysis_support" and c.status == NOT_SUPPORTED
+               for c in verdict.checks)

--- a/tests/test_sinks_go.py
+++ b/tests/test_sinks_go.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from cybergraph.security.sinks import lookup_sink
+
+
+@pytest.mark.parametrize("call_name,rule_id,vuln", [
+    ("db.Query", "CG-SQL-EXEC", "sql"),
+    ("db.QueryRow", "CG-SQL-EXEC", "sql"),
+    ("tx.Exec", "CG-SQL-EXEC", "sql"),
+    ("db.QueryContext", "CG-SQL-EXEC", "sql"),
+    ("exec.Command", "CG-CMD-EXEC", "command"),
+    ("exec.CommandContext", "CG-CMD-EXEC", "command"),
+    ("os.Open", "CG-PATH-TRAVERSAL", "path"),
+    ("os.ReadFile", "CG-PATH-TRAVERSAL", "path"),
+    ("ioutil.WriteFile", "CG-PATH-TRAVERSAL", "path"),
+    ("os.Create", "CG-PATH-TRAVERSAL", "path"),
+])
+def test_go_sinks_resolve(call_name, rule_id, vuln):
+    sink = lookup_sink(call_name, "go")
+    assert sink is not None, call_name
+    assert sink.rule_id == rule_id
+    assert sink.vuln_class == vuln
+
+
+def test_go_non_sink_is_none():
+    assert lookup_sink("fmt.Sprintf", "go") is None  # construction, not a sink
+    assert lookup_sink("log.Println", "go") is None
+
+
+def test_other_languages_unchanged():
+    assert lookup_sink("os.system", "python").rule_id == "CG-CMD-EXEC"
+    assert lookup_sink("db.Query", "python") is None
+    assert lookup_sink("db.query", "javascript").rule_id == "CG-SQL-EXEC"


### PR DESCRIPTION
Re-lands the Go slice (SQL/command/path taint analysis for Go source) that was reverted wholesale by #51 (which reverted #50) with no stated reason.

Contents are identical to #50: `src/cybergraph/analysis/go_provenance.py`, the Go additions to `src/cybergraph/analysis/go.py`, the `_GO` sink set / `"go"` entry in `src/cybergraph/security/sinks.py`, `GO_GLOBS` wiring in `src/cybergraph/security/capability.py` and `src/cybergraph/security/coverage.py`, and the `tests/test_sinks_go.py`, `tests/test_go_provenance.py`, `tests/test_go_verdicts_e2e.py` test files.

Re-applied via a revert of the revert (`git revert 434b808`), since git already counts the original Go commits as merged via #50.

Verified before pushing:
- Full test suite: 1325 passed, 1 skipped
- `benchmark/run_precision.py`: precision 1.0, recall 1.0 (gate PASSED)
- `benchmark/mutation_harness.py`: 46/46 mutations caught
- `ruff check src tests benchmark`: no new issues (pre-existing findings match baseline on `main`)

The only merge conflict was in `benchmark/mutation_harness.py`, where #49 (JS command-shell mutation entry) landed on `main` after the revert. Both sides' entries are kept: the JS `command-shell-reads-safe` entry targeting `js_provenance.py`, and all five Go mutation entries targeting `go_provenance.py`.
