### PR TITLE
feat: Java verdicts — SQL/command/path/deserialization (non-Python upgrade, slice 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ CyberGraph is designed to connect those dots.
   from construction provenance (literal vs. tainted-variable vs. unresolved), not just inventoried.
   Go now earns the same treatment for its SQL/command/path sinks (`database/sql`, `os/exec`,
   `os`/`io/ioutil`), fail-safe on anything a Go parser would be needed to read.
+- **Java SQL/command/path/deserialization verdicts** — Spring/JDBC sink arguments (`Statement`/
+  `prepareStatement`, `Runtime.exec`/`ProcessBuilder`, `File`/path constructors) are graded
+  SAFE/UNSAFE/UNKNOWN from construction provenance the same way, and native deserialization
+  (`ObjectInputStream.readObject`/`readUnshared`) is never SAFE, not just inventoried.
 - **Cross-file, interprocedural attack paths** (route → service → repository → sink) with confidence, sanitizer-barrier flags, taint/data-reachability, risk scores, and fix guidance; a `--shallow` mode reproduces intra-function traversal for comparison.
 - **Interactive, offline HTML report** built for first-time readers: a dark-mode-first neon graph explorer (glowing, security-typed nodes with a light/dark toggle), NODE/EDGE/ZONE explainer cards, a guided first view that opens on the top attack path with a plain-language narrative, a security-zones view (Attack Surface → Guards → Logic → Sensitive Sinks), search, layer/severity filters, a details panel with source drill-down, and entrypoint→sink path highlighting (Cytoscape.js, fully inlined).
 - **Exec-first report posture**: an A–F security grade with a one-line verdict and severity-distribution bar, a since-last-scan delta strip (new/regressed/fixed), findings grouped into expandable rule cards, an honest findings-cap footer, and a print stylesheet for clean PDF export.

--- a/benchmark/mutation_harness.py
+++ b/benchmark/mutation_harness.py
@@ -655,6 +655,42 @@ MUTATIONS: list[Mutation] = [
         note="a taint-confirmed command argument (`exec.Command(\"sh\", \"-c\", userCmd)` "
         "with tainted userCmd) must not read safe",
     ),
+    # -- D9: the Java verdict assessor must never fail open ------------------
+    Mutation(
+        id="D9-java-tainted-sink-reads-safe",
+        disaster="D9",
+        file="cybergraph/analysis/java_provenance.py",
+        old="        if any(n in tainted_names for n in names):\n"
+        "            return VERDICT_UNSAFE",
+        new="        if any(n in tainted_names for n in names):\n"
+        "            return VERDICT_SAFE",
+        tests=("tests/test_java_provenance.py::test_assess_sql_concat_tainted_unsafe",),
+        note="a taint-confirmed Java sink operand must not read safe",
+    ),
+    Mutation(
+        id="D9-java-unresolved-var-reads-safe",
+        disaster="D9",
+        file="cybergraph/analysis/java_provenance.py",
+        old="        if names or unresolved:\n"
+        "            # a candidate variable (resolved or not) or an operand we could not\n"
+        "            # prove literal -> never read as safe\n"
+        "            return VERDICT_UNKNOWN",
+        new="        if names or unresolved:\n"
+        "            # a candidate variable (resolved or not) or an operand we could not\n"
+        "            # prove literal -> never read as safe\n"
+        "            return VERDICT_SAFE",
+        tests=("tests/test_java_provenance.py::test_assess_sql_unresolved_unknown",),
+        note="a Java variable CyberGraph cannot resolve must read UNKNOWN, never SAFE",
+    ),
+    Mutation(
+        id="D9-java-deser-reads-safe",
+        disaster="D9",
+        file="cybergraph/analysis/java_provenance.py",
+        old="    return VERDICT_UNSAFE if tainted_present else VERDICT_UNKNOWN",
+        new="    return VERDICT_SAFE",
+        tests=("tests/test_java_provenance.py::test_deserialization_never_safe",),
+        note="native deserialization can never be proven safe from construction alone",
+    ),
 ]
 
 

--- a/docs/CRITICAL_AUDIT.md
+++ b/docs/CRITICAL_AUDIT.md
@@ -314,16 +314,19 @@ the CI SARIF filter until each language gets its own Phase-2 sink registry/predi
 the project takes on a parsing dependency, which is the tradeoff already recorded above
 against §3.2's zero-dependency moat).
 
-**Note (2026-08-11): resolved for JS (core four) and Go (SQL/command/path); Java/C# and
-other classes remain inventory-grade.** Without a JS or Go parser, a structural,
+**Note (2026-08-11, updated 2026-08-12): resolved for JS, Go, and Java core sink classes;
+C# and other classes remain inventory-grade.** Without a JS/Go/Java parser, a structural,
 statement-local classifier per language (`analysis/js_provenance.py`,
-`analysis/go_provenance.py`) now grades sink arguments as SAFE (all-literal/constant
-construction only), UNSAFE (a construction containing a variable that line-based
-intra-function taint confirms), or UNKNOWN (a variable it cannot resolve — never SAFE)
-rather than emitting the flat `CG-{JS,GO}-SINK-CALL` inventory row. JS covers four sink
+`analysis/go_provenance.py`, `analysis/java_provenance.py`) now grades sink arguments as SAFE
+(all-literal/constant construction only), UNSAFE (a construction containing a variable that
+line-based intra-function taint confirms), or UNKNOWN (a variable it cannot resolve — never SAFE)
+rather than emitting the flat `CG-{JS,GO,JAVA}-SINK-CALL` inventory row. JS covers four sink
 classes (SQL, command, code-exec, path); Go covers three (SQL, command, path — Go has no
-registered code-exec sink). Java and C# are unchanged, and other JS/TS sink classes (beyond
-SQL/command/code/path) still fall back to the pre-rewrite inventory rule. §4.5 stays OPEN.
+registered code-exec sink); Java covers four (SQL, command, path, and native deserialization —
+deserialization takes no argument to classify, so it is never SAFE, only UNSAFE/UNKNOWN). C# is
+unchanged and still emits its `CG-CSHARP-SINK-CALL` inventory row behind the CI SARIF filter
+(§4.1), and other sink classes not listed above still fall back to the pre-rewrite inventory
+rule. §4.5 stays OPEN.
 
 ### 4.6 MEDIUM — benchmark claims drift from the committed artifact
 

--- a/docs/superpowers/plans/2026-08-11-java-verdicts.md
+++ b/docs/superpowers/plans/2026-08-11-java-verdicts.md
@@ -1,0 +1,391 @@
+# Java Verdicts — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn Java from inventory `CG-JAVA-SINK-CALL` into real safe/unsafe/unknown verdicts for SQL, command, path, and unsafe deserialization — reusing Python's rule ids and reviewing under the same capabilities — with only an all-literal/constant construction ever reading SAFE and native deserialization never reading SAFE.
+
+**Architecture:** A `_JAVA` sink registry (`sinks.py`), a new `java_provenance.py` (ported from the final Go/JS provenance — positive-literal-proof + Go's all-argument command assessor — plus Java idioms and a never-SAFE deserialization rule), and Java routing in `java.py` that uses a **dedicated Java sink-call matcher** (because the existing `CALL_RE` misses constructors and chained calls) to locate sinks and their arguments. Then broaden four capabilities to `*.java`. No `checks.py` change.
+
+**Tech Stack:** Python 3.10–3.13, stdlib only (`re`). Existing `sinks.Sink`/`lookup_sink`, `predicates.VERDICT_*`, `provenance.LITERAL/COMPOSED/OPAQUE`, the capability/coverage machinery, `java.py`'s intra-function taint. Reference implementations: `src/cybergraph/analysis/go_provenance.py` and `js_provenance.py`.
+
+## Global Constraints
+
+- **Zero runtime dependencies**; stdlib only (`re`) — no Java parser. Lightweight/structural, fail-safe.
+- Python 3.10–3.13. `from __future__ import annotations` first line of any new file.
+- Ruff line-length 100; `ruff check` clean on touched files.
+- No network; no API keys on any default path.
+- **Precision over recall (cardinal):** only an all-literal/constant construction is SAFE; a variable is UNSAFE (taint-confirmed) or UNKNOWN (unresolved), never SAFE; never infer "no candidate names ⇒ literal". **Native deserialization is never SAFE** (UNSAFE if a tainted stream reaches it, else UNKNOWN).
+- Commits `Laraib <lxh417bham@gmail.com>` only (repo config already carries it — do **not** pass `-c user.email=`); no `Co-Authored-By`, no AI attribution. Many small commits; never squash. Push only to `https://github.com/AQ-Labs/cybergraph`.
+- Branch `feat/java-verdicts` is off `main` (not stacked).
+
+---
+
+## File Structure
+
+- `src/cybergraph/security/sinks.py` (modify) — `_JAVA`; register in `_BY_LANGUAGE`.
+- `src/cybergraph/analysis/java_provenance.py` (create) — classifier + assessor + `assess_command` + `assess_deserialization`.
+- `src/cybergraph/analysis/java.py` (modify) — dedicated Java sink-call matcher + routing.
+- `src/cybergraph/security/capability.py` (modify) — `JAVA_GLOBS`; broaden four capabilities.
+- `src/cybergraph/security/coverage.py` (modify) — add `JAVA_GLOBS` to the verified gate.
+- Tests: `tests/test_sinks_java.py`, `tests/test_java_provenance.py`, `tests/test_java_verdicts_e2e.py` (create).
+- `benchmark/mutation_harness.py` (modify) — seeded fail-opens incl. deserialization.
+- `README.md`, `docs/CRITICAL_AUDIT.md` (modify) — document; extend §4.5.
+
+---
+
+## Task 1: Java sink registry in `sinks.py`
+
+**Files:** Modify `src/cybergraph/security/sinks.py`; Test `tests/test_sinks_java.py` (create).
+
+**Interfaces:** `_JAVA: tuple[Sink, ...]` and `_BY_LANGUAGE["java"] = _JAVA`, so `lookup_sink(name, "java")` resolves Java sinks (reuse `_SQL`/`_CMD` constants; add a `_DESERIALIZE` plain string if not already present — Python's deser sinks use one).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_sinks_java.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from cybergraph.security.sinks import lookup_sink
+
+
+@pytest.mark.parametrize("call_name,rule_id,vuln", [
+    ("stmt.executeQuery", "CG-SQL-EXEC", "sql"),
+    ("stmt.executeUpdate", "CG-SQL-EXEC", "sql"),
+    ("em.createNativeQuery", "CG-SQL-EXEC", "sql"),
+    ("jdbcTemplate.query", "CG-SQL-EXEC", "sql"),
+    ("Runtime.exec", "CG-CMD-EXEC", "command"),
+    ("pb.start", "CG-CMD-EXEC", "command"),
+    ("File", "CG-PATH-TRAVERSAL", "path"),
+    ("Files.readAllBytes", "CG-PATH-TRAVERSAL", "path"),
+    ("ois.readObject", "CG-DESERIALIZE", "deserialize"),
+    ("ois.readUnshared", "CG-DESERIALIZE", "deserialize"),
+])
+def test_java_sinks_resolve(call_name, rule_id, vuln):
+    sink = lookup_sink(call_name, "java")
+    assert sink is not None, call_name
+    assert sink.rule_id == rule_id
+    assert sink.vuln_class == vuln
+
+
+def test_java_non_sink_is_none():
+    assert lookup_sink("logger.info", "java") is None
+    assert lookup_sink("list.add", "java") is None
+
+
+def test_other_languages_unchanged():
+    assert lookup_sink("os.system", "python").rule_id == "CG-CMD-EXEC"
+    assert lookup_sink("pickle.loads", "python").rule_id == "CG-DESERIALIZE"
+    assert lookup_sink("stmt.executeQuery", "python") is None
+    assert lookup_sink("db.query", "javascript").rule_id == "CG-SQL-EXEC"
+```
+
+- [ ] **Step 2: Run to verify it fails** — `pytest tests/test_sinks_java.py -v` → FAIL.
+
+- [ ] **Step 3: Implement.** In `sinks.py`, add after `_GO`:
+
+```python
+_JAVA: tuple[Sink, ...] = (
+    # SQL (bare method names)
+    Sink("executeQuery", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("executeUpdate", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("execute", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("query", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("update", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("createNativeQuery", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("createQuery", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    # Command (bare; Runtime.exec / ProcessBuilder / .start)
+    Sink("exec", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _CMD, "command",
+         bare=True, shell=SHELL_CONDITIONAL),
+    Sink("ProcessBuilder", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _CMD, "command",
+         bare=True, shell=SHELL_CONDITIONAL),
+    Sink("start", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _CMD, "command",
+         bare=True, shell=SHELL_CONDITIONAL),
+    # Path (bare; incl. constructor sinks File / FileReader / FileWriter / FileInputStream)
+    Sink("File", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("FileReader", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("FileWriter", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("FileInputStream", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("readAllBytes", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("write", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    # Deserialization
+    Sink("readObject", "CG-DESERIALIZE", "CWE-502", SEVERITY_CRITICAL,
+         "rebuilds objects from this stream, which can run code", "deserialize", bare=True),
+    Sink("readUnshared", "CG-DESERIALIZE", "CWE-502", SEVERITY_CRITICAL,
+         "rebuilds objects from this stream, which can run code", "deserialize", bare=True),
+)
+```
+
+Add `"java": _JAVA` to `_BY_LANGUAGE`.
+
+> The `_DESERIALIZE` plain-text constant already exists in `sinks.py` (Python uses it); reuse it instead of the inline string if present. Confirm `test_java_non_sink_is_none` holds — `logger.info`/`list.add` have no bare `info`/`add` entry.
+
+- [ ] **Step 4: Run + ruff.** `pytest tests/test_sinks_java.py -v` PASS; `ruff check` clean.
+- [ ] **Step 5: Commit** — `feat(sinks): register Java SQL/command/path/deserialization sinks`.
+
+---
+
+## Task 2: `java_provenance.py` — classifier + assessor + deserialization rule
+
+**Files:** Create `src/cybergraph/analysis/java_provenance.py`; Test `tests/test_java_provenance.py` (create).
+
+**Interfaces:** `extract_first_arg`, `extract_all_args`, `classify`, `variable_names`, `assess`, `assess_command`, `assess_deserialization`. Same contract/cardinal rule as go_provenance.
+
+**Approach:** START from `src/cybergraph/analysis/go_provenance.py` (final, reviewed — positive-literal-proof + `assess_command`). Port verbatim: `extract_first_arg`, `extract_all_args`, `_split_plus`, `_is_proven_literal_operand`, `_operand_candidates`, `assess`, `assess_command`. Adapt to Java:
+1. **`String.format(fmt, args…)`** → COMPOSED (assess ALL args incl. the format arg, like Go's `fmt.Sprintf`).
+2. **`StringBuilder`/`.append(x)` chains** → COMPOSED; extract each appended operand as a candidate via the positive-literal-proof helpers.
+3. Java string literals are `"…"` (no raw/backtick strings; no `${}`). Drop any JS/Go-specific literal forms not valid in Java, keep `"…"`.
+4. **New: `assess_deserialization(tainted_present: bool) -> str`** — native deser is never SAFE: `VERDICT_UNSAFE` if a tainted stream/value reaches the call, else `VERDICT_UNKNOWN`. (No argument classification — `readObject()`/`readUnshared()` take no argument.)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_java_provenance.py`:
+
+```python
+from __future__ import annotations
+
+from cybergraph.analysis.java_provenance import (
+    assess, assess_command, assess_deserialization, classify,
+)
+from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNKNOWN, VERDICT_UNSAFE
+from cybergraph.security.sinks import lookup_sink
+
+
+def _sql():
+    return lookup_sink("stmt.executeQuery", "java")
+
+
+def test_classify():
+    assert classify('"SELECT 1"') == "literal"
+    assert classify('"SELECT " + id') == "composed"
+    assert classify('String.format("SELECT %s", id)') == "composed"
+    assert classify("sb.append(id).toString()") == "composed" or classify("sb.append(id)") == "composed"
+    assert classify("buildQuery()") == "opaque"
+
+
+def test_assess_sql_literal_safe():
+    assert assess(_sql(), '"SELECT 1"', set()) == VERDICT_SAFE
+
+
+def test_assess_sql_concat_tainted_unsafe():
+    assert assess(_sql(), '"SELECT * FROM u WHERE id = " + id', {"id"}) == VERDICT_UNSAFE
+
+
+def test_assess_sql_format_variable_format_unsafe():
+    assert assess(_sql(), "String.format(userFmt, x)", {"userFmt"}) == VERDICT_UNSAFE
+
+
+def test_assess_sql_unresolved_unknown():
+    assert assess(_sql(), '"SELECT " + id', set()) == VERDICT_UNKNOWN
+
+
+def test_assess_command_shell_tainted_unsafe():
+    cmd = lookup_sink("Runtime.exec", "java")
+    assert assess_command(['"sh"', '"-c"', "userCmd"], {"userCmd"}) == VERDICT_UNSAFE
+    assert assess_command(['"ls"', '"-la"'], set()) == VERDICT_SAFE
+
+
+def test_deserialization_never_safe():
+    assert assess_deserialization(True) == VERDICT_UNSAFE     # tainted stream
+    assert assess_deserialization(False) == VERDICT_UNKNOWN   # unresolved -> still not safe
+```
+
+- [ ] **Step 2: Run to verify it fails** — FAIL (ModuleNotFoundError).
+- [ ] **Step 3: Implement** — port go_provenance + the four adaptations above. `assess_deserialization` is a two-line rule (tainted→UNSAFE else UNKNOWN). Confirm `provenance.LITERAL/…` and `predicates.VERDICT_*` imports; do not redefine.
+- [ ] **Step 4: Run + ruff** — `pytest tests/test_java_provenance.py -v` PASS; ruff clean.
+- [ ] **Step 5: Commit** — `feat(analysis): Java construction classifier, command + deserialization assessors`.
+
+---
+
+## Task 3: Java routing with a dedicated sink-call matcher
+
+**Files:** Modify `src/cybergraph/analysis/java.py`; Test `tests/test_java_verdicts_e2e.py` (create).
+
+**THE JAVA-SPECIFIC PROBLEM (this task's crux):** `java.py`'s existing `CALL_RE` requires a dotted name before `(`, so it **misses** the most common Java sink forms — verified:
+- `Runtime.getRuntime().exec(cmd)` → matches only `Runtime.getRuntime`, NOT `.exec(cmd)`.
+- `new File(path)`, `new ObjectInputStream(in).readObject()`, `new ProcessBuilder(args).start()` → match **nothing** (constructor / post-`)` chained call).
+
+So the verdict path cannot use `CALL_RE` to locate these sinks or their arguments. It needs a dedicated matcher.
+
+**Interfaces:** a graded verdict for a resolved Java sink (SQL/path first-arg `assess`; command all-args `assess_command`; deserialization `assess_deserialization`), replacing `CG-JAVA-SINK-CALL` for those sinks; other sinks stay inventory.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_java_verdicts_e2e.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from cybergraph.analysis.java import analyze_java_file
+
+
+def _rules(tmp_path, src):
+    p = tmp_path / "A.java"
+    p.write_text(src, encoding="utf-8")
+    _n, _e, findings = analyze_java_file(p, tmp_path)
+    return [f.rule_id for f in findings]
+
+
+def test_prepared_statement_is_safe(tmp_path):
+    src = ("class A { void h(java.sql.Connection c, String id) throws Exception {\n"
+           "  var ps = c.prepareStatement(\"SELECT * FROM u WHERE id = ?\");\n"
+           "  ps.setString(1, id); ps.executeQuery(); } }\n")
+    rules = _rules(tmp_path, src)
+    assert "CG-SQL-EXEC" not in rules  # executeQuery() has no string arg -> not a string-SQL sink
+
+
+def test_concat_sqli_is_unsafe(tmp_path):
+    src = ("class A { void h(java.sql.Statement st, javax.servlet.http.HttpServletRequest req) throws Exception {\n"
+           "  String id = req.getParameter(\"id\");\n"
+           "  st.executeQuery(\"SELECT * FROM u WHERE id = \" + id); } }\n")
+    assert "CG-SQL-EXEC" in _rules(tmp_path, src)
+
+
+def test_new_file_user_path_is_flagged(tmp_path):
+    src = ("class A { void h(javax.servlet.http.HttpServletRequest req) throws Exception {\n"
+           "  String p = req.getParameter(\"p\");\n"
+           "  new java.io.File(p); } }\n")
+    rules = _rules(tmp_path, src)
+    assert "CG-PATH-TRAVERSAL" in rules  # new File(...) constructor sink, CALL_RE would miss it
+
+
+def test_runtime_exec_chained_is_flagged(tmp_path):
+    src = ("class A { void h(javax.servlet.http.HttpServletRequest req) throws Exception {\n"
+           "  String c = req.getParameter(\"c\");\n"
+           "  Runtime.getRuntime().exec(new String[]{\"sh\", \"-c\", c}); } }\n")
+    assert "CG-CMD-EXEC" in _rules(tmp_path, src)  # chained .exec(...) after )
+
+
+def test_readobject_never_safe(tmp_path):
+    src = ("class A { Object h(javax.servlet.http.HttpServletRequest req) throws Exception {\n"
+           "  var ois = new java.io.ObjectInputStream(req.getInputStream());\n"
+           "  return ois.readObject(); } }\n")
+    rules = _rules(tmp_path, src)
+    assert "CG-DESERIALIZE" in rules or "CG-DESERIALIZE-UNVERIFIED" in rules
+```
+
+> Note: confirm how a name enters `java.py`'s per-line `tainted` set (via `INPUT_MARKERS` like `getParameter`/`getInputStream`) so the UNSAFE cases genuinely exercise taint; adjust fixtures to java.py's taint model. For `readObject`, "tainted stream" = the `ObjectInputStream` built from `req.getInputStream()` — if wiring receiver-taint is intricate, it is acceptable for `readObject` to read UNKNOWN (never SAFE) when taint cannot confirm; the test allows either the confirmed or the `-UNVERIFIED` rule id, but NEVER absent.
+
+- [ ] **Step 2: Run to verify it fails** — FAIL (sinks not graded / not detected).
+
+- [ ] **Step 3: Implement the dedicated matcher + routing**
+
+Add a Java sink-call matcher in `java.py` that finds registered sinks regardless of chaining/constructors, over the whole `source` (offset-correct):
+
+```python
+# Matches a sink call the general CALL_RE misses: a constructor `new Ctor(` or a
+# method call `.method(` (including one that follows a `)` in a chain).
+_JAVA_SINK_CALL_RE = re.compile(r"\bnew\s+(?P<ctor>[A-Z]\w*)\s*\(|\.(?P<method>[A-Za-z_]\w*)\s*\(")
+```
+
+For each match: `name = m.group("ctor") or m.group("method")`; `sink = lookup_sink(name, "java")`; if `sink is None`, skip (not a verdict sink — leave to the legacy inventory scan). Otherwise:
+- `open_paren = m.end() - 1`; `line_no = source.count("\n", 0, m.start()) + 1`.
+- Resolve the tainted-name set for that line/function (reuse java.py's `tainted_by_function`; the function owning `line_no`). A conservative function-local `set(tainted)` is acceptable (fail-safe), as in Go/JS.
+- **Zero-argument guard (precision — port Go's):** a `sql`/`path`/`command` sink call with an EMPTY argument list is NOT a string-injection sink and is skipped (emit nothing). This is essential for Java: `ps.executeQuery()` (a PreparedStatement execution — the query was set safely via `prepareStatement("…?")`) and `pb.start()` (the command lives in the `new ProcessBuilder(...)` constructor, which is matched and assessed separately) have empty parens; without the guard every PreparedStatement would false-flag. **Deserialization is EXEMPT** — `readObject()`/`readUnshared()` are zero-argument by nature and must still be assessed (never-SAFE). So: skip empty-arg SQL/path/command; always assess deserialization. (Distinguish a genuinely empty `()` from an unreadable/unbalanced arg, which stays UNKNOWN — same as Go's guard.)
+- Dispatch by `sink.vuln_class`:
+  - `sql`/`path`: `arg = extract_first_arg(source, open_paren)`; `verdict = assess(sink, arg, tainted)`.
+  - `command`: `args = extract_all_args(source, open_paren)`; `verdict = assess_command(args, tainted)`.
+  - `deserialize`: `verdict = assess_deserialization(tainted_present)` where `tainted_present` reflects whether a tainted value is in scope for that call (fail-safe: if unknown, `False` → UNKNOWN, never SAFE).
+- Emit the graded finding (UNSAFE→`sink.rule_id`, UNKNOWN→`+"-UNVERIFIED"`, SAFE→none), honoring `is_inline_suppressed`.
+
+**De-duplication:** a resolved verdict sink must not ALSO emit a legacy `CG-JAVA-SINK-CALL` for the same call. Where the legacy `CALL_RE + _is_sink` scan and the new matcher both fire for one logical sink, suppress the legacy inventory for it (e.g. the legacy scan skips a `call_name` whose bare tail resolves via `lookup_sink(call_name,"java")`). A co-emitted inventory finding on a chain's *intermediate* call (e.g. `Runtime.getRuntime`, which is not itself a registry sink) is SARIF-filtered and a tolerable minor — do not over-engineer, but the SAME sink must never double-emit.
+
+> Integrate the matcher with java.py's existing per-line loop OR run it as a second pass over `source` after the loop populates `tainted_by_function`. A second pass is cleaner (taint is fully known); map each match's `line_no` to its function via the same logic java.py uses to track `current_function`. Pin the exact integration; keep `EDGE_REACHES_SINK`/`EDGE_TAINTS` behavior for detected sinks.
+
+- [ ] **Step 4: Run + ruff** — `pytest tests/test_java_verdicts_e2e.py tests/test_java*.py -v` PASS (update stale inventory expectations if any); ruff clean.
+- [ ] **Step 5: Commit** — `feat(analysis): grade Java SQL/command/path/deserialization sinks (dedicated matcher)`.
+
+---
+
+## Task 4: Broaden four capabilities to Java
+
+**Files:** Modify `capability.py`, `coverage.py`; Test `tests/test_java_verdicts_e2e.py` (append).
+
+**Interfaces:** `JAVA_GLOBS = ("*.java",)`; `sql_construction`/`command_execution`/`path_access`/**`deserialization`** covers += `JAVA_GLOBS`; coverage verified gate += `JAVA_GLOBS`. `code_execution`, `VERIFIED_GLOBS` unchanged.
+
+- [ ] **Step 1: Write the failing test** — append to `tests/test_java_verdicts_e2e.py`:
+
+```python
+import subprocess
+from cybergraph.security.capability import CAPABILITIES, FAIL, NOT_SUPPORTED
+from cybergraph.security.check import check_change
+from cybergraph.security.verdict import STATE_REVIEW
+
+
+def _cap(cid):
+    return next(c for c in CAPABILITIES if c.id == cid)
+
+
+def test_four_capabilities_cover_java():
+    for cid in ("sql_construction", "command_execution", "path_access", "deserialization"):
+        assert "*.java" in _cap(cid).covers, cid
+    assert "*.java" not in _cap("code_execution").covers
+
+
+def _repo(tmp_path):
+    repo = tmp_path / "r"; repo.mkdir()
+    for a in (["init","-q"],["config","user.email","t@e.com"],["config","user.name","t"]):
+        subprocess.run(["git","-C",str(repo),*a], check=True)
+    (repo / "README.md").write_text("# x\n", encoding="utf-8")
+    subprocess.run(["git","-C",str(repo),"add","."], check=True)
+    subprocess.run(["git","-C",str(repo),"commit","-q","-m","base"], check=True)
+    return repo
+
+
+def test_java_sqli_reviews(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "A.java").write_text(
+        "class A { void h(java.sql.Statement st, javax.servlet.http.HttpServletRequest req) throws Exception {\n"
+        "  String id = req.getParameter(\"id\");\n"
+        "  st.executeQuery(\"SELECT * FROM u WHERE id = \" + id); } }\n", encoding="utf-8")
+    v = check_change(repo, mode="worktree")
+    assert v.state == STATE_REVIEW
+    assert any(c.capability_id == "sql_construction" and c.status == FAIL for c in v.checks)
+
+
+def test_java_still_not_supported_overall(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "A.java").write_text("class A { int x = 1; }\n", encoding="utf-8")
+    v = check_change(repo, mode="worktree")
+    assert any(c.capability_id == "source_analysis_support" and c.status == NOT_SUPPORTED
+               for c in v.checks)
+```
+
+- [ ] **Step 2: Run to verify it fails.**
+- [ ] **Step 3: Implement** — `capability.py`: add `JAVA_GLOBS = ("*.java",)`; append `+ JAVA_GLOBS` to `sql_construction`/`command_execution`/`path_access` covers; change `deserialization` from `PYTHON_GLOBS` to `PYTHON_GLOBS + JAVA_GLOBS`. `coverage.py`: import `JAVA_GLOBS`, add to the verified gate (`… + WEB_GLOBS + GO_GLOBS + JAVA_GLOBS`).
+- [ ] **Step 4: Run + ruff** — target suites PASS (update stale relevance expectations); ruff clean.
+- [ ] **Step 5: Commit** — `feat(verdict): SQL/command/path/deserialization capabilities now cover Java`.
+
+---
+
+## Task 5: Mutations + docs + full verification
+
+**Files:** Modify `benchmark/mutation_harness.py`, `README.md`, `docs/CRITICAL_AUDIT.md`.
+
+- [ ] **Step 1: Add mutations** (match `old` to committed `java_provenance.py`/`java.py` verbatim, each unique):
+  - `D9-java-tainted-sink-reads-safe` — flip the assessor's taint→UNSAFE to SAFE; map to `test_assess_sql_concat_tainted_unsafe`.
+  - `D9-java-unresolved-var-reads-safe` — flip unresolved→UNKNOWN to SAFE; map to `test_assess_sql_unresolved_unknown`.
+  - `D9-java-deser-reads-safe` — flip `assess_deserialization` so it returns SAFE; map to `test_deserialization_never_safe`.
+  Run `python benchmark/mutation_harness.py` → all CAUGHT.
+- [ ] **Step 2: Docs** — README: a bullet that Java now earns real SQL/command/path/deserialization verdicts. `docs/CRITICAL_AUDIT.md` §4.5: "resolved for JS, Go, and Java core classes; C# and other classes remain inventory-grade." NOT fully closed.
+- [ ] **Step 3: Full verification** — `pytest -q` all pass; `ruff check .` no new errors; `python benchmark/mutation_harness.py` all CAUGHT; `python benchmark/run_precision.py` gate PASSED; `python benchmark/run_eval.py` precision/recall unchanged (git checkout benchmark/results.json after; do NOT commit it) — confirm Python/JS/Go corpora identical (Java registry is language-keyed).
+- [ ] **Step 4: Commit** — `test(java): seed Java verdict fail-open mutations; document the upgrade`.
+
+---
+
+## Notes for the executor
+
+- **Precision is cardinal.** Only all-literal/constant is SAFE; native deserialization is never SAFE. Port the Go positive-literal-proof + `assess_command` exactly — do not re-derive a looser version.
+- **Task 3 is the hard one:** the dedicated `_JAVA_SINK_CALL_RE` must catch constructors (`new File(...)`, `new ProcessBuilder(...)`) and chained calls (`Runtime.getRuntime().exec(...)`, `ois.readObject()`) that the existing `CALL_RE` misses — the e2e tests (`test_new_file_user_path_is_flagged`, `test_runtime_exec_chained_is_flagged`, `test_readobject_never_safe`) force this. No SAME-sink double-emission with the legacy inventory path.
+- Confirm names/signatures against source before running each task's tests (`provenance.*`, `Sink`, `check_change`/`Verdict.checks`, java.py taint); adapt the test to reality, never the reverse.
+- Do NOT add a Java parser dependency, Java code/SpEL/JNDI detection, `*.java` in `VERIFIED_GLOBS`, or interprocedural flow — out of scope.

--- a/docs/superpowers/specs/2026-08-11-java-verdicts-design.md
+++ b/docs/superpowers/specs/2026-08-11-java-verdicts-design.md
@@ -1,0 +1,189 @@
+# Java Verdicts — Design (Non-Python upgrade, slice 3)
+
+**Status:** approved for planning
+**Slice:** the third per-language slice of the non-Python verdict upgrade — Java, for SQL,
+command, path, and unsafe **deserialization**. Replicates the shape proven in the JS and Go
+slices, plus one new vulnerability class.
+**Predecessors:** JS verdicts (#46, merged), Go verdicts (#50, merged), the JS command fix
+(#49, merged). Branches off `main` (the stack has fully drained — everything is landed);
+**not stacked.**
+
+## The sentence this slice is judged against
+
+> Java graduates from inventory `CG-JAVA-SINK-CALL` to real safe/unsafe/unknown verdicts for
+> SQL, command, path, and — the marquee Java class — unsafe deserialization, reusing Python's
+> rule ids and reviewing under the same capabilities, with only an all-literal/constant
+> construction ever reading SAFE and native Java deserialization never reading SAFE.
+
+## Why this is the right slice
+
+- `java.py` (293 lines) already tracks intra-function taint (`tainted_by_function`,
+  `_tainted_source_for_line`, `EDGE_TAINTS`, `INPUT_MARKERS` such as `getParameter`,
+  `@RequestParam`, `@PathVariable`, `request.getHeader`) and emits flat `CG-JAVA-SINK-CALL`
+  inventory for SQL/command/path — the same scaffolding JS and Go had.
+- Java adds a *new* verdict class the earlier slices didn't: native **deserialization**
+  (`ObjectInputStream.readObject`), the ysoserial/gadget-chain RCE family — high real-world value.
+
+## Decisions already made (do not re-litigate in planning)
+
+1. **Four classes: SQL, command, path, deserialization.** Java code/expression injection
+   (`ScriptEngine.eval`, SpEL, OGNL) and JNDI injection (Log4Shell `ctx.lookup`) are distinct
+   nuances, deferred. `code_execution` is NOT broadened to Java here.
+2. **Reuse Python's rule ids and broaden the existing capabilities** — `CG-SQL-EXEC`,
+   `CG-CMD-EXEC`, `CG-PATH-TRAVERSAL`, `CG-DESERIALIZE`. Broaden `sql_construction`,
+   `command_execution`, `path_access`, and — unlike Go/JS — **`deserialization`** (Python-only
+   today; Java genuinely has it) to include `JAVA_GLOBS`. `VERIFIED_GLOBS` unchanged →
+   `source_analysis_support` stays honestly NOT_SUPPORTED for Java (the tool claims exactly the
+   four classes it verifies).
+3. **Cardinal rule + positive-literal-proof from the start.** Only an all-literal/constant
+   construction is SAFE; a variable is UNSAFE (taint-confirmed) or UNKNOWN (unresolved), never
+   SAFE; never infer "no candidate names ⇒ literal" (the JS/Go final-review lesson).
+4. **Native deserialization is never SAFE (confirmed §2 below).**
+
+## Architecture — port the proven shape + one new class
+
+```
+src/cybergraph/security/sinks.py          (modify)  add _JAVA registry; _BY_LANGUAGE["java"]
+src/cybergraph/analysis/java_provenance.py(create)  Java construction classifier + assessor + deser rule
+src/cybergraph/analysis/java.py           (modify)  route the four sink classes through the assessor
+src/cybergraph/security/capability.py     (modify)  JAVA_GLOBS; broaden four capabilities
+src/cybergraph/security/coverage.py       (modify)  add JAVA_GLOBS to the verified gate
+```
+
+`checks.py` needs **no change** (the four capabilities are already in `_FINDING_RULES`, including
+`deserialization → CG-DESERIALIZE`).
+
+### The Java sink registry (`sinks.py`)
+
+Add `_JAVA` reusing `Sink(name, rule_id, cwe, severity, plain, vuln_class, bare, shell)` and
+Python's rule ids. Java methods are called on unresolvable receivers → `bare=True` on the method
+name (matching how Python treats `cursor.execute`):
+
+- **SQL** (`CG-SQL-EXEC`, CWE-89): `executeQuery`, `executeUpdate`, `execute`, `query`, `update`,
+  `createNativeQuery`, `createQuery` (bare). PreparedStatement with `?` placeholders is the safe
+  form (a literal query → SAFE).
+- **Command** (`CG-CMD-EXEC`, CWE-78): `exec` (`Runtime.exec`), `ProcessBuilder`, `start`
+  (bare; shell conditional — `exec`/`ProcessBuilder` run no shell unless the argv is `sh -c`/
+  `cmd /c`).
+- **Path** (`CG-PATH-TRAVERSAL`, CWE-22): `write`, `readAllBytes`, `newInputStream`,
+  `FileReader`, `FileWriter`, `FileInputStream`, and `File` (`new File(path)`) (bare).
+- **Deserialization** (`CG-DESERIALIZE`, CWE-502): `readObject`, `readUnshared` (bare).
+
+### The Java construction classifier + assessor (`java_provenance.py`)
+
+Ported from the final Go/JS provenance (positive-literal-proof intact: `extract_first_arg`,
+`extract_all_args`, `_split_plus`, `_is_proven_literal_operand`, `_operand_candidates`), adapted
+to Java:
+
+- **Construction idioms:** a Java string literal → LITERAL; `"…" + var` concatenation,
+  `String.format(fmt, args…)`, or a `StringBuilder`/`.append(...)` chain involving a non-literal
+  → COMPOSED; a bare identifier or call → OPAQUE; unreadable → OPAQUE (fail-safe). `String.format`
+  is treated like Go's `fmt.Sprintf` (assess **all** args, incl. the format arg — a variable
+  format is not a literal). A `StringBuilder.append(x)` chain contributes each appended operand.
+- **Taint refinement:** reuse `java.py`'s function-local taint.
+- **Per-class assessment:**
+  - **SQL / path:** all-literal/constant → SAFE; a candidate variable taint-confirms → UNSAFE;
+    unresolved variable / opaque / unreadable → UNKNOWN. (PreparedStatement `?` query is a literal
+    → SAFE.)
+  - **command:** the Go all-argument `assess_command` — any non-literal command argument →
+    UNSAFE (taint-confirmed) / UNKNOWN (unresolved); all-literal argv → SAFE. Shell form
+    (`sh`/`bash`/`cmd` + `-c`/`/c`) with a non-literal → UNSAFE/UNKNOWN.
+  - **deserialization (the new, distinct rule):** `readObject`/`readUnshared` take **no argument**
+    to classify — the danger is the stream the `ObjectInputStream` was built from. Native Java
+    deserialization is **never SAFE**: → **UNSAFE** when `java.py`'s taint shows an untrusted
+    value/stream reaching the call, else **UNKNOWN** (`CG-DESERIALIZE-UNVERIFIED` → REVIEW:
+    "verify this stream is trusted"). This is honest (static analysis cannot prove a native-deser
+    source safe) and fail-safe. The routing recognizes the deser class and applies this rule
+    instead of argument classification.
+- **Verdict → finding:** UNSAFE → `sink.rule_id`; UNKNOWN → `sink.rule_id + "-UNVERIFIED"`;
+  SAFE → none (never emitted for deserialization).
+
+### `java.py` routing
+
+Gate on **registry OR legacy** (as in JS/Go): `sink = lookup_sink(call_name, "java"); if sink is
+not None or _is_sink(call_name, custom_sinks):`. Registry hit → the assessor (SQL/path first-arg;
+command all-args; deserialization the never-SAFE rule); else → existing `CG-JAVA-SINK-CALL`
+inventory. Preserve `EDGE_REACHES_SINK`/`EDGE_TAINTS`; graded XOR inventory, never both. Use the
+whole-file offset translation (`_line_start_offsets`, the JS/Go fix) for argument extraction.
+
+> **Java-specific risk to pin in the plan:** method chaining — `Runtime.getRuntime().exec(cmd)`
+> puts the sink call's `(` after a `)`, and `new File(path)` has the `new` keyword. Confirm that
+> `CALL_RE`/`call.group("name")` yields a `call_name` whose bare tail resolves the sink
+> (`exec`/`File`), and that `call.end()-1` lands on the correct `(` for argument extraction.
+> Where a constructor (`new File(...)`, `new ProcessBuilder(...)`) is the sink, the plan pins how
+> the name is recognized (bare `File`/`ProcessBuilder`).
+
+### Capability & coverage
+
+- `capability.py`: add `JAVA_GLOBS = ("*.java",)`; broaden `sql_construction`,
+  `command_execution`, `path_access` to `… + JAVA_GLOBS`, and `deserialization` from
+  `PYTHON_GLOBS` to `PYTHON_GLOBS + JAVA_GLOBS`. `code_execution` unchanged; `VERIFIED_GLOBS`
+  unchanged.
+- `coverage.py`: add `JAVA_GLOBS` to the verified gate so a clean analyzed `.java` file reaches
+  PASS (not perpetual UNKNOWN), without changing `source_analysis_support`.
+
+## Precision & the SARIF filter
+
+The four classes emit real `CG-*` rules (uploadable); the filter still drops the remaining
+`*-SINK-CALL` inventory for Java sink names outside the registry. Audit §4.5 note extended to
+"JS + Go + Java core classes." A PreparedStatement query → SAFE; a `"…" + userInput` /
+`String.format` with a tainted arg → UNSAFE; a `readObject` on an untrusted stream → UNSAFE, on
+an unresolved stream → UNKNOWN.
+
+## Error handling
+
+- A `.java` the analyzer cannot read → containment → coverage FAILED → UNKNOWN.
+- An argument the paren matcher cannot balance → OPAQUE → UNKNOWN, never SAFE.
+- A `readObject`/`readUnshared` call → never SAFE (UNSAFE if tainted, else UNKNOWN).
+
+## Testing
+
+- **`java_provenance` units:** SQL literal → SAFE; `"…" + tainted` → UNSAFE; `String.format`
+  tainted arg (incl. variable format) → UNSAFE; `StringBuilder.append(tainted)` → UNSAFE;
+  unresolved → UNKNOWN; PreparedStatement `?` → SAFE. Command: `Runtime.exec(new String[]{"sh","-c",userCmd})`
+  / `exec("sh","-c",userCmd)` tainted → UNSAFE, all-literal → SAFE. Deserialization: tainted
+  stream → UNSAFE, untainted/unresolved → UNKNOWN, and **never SAFE** for any input.
+- **`sinks.py`:** `lookup_sink` resolves the Java names to the right rule ids/classes; other
+  languages unchanged.
+- **Capability five-state** on a `.java` change for the four capabilities; `source_analysis_support`
+  still NOT_SUPPORTED for Java; `code_execution` NOT_APPLICABLE on a Java change.
+- **End-to-end:** `cybergraph check` → REVIEW on a Java SQLi (`stmt.executeQuery("… " + req.getParameter("id"))`)
+  and on a `new ObjectInputStream(request.getInputStream()).readObject()`; ACCEPT on a
+  PreparedStatement change.
+- **Mutation harness:** seeded fail-opens incl. a tainted-SQLi-reads-safe, an unresolved-reads-safe,
+  and a **deserialization-reads-safe** (the never-SAFE rule flipped) — each red under its guard test.
+- Full suite green; ruff clean; `run_precision.py`/`run_eval.py` unchanged (Python corpus — the
+  Java registry is language-keyed; verify identical).
+
+## Global constraints (inherited, unchanged)
+
+- Python 3.10–3.13. **Zero runtime dependencies**; standard library only (`re`) — no Java parser.
+  Lightweight/structural, fail-safe.
+- Ruff line-length 100; `from __future__ import annotations` in every file.
+- No network; no API keys on any default path.
+- **Precision over recall:** only an all-literal/constant construction is SAFE; native
+  deserialization is never SAFE; uncertainty → UNKNOWN.
+- Commits `Laraib <lxh417bham@gmail.com>` only; no `Co-Authored-By`, no AI attribution. Many small
+  commits; never squash. Push only to `https://github.com/AQ-Labs/cybergraph`.
+
+## Roadmap alignment — what this does NOT touch
+
+Builds Java verdicts for SQL/command/path/deserialization and broadens four capabilities.
+Deliberately excluded: Java code/expression injection (`ScriptEngine`/SpEL/OGNL), JNDI injection
+(Log4Shell), interprocedural/cross-file flow, `*.java` in `VERIFIED_GLOBS`, and C# (the final
+non-Python slice). `CG-JAVA-SINK-CALL` inventory remains for Java sink names outside the registry.
+
+## Success criteria
+
+1. `sinks.py` resolves the Java SQL/command/path/deserialization sink names to Python's rule ids
+   (bare); other languages unchanged.
+2. The Java classifier maps all-literal/constant → SAFE, a taint-confirmed variable → UNSAFE, an
+   unresolved variable/unreadable arg → UNKNOWN, per class (SQL/command/path); and native
+   deserialization → UNSAFE (tainted) / UNKNOWN (else), **never SAFE**. No variable is ever SAFE.
+3. A Java injection or unsafe deserialization on a changed `.java` → the matching capability FAIL
+   → `cybergraph check` REVIEW; a PreparedStatement/all-literal change → SAFE → ACCEPT (end-to-end).
+4. `source_analysis_support` still reports Java NOT_SUPPORTED; `sql_construction`/`command_execution`/
+   `path_access`/`deserialization` cover Java; `code_execution` does not.
+5. The four classes emit real `CG-*` rules, not `CG-JAVA-SINK-CALL`; other Java sinks stay inventory.
+6. Full suite green; ruff clean; the mutation harness catches every seeded Java fail-open incl.
+   the deserialization one; `run_precision.py`/`run_eval.py` unchanged.

--- a/src/cybergraph/analysis/java.py
+++ b/src/cybergraph/analysis/java.py
@@ -12,6 +12,13 @@ import re
 from pathlib import Path
 
 from cybergraph.analysis._source_text import strip_code
+from cybergraph.analysis.java_provenance import (
+    assess,
+    assess_command,
+    assess_deserialization,
+    extract_all_args,
+    extract_first_arg,
+)
 from cybergraph.graph import Edge, Finding, Node
 from cybergraph.security.ontology import (
     EDGE_EXPOSES_ENTRYPOINT,
@@ -22,6 +29,8 @@ from cybergraph.security.ontology import (
     EDGE_TAINTS,
     EDGE_USES_SECRET,
 )
+from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNSAFE
+from cybergraph.security.sinks import lookup_sink
 from cybergraph.suppressions import is_inline_suppressed
 
 # Method declarations: optional annotations are matched separately; this matches
@@ -36,6 +45,10 @@ SPRING_ROUTE_RE = re.compile(
     r"\s*(?:\(\s*(?:value\s*=\s*)?\"(?P<path>[^\"]*)\")?"
 )
 CALL_RE = re.compile(r"(?P<name>[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)+)\s*\(")
+# Matches a sink call the general CALL_RE misses: a constructor `new Ctor(` or a
+# method call `.method(` (including one that follows a `)` in a chain). Run over
+# the whole `source` (not per-line) so a chained call after a `)` is still found.
+_JAVA_SINK_CALL_RE = re.compile(r"\bnew\s+(?P<ctor>[A-Z]\w*)\s*\(|\.(?P<method>[A-Za-z_]\w*)\s*\(")
 ASSIGN_RE = re.compile(
     r"\b(?:final\s+)?(?:var|String|int|long|boolean|Path|File|[\w<>]+)"
     r"\s+(?P<name>[A-Za-z_]\w*)\s*=\s*(?P<expr>.+)"
@@ -85,6 +98,12 @@ def analyze_java_file(
     pending_route: dict | None = None
     current_function: str | None = None
     tainted_by_function: dict[str, dict[str, str]] = {}
+    # The owning function key (or `rel` at file scope) for each 1-based line,
+    # recorded as the main loop attributes sinks/taint to `sink_source` -- reused
+    # by the second-pass sink-call matcher below so a call the general `CALL_RE`
+    # cannot see (a constructor, or a chained call after `)`) is still attributed
+    # to the right function and taint set.
+    line_owner: list[str] = []
     for line_no, line in enumerate(lines, start=1):
         route_match = SPRING_ROUTE_RE.search(line)
         if route_match:
@@ -123,6 +142,7 @@ def analyze_java_file(
                 pending_route = None
 
         sink_source = current_function or rel
+        line_owner.append(sink_source)
         tainted = tainted_by_function.setdefault(sink_source, {})
         lowered_line = line.lower()
         code_line = code_lines[line_no - 1] if line_no - 1 < len(code_lines) else line
@@ -163,7 +183,11 @@ def analyze_java_file(
                         {"reason": "secret passed to exposure sink"},
                     )
                 )
-            if _is_sink(call_name, custom_sinks):
+            # A call_name whose bare tail resolves to a registered sink is graded
+            # by the dedicated matcher/second pass below instead -- skip it here
+            # so the same sink never double-emits (once as this legacy inventory
+            # finding, once as a graded verdict).
+            if _is_sink(call_name, custom_sinks) and lookup_sink(call_name, "java") is None:
                 edges.append(Edge(EDGE_REACHES_SINK, sink_source, call_name, rel, line_no))
                 taint_source = source_key or _tainted_source_for_line(line, tainted)
                 if taint_source:
@@ -190,6 +214,7 @@ def analyze_java_file(
                         )
                     )
 
+    _grade_java_sinks(source, lines, rel, line_owner, tainted_by_function, edges, findings)
     return nodes, edges, findings
 
 
@@ -267,6 +292,120 @@ def _tainted_source_for_line(line: str, tainted: dict[str, str]) -> str:
         if re.search(rf"\b{re.escape(name)}\b", line):
             return key
     return ""
+
+
+def _grade_java_sinks(
+    source: str,
+    lines: list[str],
+    rel: str,
+    line_owner: list[str],
+    tainted_by_function: dict[str, dict[str, str]],
+    edges: list[Edge],
+    findings: list[Finding],
+) -> None:
+    """Second pass: grade every sink `_JAVA_SINK_CALL_RE` finds into a real verdict.
+
+    Runs over the whole `source` (not per-line) so a constructor (`new File(...)`)
+    or a chained call after a `)` (`Runtime.getRuntime().exec(...)`) -- both
+    invisible to `CALL_RE` -- is still located. Taint is fully known by the time
+    this runs, so each match's line is mapped to its owning function via
+    `line_owner` (built by the main per-line loop) rather than re-tracking
+    `current_function`.
+    """
+    for call in _JAVA_SINK_CALL_RE.finditer(source):
+        name = call.group("ctor") or call.group("method")
+        sink = lookup_sink(name, "java")
+        if sink is None:
+            continue  # not a registered sink -- left to the legacy inventory scan
+        line_no = source.count("\n", 0, call.start()) + 1
+        open_paren = call.end() - 1
+        owner = line_owner[line_no - 1] if 0 < line_no <= len(line_owner) else rel
+        tainted_map = tainted_by_function.get(owner, {})
+        line_text = lines[line_no - 1] if 0 < line_no <= len(lines) else ""
+
+        # Zero-argument guard: `ps.executeQuery()`/`pb.start()` have empty parens
+        # and are not a string-injection sink call -- the query/command lives
+        # elsewhere (`prepareStatement("...")` / `new ProcessBuilder(...)`),
+        # matched and assessed separately. Deserialization is exempt:
+        # `readObject()`/`readUnshared()` are zero-argument by nature. An
+        # unbalanced/unreadable arg list is NOT genuinely empty and must still
+        # be assessed as unknown, not skipped.
+        if sink.vuln_class != "deserialize" and _call_is_empty(source, open_paren) is True:
+            continue
+
+        edges.append(Edge(EDGE_REACHES_SINK, owner, name, rel, line_no))
+        taint_key = _tainted_source_for_line(line_text, tainted_map)
+        if taint_key:
+            edges.append(
+                Edge(
+                    EDGE_TAINTS, taint_key, name, rel, line_no,
+                    {"function": owner, "reason": "tainted argument"},
+                )
+            )
+
+        if sink.vuln_class == "deserialize":
+            verdict = assess_deserialization(bool(taint_key))
+        elif sink.vuln_class == "command":
+            verdict = assess_command(extract_all_args(source, open_paren), set(tainted_map))
+        else:  # sql / path
+            verdict = assess(sink, extract_first_arg(source, open_paren), set(tainted_map))
+
+        finding = _java_verdict_finding(sink, verdict, rel, line_no, line_text)
+        if finding is not None and not is_inline_suppressed(lines, line_no, finding.rule_id):
+            findings.append(finding)
+
+
+def _call_is_empty(source: str, open_paren: int) -> bool | None:
+    """True for a genuinely empty `()`, False if it has content, None if unbalanced.
+
+    Quote/bracket-aware, mirroring `extract_first_arg`'s scan -- so a `)`/`,`
+    inside a nested string literal never mistakenly closes the call early.
+    `None` (unbalanced) is deliberately distinct from `True`: the zero-arg
+    guard must only fire on a call *proven* to take no arguments, never on one
+    that merely could not be read.
+    """
+    depth = 0
+    quote: str | None = None
+    i = open_paren
+    while i < len(source):
+        c = source[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"":
+            quote = c
+        elif c == "(":
+            depth += 1
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return not source[open_paren + 1 : i].strip()
+        i += 1
+    return None
+
+
+def _java_verdict_finding(sink, verdict: str, rel: str, line_no: int, line: str) -> Finding | None:
+    if verdict == VERDICT_SAFE:
+        return None
+    unsafe = verdict == VERDICT_UNSAFE
+    return Finding(
+        rule_id=sink.rule_id if unsafe else f"{sink.rule_id}-UNVERIFIED",
+        severity=sink.severity if unsafe else "medium",
+        message=(f"`{sink.name}` {sink.plain}" if unsafe
+                 else f"`{sink.name}` {sink.plain}, and CyberGraph could not confirm "
+                      "the value is safe"),
+        file_path=rel,
+        line_start=line_no,
+        cwe=sink.cwe,
+        evidence=line.strip(),
+    )
 
 
 def _classify_java_name(name: str) -> dict[str, bool]:

--- a/src/cybergraph/analysis/java.py
+++ b/src/cybergraph/analysis/java.py
@@ -311,13 +311,22 @@ def _grade_java_sinks(
     this runs, so each match's line is mapped to its owning function via
     `line_owner` (built by the main per-line loop) rather than re-tracking
     `current_function`.
+
+    Matches, the zero-arg check, and argument extraction all run against
+    `code` -- `source` with `//`/`/* */` comments blanked (string/char literals
+    left untouched) -- not raw `source`, so a commented-out sink call is
+    invisible here and never graded as live. `code` is exactly as long as
+    `source` (comment text becomes spaces, line boundaries are kept), so every
+    offset computed against it -- `line_no`, `open_paren` -- is equally valid
+    used against `source`; nothing needs translating.
     """
-    for call in _JAVA_SINK_CALL_RE.finditer(source):
+    code = _blank_java_comments(source)
+    for call in _JAVA_SINK_CALL_RE.finditer(code):
         name = call.group("ctor") or call.group("method")
         sink = lookup_sink(name, "java")
         if sink is None:
             continue  # not a registered sink -- left to the legacy inventory scan
-        line_no = source.count("\n", 0, call.start()) + 1
+        line_no = code.count("\n", 0, call.start()) + 1
         open_paren = call.end() - 1
         owner = line_owner[line_no - 1] if 0 < line_no <= len(line_owner) else rel
         tainted_map = tainted_by_function.get(owner, {})
@@ -329,8 +338,10 @@ def _grade_java_sinks(
         # matched and assessed separately. Deserialization is exempt:
         # `readObject()`/`readUnshared()` are zero-argument by nature. An
         # unbalanced/unreadable arg list is NOT genuinely empty and must still
-        # be assessed as unknown, not skipped.
-        if sink.vuln_class != "deserialize" and _call_is_empty(source, open_paren) is True:
+        # be assessed as unknown, not skipped. Checked against `code` too, so a
+        # call with only a comment between its parens (`executeQuery(/* n/a */)`)
+        # reads as empty rather than as an opaque, unreadable argument.
+        if sink.vuln_class != "deserialize" and _call_is_empty(code, open_paren) is True:
             continue
 
         edges.append(Edge(EDGE_REACHES_SINK, owner, name, rel, line_no))
@@ -346,13 +357,67 @@ def _grade_java_sinks(
         if sink.vuln_class == "deserialize":
             verdict = assess_deserialization(bool(taint_key))
         elif sink.vuln_class == "command":
-            verdict = assess_command(extract_all_args(source, open_paren), set(tainted_map))
+            verdict = assess_command(extract_all_args(code, open_paren), set(tainted_map))
         else:  # sql / path
-            verdict = assess(sink, extract_first_arg(source, open_paren), set(tainted_map))
+            verdict = assess(sink, extract_first_arg(code, open_paren), set(tainted_map))
 
         finding = _java_verdict_finding(sink, verdict, rel, line_no, line_text)
         if finding is not None and not is_inline_suppressed(lines, line_no, finding.rule_id):
             findings.append(finding)
+
+
+def _blank_java_comments(source: str) -> str:
+    """Blank `//` and `/* */` comments; leave everything else -- including every
+    string/char literal -- untouched, character-for-character.
+
+    A commented-out sink call must not be graded as live (a `//`/`/* */`'d out
+    `new File(tainted)` is dead code), but a REAL sink's string-literal argument
+    must survive completely intact for `extract_first_arg`/`assess` to classify
+    -- so, unlike `strip_code` (which also blanks string literals, for a
+    different consumer), this only ever blanks comment text. Quote-aware so a
+    `//`/`/*` inside a string or char literal (`"http://x"`) is never mistaken
+    for a comment opener; escape-aware so `'\\''` does not end a char literal
+    early. Same length as `source`, with line boundaries preserved, so a
+    position computed against the result is equally valid against `source`.
+    """
+    out: list[str] = []
+    quote: str | None = None
+    i = 0
+    n = len(source)
+    while i < n:
+        c = source[i]
+        if quote is not None:
+            out.append(c)
+            if c == "\\" and i + 1 < n:
+                out.append(source[i + 1])
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in "\"'":
+            quote = c
+            out.append(c)
+            i += 1
+            continue
+        if source.startswith("//", i):
+            j = i
+            while j < n and source[j] not in "\n\r":
+                out.append(" ")
+                j += 1
+            i = j
+            continue
+        if source.startswith("/*", i):
+            end = source.find("*/", i + 2)
+            end = n if end == -1 else end + 2
+            for k in range(i, end):
+                out.append(source[k] if source[k] in "\n\r" else " ")
+            i = end
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
 
 
 def _call_is_empty(source: str, open_paren: int) -> bool | None:

--- a/src/cybergraph/analysis/java.py
+++ b/src/cybergraph/analysis/java.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from cybergraph.analysis import _source_text
 from cybergraph.analysis._source_text import strip_code
 from cybergraph.analysis.java_provenance import (
     assess,
@@ -368,54 +369,45 @@ def _grade_java_sinks(
 
 def _blank_java_comments(source: str) -> str:
     """Blank `//` and `/* */` comments; leave everything else -- including every
-    string/char literal -- untouched, character-for-character.
+    string, char literal, and Java 15+ text block (`\"\"\"...\"\"\"`) -- untouched,
+    character-for-character.
 
     A commented-out sink call must not be graded as live (a `//`/`/* */`'d out
     `new File(tainted)` is dead code), but a REAL sink's string-literal argument
     must survive completely intact for `extract_first_arg`/`assess` to classify
-    -- so, unlike `strip_code` (which also blanks string literals, for a
-    different consumer), this only ever blanks comment text. Quote-aware so a
-    `//`/`/*` inside a string or char literal (`"http://x"`) is never mistaken
-    for a comment opener; escape-aware so `'\\''` does not end a char literal
-    early. Same length as `source`, with line boundaries preserved, so a
-    position computed against the result is equally valid against `source`.
+    -- so, unlike `strip_code` (which also blanks string/text-block content, for
+    a different consumer), this only ever blanks comment text.
+
+    Deliberately reuses `_source_text`'s Java tokenizer (`_SYNTAX["java"]`,
+    `_consume_comment`, `_string_at`, `_consume_string`) rather than a
+    hand-rolled quote scan: a single-quote-parity tracker has no notion of a
+    text block, so an ODD number of unescaped `"` inside one desyncs its
+    parity state and every `//`/`/*` for the rest of the file stops being
+    recognised as a comment opener at all -- the false positive this function
+    exists to close (a genuinely commented-out sink still graded as live).
+    `_consume_string` is asked to blank into a throwaway buffer purely to
+    learn where the literal ends; the original text is copied back verbatim
+    into `out`. Same length as `source`, with line boundaries preserved
+    (`_consume_comment` blanks in place, and a copied-back literal carries its
+    own real newlines), so a position computed against the result is equally
+    valid used against `source`.
     """
+    syntax = _source_text._SYNTAX["java"]
     out: list[str] = []
-    quote: str | None = None
     i = 0
     n = len(source)
     while i < n:
-        c = source[i]
-        if quote is not None:
-            out.append(c)
-            if c == "\\" and i + 1 < n:
-                out.append(source[i + 1])
-                i += 2
-                continue
-            if c == quote:
-                quote = None
-            i += 1
+        nxt = _source_text._consume_comment(source, i, syntax, out)
+        if nxt is not None:
+            i = nxt
             continue
-        if c in "\"'":
-            quote = c
-            out.append(c)
-            i += 1
-            continue
-        if source.startswith("//", i):
-            j = i
-            while j < n and source[j] not in "\n\r":
-                out.append(" ")
-                j += 1
-            i = j
-            continue
-        if source.startswith("/*", i):
-            end = source.find("*/", i + 2)
-            end = n if end == -1 else end + 2
-            for k in range(i, end):
-                out.append(source[k] if source[k] in "\n\r" else " ")
+        kind = _source_text._string_at(source, i, syntax)
+        if kind is not None:
+            end = _source_text._consume_string(source, i, kind, [])
+            out.append(source[i:end])
             i = end
             continue
-        out.append(c)
+        out.append(source[i])
         i += 1
     return "".join(out)
 

--- a/src/cybergraph/analysis/java_provenance.py
+++ b/src/cybergraph/analysis/java_provenance.py
@@ -344,6 +344,28 @@ def _chain_receiver(leading_gap: str) -> str | None:
     return prefix
 
 
+def _is_bare_call_receiver(leading_gap: str) -> bool:
+    """True when ``leading_gap`` is a bare call NAME with no receiver before it
+    (`currentQuery`, `buildQuery`, `format`) -- i.e. the case `_chain_receiver`
+    treats as inert via its "bare call: no receiver" branch.
+
+    `_chain_receiver` returns None for four shapes (empty gap, bare call,
+    `String`, allowlisted `new`); this isolates the bare-call one so the caller
+    can distinguish an opaque method-call receiver (whose unknown return value
+    is NOT provably literal) from the genuinely-inert `String`/`new` forms.
+    """
+    g = leading_gap.strip()
+    if not g:
+        return False
+    method = _TRAILING_IDENT_RE.search(g)
+    if method is None:
+        return False
+    prefix = g[: method.start()].strip()
+    if prefix.endswith("."):
+        prefix = prefix[:-1].strip()
+    return prefix == ""
+
+
 def _chain_operand_candidates(text: str) -> tuple[list[str], bool]:
     """Candidate variable names from EVERY call in a dotted call chain --
     ``String.format(...)``, a ``StringBuilder``/``.append`` chain, or any mix,
@@ -381,7 +403,8 @@ def _chain_operand_candidates(text: str) -> tuple[list[str], bool]:
     unresolved = False
     cursor = 0
     n = len(text)
-    for open_paren in _call_open_parens_generic(text):
+    calls = _call_open_parens_generic(text)
+    for idx, open_paren in enumerate(calls):
         if open_paren < cursor:
             continue  # already inside a call span consumed above
         gap = text[cursor:open_paren]
@@ -400,6 +423,14 @@ def _chain_operand_candidates(text: str) -> tuple[list[str], bool]:
             receiver = _chain_receiver(gap)
             if receiver is not None:
                 operands.append(receiver)
+            elif idx < len(calls) - 1 and _is_bare_call_receiver(gap):
+                # A leading BARE call (`currentQuery()`, no receiver, not
+                # `String` / `new StringBuilder`) whose result is CONSUMED by a
+                # further chained call is an opaque, unmodelled value: its return
+                # is not provably literal, so the whole chain can never read
+                # SAFE. (A terminal bare call -- `format("%s", x)` -- keeps its
+                # SAFE-eligibility; its own args are the operands examined below.)
+                unresolved = True
         close_paren = _matching_close_paren(text, open_paren)
         if close_paren is None:
             unresolved = True

--- a/src/cybergraph/analysis/java_provenance.py
+++ b/src/cybergraph/analysis/java_provenance.py
@@ -133,11 +133,17 @@ def classify(arg_text: str) -> str:
     s = arg_text.strip()
     if _STRING_ONLY_RE.match(s):
         return LITERAL
+    # A top-level `+` is checked before either call-shaped idiom below, and
+    # decides COMPOSED on its own: whether one of its operands *also* happens
+    # to look like a `String.format(...)` call or contain the text
+    # `.append(` (e.g. inside a string literal, or as a nested sub-call) is
+    # irrelevant to the classification of the whole expression, and must
+    # never gate whether the `+`'s other operands get examined at all.
+    if len(_split_plus(s)) > 1:
+        return COMPOSED
     if s.startswith("String.format(") and s.endswith(")"):
         return COMPOSED
-    if _APPEND_RE.search(s):
-        return COMPOSED
-    if len(_split_plus(s)) > 1:
+    if _append_open_parens(s):
         return COMPOSED
     return OPAQUE
 
@@ -208,17 +214,57 @@ def _format_operand_candidates(format_text: str) -> tuple[list[str], bool]:
     return _operand_candidates(args)
 
 
+def _append_open_parens(text: str) -> list[int]:
+    """Indices of the ``(`` in every real, unquoted ``.append(`` call.
+
+    A plain ``_APPEND_RE.search``/``finditer`` over the raw text is
+    quote-unaware: an argument that merely *contains* the text ``.append(``
+    inside a string literal -- ``"foo.append(1)" + userInput`` -- would match
+    just the same as a genuine ``StringBuilder`` chain, hijacking the append
+    branch and silently dropping the real (and here, tainted) operand after
+    the ``+``. This walks the same quote-tracking scan `_split_plus` and
+    `extract_first_arg` already use, and only recognises ``.append(`` outside
+    any ``"..."``/``'...'`` literal.
+    """
+    positions: list[int] = []
+    quote: str | None = None
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in "'\"":
+            quote = c
+            i += 1
+            continue
+        match = _APPEND_RE.match(text, i)
+        if match:
+            positions.append(match.end() - 1)
+            i = match.end()
+            continue
+        i += 1
+    return positions
+
+
 def _append_operand_candidates(text: str) -> tuple[list[str], bool]:
-    """Candidate variable names from every ``.append(...)`` call's argument.
+    """Candidate variable names from every real ``.append(...)`` call's argument.
 
     A ``StringBuilder`` chain (``sb.append(a).append(b).toString()``) is
     Java's other composing idiom: each appended operand is assessed with the
     same positive-literal-proof logic as a ``+`` operand or a
-    ``String.format`` argument.
+    ``String.format`` argument. Uses `_append_open_parens` rather than a bare
+    regex scan so a `.append(` inside a string literal is never mistaken for
+    a real call.
     """
     operands: list[str] = []
-    for match in _APPEND_RE.finditer(text):
-        open_paren = match.end() - 1
+    for open_paren in _append_open_parens(text):
         arg = extract_first_arg(text, open_paren)
         if arg is not None:
             operands.append(arg)
@@ -226,12 +272,18 @@ def _append_operand_candidates(text: str) -> tuple[list[str], bool]:
 
 
 def variable_names(arg_text: str) -> list[str]:
-    """Identifiers from a ``String.format``/``.append`` chain or a ``+`` operand."""
+    """Identifiers from a top-level ``+`` operand, a ``String.format`` call, or a
+    ``.append`` chain -- in that priority order, matching `classify`/`assess`.
+    """
     s = arg_text.strip()
+    parts = _split_plus(s)
+    if len(parts) > 1:
+        names, _unresolved = _operand_candidates(parts)
+        return _dedup(names)
     if s.startswith("String.format(") and s.endswith(")"):
         names, _unresolved = _format_operand_candidates(s)
         return _dedup(names)
-    if _APPEND_RE.search(s):
+    if _append_open_parens(s):
         names, _unresolved = _append_operand_candidates(s)
         return _dedup(names)
     names, _unresolved = _plus_operand_candidates(arg_text)
@@ -335,12 +387,19 @@ def assess(sink: Sink, arg_text: str | None, tainted_names: set[str]) -> str:
         return VERDICT_SAFE
     if construction == COMPOSED:
         s = arg_text.strip()
-        if s.startswith("String.format(") and s.endswith(")"):
+        # Same priority order as `classify`: a top-level `+` is resolved on
+        # its own operands first, so a `String.format(...)`/`.append(...)`
+        # shape embedded *inside* one of them (a nested call, or merely text
+        # inside a string literal) never suppresses examination of the
+        # operands beside it -- that suppression is the false-SAFE this
+        # ordering exists to close.
+        parts = _split_plus(s)
+        if len(parts) > 1:
+            names, unresolved = _operand_candidates(parts)
+        elif s.startswith("String.format(") and s.endswith(")"):
             names, unresolved = _format_operand_candidates(s)
-        elif _APPEND_RE.search(s):
-            names, unresolved = _append_operand_candidates(s)
         else:
-            names, unresolved = _plus_operand_candidates(arg_text)
+            names, unresolved = _append_operand_candidates(s)
         if any(n in tainted_names for n in names):
             return VERDICT_UNSAFE
         if names or unresolved:

--- a/src/cybergraph/analysis/java_provenance.py
+++ b/src/cybergraph/analysis/java_provenance.py
@@ -209,8 +209,15 @@ def _format_operand_candidates(format_text: str) -> tuple[list[str], bool]:
     positive-literal-proof logic; a format that genuinely is a string literal
     is a proven literal and is skipped by `_is_proven_literal_operand` on its
     own, with no special-casing needed here.
+
+    If `_split_call_args` cannot find where the call's arguments end -- an
+    unbalanced quote inside one of them, say -- it returns ``None`` rather
+    than a partial list, and that must read as unresolved, never as "no
+    arguments found, so every (nonexistent) argument is trivially literal."
     """
     args = _split_call_args(format_text)
+    if args is None:
+        return [], True
     return _operand_candidates(args)
 
 
@@ -262,13 +269,26 @@ def _append_operand_candidates(text: str) -> tuple[list[str], bool]:
     ``String.format`` argument. Uses `_append_open_parens` rather than a bare
     regex scan so a `.append(` inside a string literal is never mistaken for
     a real call.
+
+    A detected append site whose own argument does not balance --
+    ``sb.append("a).append(userInput)``, where the unterminated ``"a`` string
+    swallows everything after it, including the real ``.append(userInput)``
+    -- must never be silently dropped from ``operands``: `extract_first_arg`
+    returning ``None`` there is exactly the "we could not read this" case
+    ``unresolved`` exists for. Dropping it instead of flagging it is what let
+    an unreadable append chain fall through to the COMPOSED "every operand is
+    a proven literal" branch and read SAFE.
     """
     operands: list[str] = []
+    unresolved = False
     for open_paren in _append_open_parens(text):
         arg = extract_first_arg(text, open_paren)
-        if arg is not None:
-            operands.append(arg)
-    return _operand_candidates(operands)
+        if arg is None:
+            unresolved = True
+            continue
+        operands.append(arg)
+    names, operand_unresolved = _operand_candidates(operands)
+    return names, unresolved or operand_unresolved
 
 
 def variable_names(arg_text: str) -> list[str]:
@@ -335,12 +355,19 @@ def _split_plus(text: str) -> list[str]:
     return parts
 
 
-def _split_call_args(s: str) -> list[str]:
+def _split_call_args(s: str) -> list[str] | None:
     """Top-level, comma-separated arguments of the first ``(...)`` call in s.
 
     Mirrors ``extract_first_arg``'s string/paren-aware scan, but returns every
     top-level argument instead of stopping at the first. Used to split
     ``String.format(...)``'s argument list.
+
+    Returns ``None`` -- not a partial list -- if the call never closes (an
+    unbalanced quote inside an argument can swallow the rest of the text,
+    including the closing ``)``). A caller that treated the empty/partial
+    list this used to return as "this call has no arguments" would let it
+    fall through to "every (zero) argument is a proven literal" and read
+    SAFE; ``None`` forces the caller to treat it as unresolved instead.
     """
     open_paren = s.index("(")
     depth = 0
@@ -375,7 +402,7 @@ def _split_call_args(s: str) -> list[str]:
             args.append(s[start:i].strip())
             start = i + 1
         i += 1
-    return args  # unbalanced -> caller treats as best-effort partial list
+    return None  # unbalanced -> caller must treat as unresolved, never SAFE
 
 
 def assess(sink: Sink, arg_text: str | None, tainted_names: set[str]) -> str:

--- a/src/cybergraph/analysis/java_provenance.py
+++ b/src/cybergraph/analysis/java_provenance.py
@@ -41,6 +41,22 @@ _NUMERIC_RE = re.compile(r"^[+-]?\d+(?:\.\d+)?$")
 _JAVA_KEYWORDS = frozenset({"true", "false", "null"})
 _CONST_LITERAL_KEYWORDS = _JAVA_KEYWORDS
 _APPEND_RE = re.compile(r"\.append\s*\(")
+# Any bareword call, dotted or bare: matches `append(`/`substring(` in a
+# member chain, and `format(` inside `String.format(`. Deliberately broader
+# than `_APPEND_RE` -- this is what makes the operand-extraction coverage
+# check in `_chain_operand_candidates` a single shared guard rather than a
+# per-idiom special case: it finds a *trailing* `.substring(evil)` after a
+# recognised append/format chain exactly the same way it finds the
+# recognised chain itself.
+_CALL_RE = re.compile(r"[A-Za-z_]\w*\s*\(")
+# A "gap" between (or before/after) recognised calls is safe to skip only
+# when it is pure chain navigation -- a receiver/method name and the dots
+# connecting them (`sb.`, `.`, `.toString`) -- never anything else. Method
+# and receiver *names* are not treated as data operands anywhere in this
+# module (the same is true of `sb` in `sb.append(x)`), so this deliberately
+# does not flag a bare name here; what it does flag is anything with
+# structure this module cannot vouch for -- brackets, stray quotes, operators.
+_NAV_ONLY_RE = re.compile(r"^[\s.\w]*$")
 
 
 def extract_first_arg(source: str, open_paren: int) -> str | None:
@@ -193,34 +209,6 @@ def _operand_candidates(operands: list[str]) -> tuple[list[str], bool]:
     return names, unresolved
 
 
-def _plus_operand_candidates(arg_text: str) -> tuple[list[str], bool]:
-    """Candidate variable names from non-literal top-level ``+`` operands."""
-    return _operand_candidates(_split_plus(arg_text))
-
-
-def _format_operand_candidates(format_text: str) -> tuple[list[str], bool]:
-    """Candidate variable names from ALL of a ``String.format(...)`` call's arguments.
-
-    Unlike a JS template literal, whose leading piece is always a literal
-    fragment of the source text, Java's format argument is a normal runtime
-    value: ``String.format(userFmt, x)`` and
-    ``String.format("SELECT * FROM " + tbl, "x")`` both carry a non-literal
-    format. So every argument -- format included -- is assessed with the same
-    positive-literal-proof logic; a format that genuinely is a string literal
-    is a proven literal and is skipped by `_is_proven_literal_operand` on its
-    own, with no special-casing needed here.
-
-    If `_split_call_args` cannot find where the call's arguments end -- an
-    unbalanced quote inside one of them, say -- it returns ``None`` rather
-    than a partial list, and that must read as unresolved, never as "no
-    arguments found, so every (nonexistent) argument is trivially literal."
-    """
-    args = _split_call_args(format_text)
-    if args is None:
-        return [], True
-    return _operand_candidates(args)
-
-
 def _append_open_parens(text: str) -> list[int]:
     """Indices of the ``(`` in every real, unquoted ``.append(`` call.
 
@@ -260,53 +248,151 @@ def _append_open_parens(text: str) -> list[int]:
     return positions
 
 
-def _append_operand_candidates(text: str) -> tuple[list[str], bool]:
-    """Candidate variable names from every real ``.append(...)`` call's argument.
+def _matching_close_paren(text: str, open_paren: int) -> int | None:
+    """Index of the ``)`` matching the ``(`` at ``open_paren``, or None if unbalanced.
 
-    A ``StringBuilder`` chain (``sb.append(a).append(b).toString()``) is
-    Java's other composing idiom: each appended operand is assessed with the
-    same positive-literal-proof logic as a ``+`` operand or a
-    ``String.format`` argument. Uses `_append_open_parens` rather than a bare
-    regex scan so a `.append(` inside a string literal is never mistaken for
-    a real call.
+    Quote/paren-aware like `extract_first_arg`, but returns only the
+    boundary, not the argument text: a chain call's raw slice may carry its
+    own top-level commas (``String.format("%s", "lit")``), and this
+    deliberately does not split on them -- `_chain_operand_candidates` checks
+    the whole slice for a single literal first and otherwise falls back to a
+    broad identifier scan across it, which finds every identifier regardless
+    of where the commas fall.
+    """
+    depth = 0
+    quote: str | None = None
+    i = open_paren
+    while i < len(text):
+        c = text[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"":
+            quote = c
+        elif c == "(":
+            depth += 1
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return None  # unbalanced -> caller must treat as unresolved, never SAFE
 
-    A detected append site whose own argument does not balance --
-    ``sb.append("a).append(userInput)``, where the unterminated ``"a`` string
-    swallows everything after it, including the real ``.append(userInput)``
-    -- must never be silently dropped from ``operands``: `extract_first_arg`
-    returning ``None`` there is exactly the "we could not read this" case
-    ``unresolved`` exists for. Dropping it instead of flagging it is what let
-    an unreadable append chain fall through to the COMPOSED "every operand is
-    a proven literal" branch and read SAFE.
+
+def _chain_operand_candidates(text: str) -> tuple[list[str], bool]:
+    """Candidate variable names from EVERY call in a dotted call chain --
+    ``String.format(...)``, a ``StringBuilder``/``.append`` chain, or any mix,
+    including calls this module has no special name for (``.substring(...)``,
+    ``.concat(...)``, ``.replace(...)``, ...).
+
+    This is the shared coverage guard: three rounds of review found the same
+    fail-open shape three times over -- ``_format_operand_candidates`` reading
+    only ``String.format(...)``'s own arguments, and ``_append_operand_candidates``
+    reading only ``.append(...)`` sites, both let a SAFE verdict through
+    whenever a *trailing* call they did not recognise (``.substring(evil)``
+    after either idiom) was silently never examined. Precision was scoped to
+    "the operands of the calls we went looking for"; the invariant that
+    actually has to hold is "the operands of the WHOLE text, proven, not
+    assumed". So this walks every real (quote-aware, `_CALL_RE`-matched) call
+    in the text, whichever name it has, and tracks a `cursor` proving each
+    one's args were read *and* that nothing between two calls -- or before the
+    first, or after the last -- was left unexamined:
+
+    * a gap that is pure chain navigation (a receiver/method name, dots,
+      whitespace -- `_NAV_ONLY_RE`) is skipped, same as a receiver name always
+      has been in this module;
+    * any other gap (brackets, stray text, an unrecognised shape) is not
+      trusted to be inert: it is scanned for identifiers exactly like a
+      non-literal operand, and marks the result unresolved;
+    * a call whose own argument list never balances (the unterminated-string
+      shape from the previous two rounds) marks the rest of the text from
+      that point on as unresolved rather than dropping it.
+
+    SAFE is reachable through this function only when every character of the
+    text was accounted for by a proven-literal operand or benign navigation --
+    never by "the first call we recognised happened to be all-literal".
     """
     operands: list[str] = []
     unresolved = False
-    for open_paren in _append_open_parens(text):
-        arg = extract_first_arg(text, open_paren)
-        if arg is None:
+    cursor = 0
+    n = len(text)
+    for open_paren in _call_open_parens_generic(text):
+        if open_paren < cursor:
+            continue  # already inside a call span consumed above
+        gap = text[cursor:open_paren]
+        if not _NAV_ONLY_RE.match(gap):
             unresolved = True
-            continue
-        operands.append(arg)
+            operands.append(gap)
+        close_paren = _matching_close_paren(text, open_paren)
+        if close_paren is None:
+            unresolved = True
+            cursor = n
+            break
+        arg = text[open_paren + 1 : close_paren].strip()
+        if arg:
+            operands.append(arg)
+        cursor = close_paren + 1
+    tail = text[cursor:]
+    if not _NAV_ONLY_RE.match(tail):
+        unresolved = True
+        operands.append(tail)
     names, operand_unresolved = _operand_candidates(operands)
     return names, unresolved or operand_unresolved
 
 
+def _call_open_parens_generic(text: str) -> list[int]:
+    """Indices of the ``(`` in every real, unquoted call: `_CALL_RE`, quote-aware.
+
+    Same quote-tracking scan as `_append_open_parens`, generalised from the
+    literal ``.append(`` to any bareword call -- deliberately so: it is what
+    lets `_chain_operand_candidates` find a trailing ``.substring(evil)`` or
+    ``.concat(...)`` the same way it finds the ``.append(``/``format(`` it
+    was looking for, instead of needing a new special case per method name.
+    """
+    positions: list[int] = []
+    quote: str | None = None
+    i = 0
+    n = len(text)
+    while i < n:
+        c = text[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+            i += 1
+            continue
+        if c in "'\"":
+            quote = c
+            i += 1
+            continue
+        match = _CALL_RE.match(text, i)
+        if match:
+            positions.append(match.end() - 1)
+            i = match.end()
+            continue
+        i += 1
+    return positions
+
+
 def variable_names(arg_text: str) -> list[str]:
-    """Identifiers from a top-level ``+`` operand, a ``String.format`` call, or a
-    ``.append`` chain -- in that priority order, matching `classify`/`assess`.
+    """Identifiers from a top-level ``+`` operand, or a call chain otherwise --
+    matching `assess`'s dispatch and its coverage guard.
     """
     s = arg_text.strip()
     parts = _split_plus(s)
     if len(parts) > 1:
         names, _unresolved = _operand_candidates(parts)
         return _dedup(names)
-    if s.startswith("String.format(") and s.endswith(")"):
-        names, _unresolved = _format_operand_candidates(s)
-        return _dedup(names)
-    if _append_open_parens(s):
-        names, _unresolved = _append_operand_candidates(s)
-        return _dedup(names)
-    names, _unresolved = _plus_operand_candidates(arg_text)
+    names, _unresolved = _chain_operand_candidates(s)
     return _dedup(names)
 
 
@@ -355,56 +441,6 @@ def _split_plus(text: str) -> list[str]:
     return parts
 
 
-def _split_call_args(s: str) -> list[str] | None:
-    """Top-level, comma-separated arguments of the first ``(...)`` call in s.
-
-    Mirrors ``extract_first_arg``'s string/paren-aware scan, but returns every
-    top-level argument instead of stopping at the first. Used to split
-    ``String.format(...)``'s argument list.
-
-    Returns ``None`` -- not a partial list -- if the call never closes (an
-    unbalanced quote inside an argument can swallow the rest of the text,
-    including the closing ``)``). A caller that treated the empty/partial
-    list this used to return as "this call has no arguments" would let it
-    fall through to "every (zero) argument is a proven literal" and read
-    SAFE; ``None`` forces the caller to treat it as unresolved instead.
-    """
-    open_paren = s.index("(")
-    depth = 0
-    quote: str | None = None
-    start = -1
-    args: list[str] = []
-    i = open_paren
-    while i < len(s):
-        c = s[i]
-        if quote is not None:
-            if c == "\\":
-                i += 2
-                continue
-            if c == quote:
-                quote = None
-        elif c in "'\"":
-            quote = c
-        elif c == "(":
-            depth += 1
-            if depth == 1:
-                start = i + 1
-        elif c in "[{":
-            depth += 1
-        elif c in "]}":
-            depth -= 1
-        elif c == ")":
-            depth -= 1
-            if depth == 0:
-                args.append(s[start:i].strip())
-                return args
-        elif c == "," and depth == 1:
-            args.append(s[start:i].strip())
-            start = i + 1
-        i += 1
-    return None  # unbalanced -> caller must treat as unresolved, never SAFE
-
-
 def assess(sink: Sink, arg_text: str | None, tainted_names: set[str]) -> str:
     """Verdict for a Java sink call. Only an all-literal/constant construction is SAFE."""
     if arg_text is None:
@@ -418,15 +454,15 @@ def assess(sink: Sink, arg_text: str | None, tainted_names: set[str]) -> str:
         # its own operands first, so a `String.format(...)`/`.append(...)`
         # shape embedded *inside* one of them (a nested call, or merely text
         # inside a string literal) never suppresses examination of the
-        # operands beside it -- that suppression is the false-SAFE this
-        # ordering exists to close.
+        # operands beside it -- that suppression is the false-SAFE round 1
+        # closed. Otherwise, `_chain_operand_candidates` is the shared
+        # coverage guard closing round 3: it proves the operands it collects
+        # account for the WHOLE text, not just the first call recognised.
         parts = _split_plus(s)
         if len(parts) > 1:
             names, unresolved = _operand_candidates(parts)
-        elif s.startswith("String.format(") and s.endswith(")"):
-            names, unresolved = _format_operand_candidates(s)
         else:
-            names, unresolved = _append_operand_candidates(s)
+            names, unresolved = _chain_operand_candidates(s)
         if any(n in tainted_names for n in names):
             return VERDICT_UNSAFE
         if names or unresolved:
@@ -435,13 +471,12 @@ def assess(sink: Sink, arg_text: str | None, tainted_names: set[str]) -> str:
             return VERDICT_UNKNOWN
         # every operand is a proven literal/constant (e.g. `String.format("%d", 1)`)
         return VERDICT_SAFE
-    # OPAQUE: candidates are only extracted from a `String.format(...)` call, a
-    # `.append(...)` chain, or a `+` operand, so nothing is found in a bare
-    # identifier (none of those) even though the whole argument *is* one.
-    # Handle that shape directly: a bare identifier can be checked against
-    # taint; any other opaque expression (a call, field access, ...) has no
-    # name to check and must fail safe rather than read as unconditionally
-    # SAFE.
+    # OPAQUE: candidates are only extracted from a call chain or a `+`
+    # operand, so nothing is found in a bare identifier (neither of those)
+    # even though the whole argument *is* one. Handle that shape directly: a
+    # bare identifier can be checked against taint; any other opaque
+    # expression (a call, field access, ...) has no name to check and must
+    # fail safe rather than read as unconditionally SAFE.
     s = arg_text.strip()
     match = _IDENT_RE.fullmatch(s)
     if match and match.group(0) not in _JAVA_KEYWORDS and match.group(0) in tainted_names:

--- a/src/cybergraph/analysis/java_provenance.py
+++ b/src/cybergraph/analysis/java_provenance.py
@@ -332,7 +332,13 @@ def _chain_receiver(leading_gap: str) -> str | None:
         # semantics are unknown: return the whole receiver as a non-literal
         # operand so an all-literal `new Foo("a").append("b")` cannot read SAFE.
         cls = method.group().strip()
-        if cls in ("StringBuilder", "StringBuffer"):
+        # Only the BARE `new StringBuilder(...)` / `new StringBuffer(...)` shape
+        # is allowlisted -- `prefix` is exactly `new` with no package qualifier.
+        # A qualified name (`new com.evil.StringBuilder(...)`) leaves a non-empty
+        # qualifier in `prefix`; we cannot tell the real `java.lang.StringBuilder`
+        # from an attacker class whose simple name merely collides, so any
+        # qualified form is treated as an unmodelled construct (never SAFE).
+        if prefix.strip() == "new" and cls in ("StringBuilder", "StringBuffer"):
             return None
         return g
     return prefix

--- a/src/cybergraph/analysis/java_provenance.py
+++ b/src/cybergraph/analysis/java_provenance.py
@@ -1,0 +1,406 @@
+"""Lightweight construction provenance for Java sink arguments.
+
+No Java parser: a structural, statement-local classifier over the argument
+text, fail-safe on anything it cannot read. It reuses the engine's vocabulary
+(LITERAL/COMPOSED/OPAQUE and VERDICT_*) but is deliberately more conservative
+than the Python predicates: because Java taint is weaker (intra-method,
+line-based), only an all-literal/constant construction is SAFE. A construction
+that contains a variable is UNSAFE when taint confirms it is user-controlled
+and UNKNOWN otherwise -- never SAFE, and never a confident UNSAFE on an
+unresolved variable.
+
+Java has no template-literal interpolation; its idioms are
+``String.format(fmt, ...)`` and a ``StringBuilder``/``.append(x)`` chain, so
+both are treated the way a JS template literal is treated: COMPOSED, with
+their operands as candidate variables. Java string literals are only the
+double-quoted form -- there is no raw/backtick string and no ``${}``
+interpolation to special-case.
+
+Native deserialization (``ObjectInputStream.readObject``/``readUnshared``)
+takes no argument to classify at all -- the danger is the tainted stream
+itself reaching the call, not anything about how a string was built -- so it
+gets its own two-outcome rule (:func:`assess_deserialization`) rather than
+running through :func:`assess`: it can never read SAFE, because a
+deserialization sink is never provably safe from construction alone.
+"""
+
+from __future__ import annotations
+
+import re
+
+from cybergraph.analysis.provenance import COMPOSED, LITERAL, OPAQUE
+from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNKNOWN, VERDICT_UNSAFE
+from cybergraph.security.sinks import Sink
+
+_IDENT_RE = re.compile(r"[A-Za-z_]\w*")
+_STRING_ONLY_RE = re.compile(r'^\s*"[^"]*"\s*$')
+_NUMERIC_RE = re.compile(r"^[+-]?\d+(?:\.\d+)?$")
+# Java keywords that are also constant literals (booleans, the null
+# reference) -- proven literals, and also excluded from candidate variable
+# names.
+_JAVA_KEYWORDS = frozenset({"true", "false", "null"})
+_CONST_LITERAL_KEYWORDS = _JAVA_KEYWORDS
+_APPEND_RE = re.compile(r"\.append\s*\(")
+
+
+def extract_first_arg(source: str, open_paren: int) -> str | None:
+    """Return the first top-level argument's source text, or None if unbalanced.
+
+    String-aware (skips ()/,/quotes inside a ``"..."`` string literal or a
+    ``'x'`` char literal) so a ')' or ',' inside one does not end the argument
+    early.
+    """
+    depth = 0
+    quote: str | None = None
+    start = -1
+    i = open_paren
+    while i < len(source):
+        c = source[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"":
+            quote = c
+        elif c == "(":
+            depth += 1
+            if depth == 1:
+                start = i + 1
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return source[start:i].strip() or None
+        elif c == "," and depth == 1:
+            return source[start:i].strip() or None
+        i += 1
+    return None  # unbalanced -> caller treats as UNKNOWN
+
+
+def extract_all_args(source: str, open_paren: int) -> list[str]:
+    """Return every top-level argument's source text, or [] if unbalanced.
+
+    Command-class sinks (``Runtime.exec``, ``ProcessBuilder``) take argv, not
+    a single string, so grading them on `extract_first_arg` alone only ever
+    sees the program name -- for the shell idiom, the literal ``"sh"`` -- and
+    never the tainted argument that follows it. This walks the same
+    string/paren-aware scan as `extract_first_arg` but keeps collecting past
+    the first top-level comma instead of stopping there.
+    """
+    depth = 0
+    quote: str | None = None
+    start = -1
+    args: list[str] = []
+    i = open_paren
+    while i < len(source):
+        c = source[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"":
+            quote = c
+        elif c == "(":
+            depth += 1
+            if depth == 1:
+                start = i + 1
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                tail = source[start:i].strip()
+                if tail or args:
+                    args.append(tail)
+                return args
+        elif c == "," and depth == 1:
+            args.append(source[start:i].strip())
+            start = i + 1
+        i += 1
+    return []  # unbalanced -> caller treats as UNKNOWN
+
+
+def classify(arg_text: str) -> str:
+    s = arg_text.strip()
+    if _STRING_ONLY_RE.match(s):
+        return LITERAL
+    if s.startswith("String.format(") and s.endswith(")"):
+        return COMPOSED
+    if _APPEND_RE.search(s):
+        return COMPOSED
+    if len(_split_plus(s)) > 1:
+        return COMPOSED
+    return OPAQUE
+
+
+def _is_proven_literal_operand(operand: str) -> bool:
+    """True only for a construction that is positively known to be constant.
+
+    A double-quoted string literal, or a numeric/boolean/null constant.
+    Anything else -- a bare identifier, a parenthesized expression, a
+    bracketed expression, a call, a field access -- is NOT proven literal,
+    even if it happens to contain no scannable identifier: absence of a name
+    must never be read as proof of literal-ness.
+    """
+    s = operand.strip()
+    if not s:
+        return False
+    if _STRING_ONLY_RE.match(s):
+        return True
+    if _NUMERIC_RE.match(s):
+        return True
+    if s in _CONST_LITERAL_KEYWORDS:
+        return True
+    return False
+
+
+def _operand_candidates(operands: list[str]) -> tuple[list[str], bool]:
+    """Candidate variable names from non-literal operands.
+
+    Also returns whether any operand is "unresolved": not a proven literal and
+    yet contains no identifier at all (e.g. `(1 + 1)` as an operand) -- such an
+    operand must never be silently treated as safe just because it has no name
+    to check.
+    """
+    names: list[str] = []
+    unresolved = False
+    for part in operands:
+        p = part.strip()
+        if not p or _is_proven_literal_operand(p):
+            continue
+        idents = _IDENT_RE.findall(p)
+        if not idents:
+            unresolved = True
+            continue
+        for ident in idents:
+            if ident not in _JAVA_KEYWORDS:
+                names.append(ident)
+    return names, unresolved
+
+
+def _plus_operand_candidates(arg_text: str) -> tuple[list[str], bool]:
+    """Candidate variable names from non-literal top-level ``+`` operands."""
+    return _operand_candidates(_split_plus(arg_text))
+
+
+def _format_operand_candidates(format_text: str) -> tuple[list[str], bool]:
+    """Candidate variable names from ALL of a ``String.format(...)`` call's arguments.
+
+    Unlike a JS template literal, whose leading piece is always a literal
+    fragment of the source text, Java's format argument is a normal runtime
+    value: ``String.format(userFmt, x)`` and
+    ``String.format("SELECT * FROM " + tbl, "x")`` both carry a non-literal
+    format. So every argument -- format included -- is assessed with the same
+    positive-literal-proof logic; a format that genuinely is a string literal
+    is a proven literal and is skipped by `_is_proven_literal_operand` on its
+    own, with no special-casing needed here.
+    """
+    args = _split_call_args(format_text)
+    return _operand_candidates(args)
+
+
+def _append_operand_candidates(text: str) -> tuple[list[str], bool]:
+    """Candidate variable names from every ``.append(...)`` call's argument.
+
+    A ``StringBuilder`` chain (``sb.append(a).append(b).toString()``) is
+    Java's other composing idiom: each appended operand is assessed with the
+    same positive-literal-proof logic as a ``+`` operand or a
+    ``String.format`` argument.
+    """
+    operands: list[str] = []
+    for match in _APPEND_RE.finditer(text):
+        open_paren = match.end() - 1
+        arg = extract_first_arg(text, open_paren)
+        if arg is not None:
+            operands.append(arg)
+    return _operand_candidates(operands)
+
+
+def variable_names(arg_text: str) -> list[str]:
+    """Identifiers from a ``String.format``/``.append`` chain or a ``+`` operand."""
+    s = arg_text.strip()
+    if s.startswith("String.format(") and s.endswith(")"):
+        names, _unresolved = _format_operand_candidates(s)
+        return _dedup(names)
+    if _APPEND_RE.search(s):
+        names, _unresolved = _append_operand_candidates(s)
+        return _dedup(names)
+    names, _unresolved = _plus_operand_candidates(arg_text)
+    return _dedup(names)
+
+
+def _dedup(names: list[str]) -> list[str]:
+    """De-dup a list of names, preserving first-seen order."""
+    seen: set[str] = set()
+    out = []
+    for n in names:
+        if n not in seen:
+            seen.add(n)
+            out.append(n)
+    return out
+
+
+def _split_plus(text: str) -> list[str]:
+    """Split on top-level '+', string/paren-aware."""
+    parts, depth, quote, buf = [], 0, None, []
+    i = 0
+    while i < len(text):
+        c = text[i]
+        if quote is not None:
+            buf.append(c)
+            if c == "\\":
+                if i + 1 < len(text):
+                    buf.append(text[i + 1])
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"":
+            quote = c
+            buf.append(c)
+        elif c in "([{":
+            depth += 1
+            buf.append(c)
+        elif c in ")]}":
+            depth -= 1
+            buf.append(c)
+        elif c == "+" and depth == 0:
+            parts.append("".join(buf))
+            buf = []
+        else:
+            buf.append(c)
+        i += 1
+    parts.append("".join(buf))
+    return parts
+
+
+def _split_call_args(s: str) -> list[str]:
+    """Top-level, comma-separated arguments of the first ``(...)`` call in s.
+
+    Mirrors ``extract_first_arg``'s string/paren-aware scan, but returns every
+    top-level argument instead of stopping at the first. Used to split
+    ``String.format(...)``'s argument list.
+    """
+    open_paren = s.index("(")
+    depth = 0
+    quote: str | None = None
+    start = -1
+    args: list[str] = []
+    i = open_paren
+    while i < len(s):
+        c = s[i]
+        if quote is not None:
+            if c == "\\":
+                i += 2
+                continue
+            if c == quote:
+                quote = None
+        elif c in "'\"":
+            quote = c
+        elif c == "(":
+            depth += 1
+            if depth == 1:
+                start = i + 1
+        elif c in "[{":
+            depth += 1
+        elif c in "]}":
+            depth -= 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                args.append(s[start:i].strip())
+                return args
+        elif c == "," and depth == 1:
+            args.append(s[start:i].strip())
+            start = i + 1
+        i += 1
+    return args  # unbalanced -> caller treats as best-effort partial list
+
+
+def assess(sink: Sink, arg_text: str | None, tainted_names: set[str]) -> str:
+    """Verdict for a Java sink call. Only an all-literal/constant construction is SAFE."""
+    if arg_text is None:
+        return VERDICT_UNKNOWN
+    construction = classify(arg_text)
+    if construction == LITERAL:
+        return VERDICT_SAFE
+    if construction == COMPOSED:
+        s = arg_text.strip()
+        if s.startswith("String.format(") and s.endswith(")"):
+            names, unresolved = _format_operand_candidates(s)
+        elif _APPEND_RE.search(s):
+            names, unresolved = _append_operand_candidates(s)
+        else:
+            names, unresolved = _plus_operand_candidates(arg_text)
+        if any(n in tainted_names for n in names):
+            return VERDICT_UNSAFE
+        if names or unresolved:
+            # a candidate variable (resolved or not) or an operand we could not
+            # prove literal -> never read as safe
+            return VERDICT_UNKNOWN
+        # every operand is a proven literal/constant (e.g. `String.format("%d", 1)`)
+        return VERDICT_SAFE
+    # OPAQUE: candidates are only extracted from a `String.format(...)` call, a
+    # `.append(...)` chain, or a `+` operand, so nothing is found in a bare
+    # identifier (none of those) even though the whole argument *is* one.
+    # Handle that shape directly: a bare identifier can be checked against
+    # taint; any other opaque expression (a call, field access, ...) has no
+    # name to check and must fail safe rather than read as unconditionally
+    # SAFE.
+    s = arg_text.strip()
+    match = _IDENT_RE.fullmatch(s)
+    if match and match.group(0) not in _JAVA_KEYWORDS and match.group(0) in tainted_names:
+        return VERDICT_UNSAFE
+    return VERDICT_UNKNOWN
+
+
+def assess_command(args: list[str] | None, tainted_names: set[str]) -> str:
+    """Verdict for a Java command sink (``Runtime.exec``/``ProcessBuilder``) over ALL arguments.
+
+    `assess` grades a sink on its first argument alone, which is right for a
+    single SQL/path string but wrong for argv: it would see only the program
+    name and miss a tainted argument anywhere else in the call -- e.g.
+    ``new ProcessBuilder("sh", "-c", userInput)`` must not read SAFE just
+    because argv[0] is the literal ``"sh"``. This assesses the whole argument
+    list instead, reusing `_operand_candidates` / `_is_proven_literal_operand`
+    so the same positive-literal-proof invariant holds -- a non-literal
+    argument with no scannable identifier is unresolved, never silently SAFE.
+
+    Verdict rule, fail-safe throughout:
+    - no arguments (unreadable call) -> UNKNOWN.
+    - every argument is a proven literal/constant -> SAFE.
+    - otherwise, some argument is not a proven literal -> UNSAFE if a
+      candidate name is taint-confirmed, else UNKNOWN.
+
+    In no branch is a non-literal argument ever read as SAFE, which is the
+    false-SAFE this function exists to close.
+    """
+    if not args:
+        return VERDICT_UNKNOWN
+    if all(_is_proven_literal_operand(a) for a in args):
+        return VERDICT_SAFE
+    names, _unresolved = _operand_candidates(args)
+    if any(n in tainted_names for n in names):
+        return VERDICT_UNSAFE
+    return VERDICT_UNKNOWN
+
+
+def assess_deserialization(tainted_present: bool) -> str:
+    """Verdict for a native deserialization sink (``readObject``/``readUnshared``).
+
+    These take no argument to classify -- the danger is the tainted
+    stream/value reaching the call at all, not how a string was built -- so
+    there is no construction to prove literal and this can never return
+    VERDICT_SAFE. UNSAFE when taint is confirmed, UNKNOWN otherwise: an
+    unresolved deserialization call is still not provably safe.
+    """
+    return VERDICT_UNSAFE if tainted_present else VERDICT_UNKNOWN

--- a/src/cybergraph/analysis/java_provenance.py
+++ b/src/cybergraph/analysis/java_provenance.py
@@ -301,8 +301,10 @@ def _chain_receiver(leading_gap: str) -> str | None:
       * no receiver at all (a bare call), OR
       * exactly ``String`` (the static ``String.format``/``join``/``valueOf``/
         ``copyValueOf`` allowlist -- receiver is the class name), OR
-      * a ``new ...`` construction (its own args are examined as a call, so the
-        freshly built value carries no external string state of its own).
+      * a ``new StringBuilder(...)`` / ``new StringBuffer(...)`` construction
+        (its own args are examined as a call, so the freshly built value carries
+        no external string state of its own). Any other ``new X(...)`` is an
+        unmodelled construct and is returned as a non-literal operand.
 
     Otherwise returns the receiver expression (a bare variable like ``sb`` /
     ``evil`` / ``query``, a field access, an unknown form) so the caller
@@ -323,7 +325,16 @@ def _chain_receiver(leading_gap: str) -> str | None:
     if prefix == "String":
         return None  # allowlisted static receiver
     if re.match(r"^new(?:\s|$)", prefix):
-        return None  # `new X(...)` construction; args examined as a call
+        # A construction receiver stays SAFE-eligible ONLY for the modelled
+        # string builders -- their own constructor args are examined as a call
+        # below, so a freshly built value carries no external string state. Any
+        # other `new X(...)` is an unmodelled construct whose `.method(...)`
+        # semantics are unknown: return the whole receiver as a non-literal
+        # operand so an all-literal `new Foo("a").append("b")` cannot read SAFE.
+        cls = method.group().strip()
+        if cls in ("StringBuilder", "StringBuffer"):
+            return None
+        return g
     return prefix
 
 

--- a/src/cybergraph/analysis/java_provenance.py
+++ b/src/cybergraph/analysis/java_provenance.py
@@ -50,12 +50,13 @@ _APPEND_RE = re.compile(r"\.append\s*\(")
 # recognised chain itself.
 _CALL_RE = re.compile(r"[A-Za-z_]\w*\s*\(")
 # A "gap" between (or before/after) recognised calls is safe to skip only
-# when it is pure chain navigation -- a receiver/method name and the dots
-# connecting them (`sb.`, `.`, `.toString`) -- never anything else. Method
-# and receiver *names* are not treated as data operands anywhere in this
-# module (the same is true of `sb` in `sb.append(x)`), so this deliberately
-# does not flag a bare name here; what it does flag is anything with
-# structure this module cannot vouch for -- brackets, stray quotes, operators.
+# when it is pure chain navigation -- method names and the dots connecting
+# them (`.`, `.toString`) -- never anything else. This regex only decides
+# nav-vs-structural (brackets, stray quotes, operators are flagged); the
+# leading gap of a chain is examined further by `_chain_receiver`, because the
+# *receiver* it carries (`sb` in `sb.append(x)`) is a real data operand whose
+# prior state feeds the resulting string and so must be taint-checked, not
+# waved through as navigation.
 _NAV_ONLY_RE = re.compile(r"^[\s.\w]*$")
 
 
@@ -252,12 +253,10 @@ def _matching_close_paren(text: str, open_paren: int) -> int | None:
     """Index of the ``)`` matching the ``(`` at ``open_paren``, or None if unbalanced.
 
     Quote/paren-aware like `extract_first_arg`, but returns only the
-    boundary, not the argument text: a chain call's raw slice may carry its
-    own top-level commas (``String.format("%s", "lit")``), and this
-    deliberately does not split on them -- `_chain_operand_candidates` checks
-    the whole slice for a single literal first and otherwise falls back to a
-    broad identifier scan across it, which finds every identifier regardless
-    of where the commas fall.
+    boundary, not the argument text: `_chain_operand_candidates` uses this to
+    advance its coverage cursor past the whole call, and separately splits the
+    call's argument list on top-level commas (via `extract_all_args`) so each
+    argument is tested individually.
     """
     depth = 0
     quote: str | None = None
@@ -284,6 +283,48 @@ def _matching_close_paren(text: str, open_paren: int) -> int | None:
                 return i
         i += 1
     return None  # unbalanced -> caller must treat as unresolved, never SAFE
+
+
+_TRAILING_IDENT_RE = re.compile(r"\w+\s*$")
+
+
+def _chain_receiver(leading_gap: str) -> str | None:
+    """The receiver operand of a call chain, or None when it is genuinely inert.
+
+    ``leading_gap`` is the text before the first call's ``(`` -- a nav-only
+    span (`_NAV_ONLY_RE`) of the form ``<receiver>.<method>`` (`sb.append`),
+    a bare ``<method>`` (`format`, `buildQuery`), or a construction
+    (`new StringBuilder`). The method name is the trailing identifier; what
+    precedes it, minus the connecting dot, is the receiver expression.
+
+    Returns None -- SAFE-eligible, inert -- for:
+      * no receiver at all (a bare call), OR
+      * exactly ``String`` (the static ``String.format``/``join``/``valueOf``/
+        ``copyValueOf`` allowlist -- receiver is the class name), OR
+      * a ``new ...`` construction (its own args are examined as a call, so the
+        freshly built value carries no external string state of its own).
+
+    Otherwise returns the receiver expression (a bare variable like ``sb`` /
+    ``evil`` / ``query``, a field access, an unknown form) so the caller
+    taint-checks it exactly like an argument: it is a non-literal operand and
+    can never be proven safe.
+    """
+    g = leading_gap.strip()
+    if not g:
+        return None
+    method = _TRAILING_IDENT_RE.search(g)
+    if method is None:
+        return None
+    prefix = g[: method.start()].strip()
+    if prefix.endswith("."):
+        prefix = prefix[:-1].strip()
+    if not prefix:
+        return None  # bare call: no receiver
+    if prefix == "String":
+        return None  # allowlisted static receiver
+    if re.match(r"^new(?:\s|$)", prefix):
+        return None  # `new X(...)` construction; args examined as a call
+    return prefix
 
 
 def _chain_operand_candidates(text: str) -> tuple[list[str], bool]:
@@ -330,14 +371,31 @@ def _chain_operand_candidates(text: str) -> tuple[list[str], bool]:
         if not _NAV_ONLY_RE.match(gap):
             unresolved = True
             operands.append(gap)
+        elif cursor == 0:
+            # Only the leading gap carries the chain's *receiver*; every later
+            # gap is `.method` navigation on the previous call's result and is
+            # genuinely inert. An instance receiver's prior state IS part of
+            # the resulting string, so a bare-variable receiver (`sb`, `evil`,
+            # `query`) is a non-literal operand and must be taint-checked just
+            # like an argument -- never exempted as mere navigation. Only a
+            # `String.*` static call or a `new ...(...)` construction receiver
+            # (whose own args are examined as a call below) stays SAFE-eligible.
+            receiver = _chain_receiver(gap)
+            if receiver is not None:
+                operands.append(receiver)
         close_paren = _matching_close_paren(text, open_paren)
         if close_paren is None:
             unresolved = True
             cursor = n
             break
-        arg = text[open_paren + 1 : close_paren].strip()
-        if arg:
-            operands.append(arg)
+        # Split the call's argument list on TOP-LEVEL commas (quote/paren-aware
+        # via `extract_all_args`) so each argument is tested individually by
+        # the proven-literal check -- a multi-arg all-literal call
+        # (`String.format("%d", 1)`) is a literal composition, not one opaque
+        # comma-joined span.
+        for arg in extract_all_args(text, open_paren):
+            if arg:
+                operands.append(arg)
         cursor = close_paren + 1
     tail = text[cursor:]
     if not _NAV_ONLY_RE.match(tail):

--- a/src/cybergraph/security/capability.py
+++ b/src/cybergraph/security/capability.py
@@ -37,6 +37,7 @@ _REVIEW_STATES = frozenset({FAIL, UNKNOWN, NOT_SUPPORTED})
 PYTHON_GLOBS = ("*.py",)
 WEB_GLOBS = ("*.ts", "*.tsx", "*.js", "*.jsx", "*.vue", "*.svelte", "*.mjs", "*.cjs")
 GO_GLOBS = ("*.go",)
+JAVA_GLOBS = ("*.java",)
 
 # Every extension CyberGraph recognises as executable source, supported or not.
 SOURCE_GLOBS = (
@@ -72,13 +73,13 @@ class Capability:
 
 CAPABILITIES: tuple[Capability, ...] = (
     Capability("sql_construction", "Unsafe database queries",
-               PYTHON_GLOBS + WEB_GLOBS + GO_GLOBS, True),
+               PYTHON_GLOBS + WEB_GLOBS + GO_GLOBS + JAVA_GLOBS, True),
     Capability("command_execution", "Unsafe system commands",
-               PYTHON_GLOBS + WEB_GLOBS + GO_GLOBS, True),
+               PYTHON_GLOBS + WEB_GLOBS + GO_GLOBS + JAVA_GLOBS, True),
     Capability("code_execution", "Code run from user input", PYTHON_GLOBS + WEB_GLOBS, True),
-    Capability("deserialization", "Unsafe data loading", PYTHON_GLOBS, True),
+    Capability("deserialization", "Unsafe data loading", PYTHON_GLOBS + JAVA_GLOBS, True),
     Capability("path_access", "Files opened from user input",
-               PYTHON_GLOBS + WEB_GLOBS + GO_GLOBS, True),
+               PYTHON_GLOBS + WEB_GLOBS + GO_GLOBS + JAVA_GLOBS, True),
     Capability("declared_login_rules", "Your declared login rules", PYTHON_GLOBS, True),
     Capability("reachable_data_paths",
                "New routes from the internet to sensitive code", PYTHON_GLOBS, True),

--- a/src/cybergraph/security/coverage.py
+++ b/src/cybergraph/security/coverage.py
@@ -20,6 +20,7 @@ from cybergraph.graph import GraphStore
 from cybergraph.security.capability import (
     CONFIG_GLOBS,
     GO_GLOBS,
+    JAVA_GLOBS,
     SOURCE_GLOBS,
     VERIFIED_GLOBS,
     WEB_GLOBS,
@@ -75,7 +76,9 @@ def assess_coverage(
             results.append(FileCoverage(file, STATUS_FAILED, "the file could not be read"))
         elif not any(
             fnmatch(file, pattern)
-            for pattern in VERIFIED_GLOBS + CONFIG_GLOBS + WEB_GLOBS + GO_GLOBS
+            for pattern in (
+                VERIFIED_GLOBS + CONFIG_GLOBS + WEB_GLOBS + GO_GLOBS + JAVA_GLOBS
+            )
         ):
             results.append(
                 FileCoverage(file, STATUS_UNSUPPORTED, "no analyzer for this language yet")

--- a/src/cybergraph/security/sinks.py
+++ b/src/cybergraph/security/sinks.py
@@ -155,6 +155,14 @@ _JAVA: tuple[Sink, ...] = (
     Sink("update", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
     Sink("createNativeQuery", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
     Sink("createQuery", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    # `Statement.prepareStatement`/`prepareCall` build the query text itself --
+    # a concatenated argument here is exactly as unsafe as `executeQuery` on the
+    # concatenated string; the parameterized `?`-placeholder form is the safe
+    # idiom, which is why grading these (rather than the argument-less
+    # `.executeQuery()` that follows) is what actually catches a concatenated
+    # PreparedStatement.
+    Sink("prepareStatement", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("prepareCall", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
     # Command (bare; Runtime.exec / ProcessBuilder / .start)
     Sink("exec", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _CMD, "command",
          bare=True, shell=SHELL_CONDITIONAL),

--- a/src/cybergraph/security/sinks.py
+++ b/src/cybergraph/security/sinks.py
@@ -146,10 +146,47 @@ _GO: tuple[Sink, ...] = (
          "opens a file whose path comes from this value", "path", bare=True),
 )
 
+_JAVA: tuple[Sink, ...] = (
+    # SQL (bare method names)
+    Sink("executeQuery", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("executeUpdate", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("execute", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("query", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("update", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("createNativeQuery", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    Sink("createQuery", "CG-SQL-EXEC", "CWE-89", SEVERITY_HIGH, _SQL, "sql", bare=True),
+    # Command (bare; Runtime.exec / ProcessBuilder / .start)
+    Sink("exec", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _CMD, "command",
+         bare=True, shell=SHELL_CONDITIONAL),
+    Sink("ProcessBuilder", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _CMD, "command",
+         bare=True, shell=SHELL_CONDITIONAL),
+    Sink("start", "CG-CMD-EXEC", "CWE-78", SEVERITY_CRITICAL, _CMD, "command",
+         bare=True, shell=SHELL_CONDITIONAL),
+    # Path (bare; incl. constructor sinks File / FileReader / FileWriter / FileInputStream)
+    Sink("File", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("FileReader", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("FileWriter", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("FileInputStream", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("readAllBytes", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    Sink("write", "CG-PATH-TRAVERSAL", "CWE-22", SEVERITY_HIGH,
+         "opens a file whose path comes from this value", "path", bare=True),
+    # Deserialization
+    Sink("readObject", "CG-DESERIALIZE", "CWE-502", SEVERITY_CRITICAL,
+         _DESERIALIZE, "deserialize", bare=True),
+    Sink("readUnshared", "CG-DESERIALIZE", "CWE-502", SEVERITY_CRITICAL,
+         _DESERIALIZE, "deserialize", bare=True),
+)
+
 _BY_LANGUAGE: dict[str, tuple[Sink, ...]] = {
     "python": _PYTHON,
     "javascript": _JAVASCRIPT,
     "go": _GO,
+    "java": _JAVA,
 }
 
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -24,8 +24,11 @@ def test_unparseable_file_is_failed_not_clean(tmp_path: Path):
 
 
 def test_language_without_an_analyzer_is_unsupported(tmp_path: Path):
-    (tmp_path / "Main.java").write_text("class Main {}\n", encoding="utf-8")
-    assert _status(tmp_path, ("Main.java",)) == {"Main.java": "unsupported"}
+    # Ruby has no analyzer -- recognised as source (SOURCE_GLOBS) but not in the
+    # verified gate. (Java used to be the example here; it is now analyzed, see
+    # test_java_is_analyzed_now_it_has_a_partial_analyzer.)
+    (tmp_path / "app.rb").write_text("puts 'hi'\n", encoding="utf-8")
+    assert _status(tmp_path, ("app.rb",)) == {"app.rb": "unsupported"}
 
 
 def test_go_is_analyzed_now_it_has_a_partial_analyzer(tmp_path: Path):
@@ -36,6 +39,15 @@ def test_go_is_analyzed_now_it_has_a_partial_analyzer(tmp_path: Path):
     NOT_SUPPORTED for Go (see test_go_verdicts_e2e.py)."""
     (tmp_path / "main.go").write_text("package main\n", encoding="utf-8")
     assert _status(tmp_path, ("main.go",)) == {"main.go": "analyzed"}
+
+
+def test_java_is_analyzed_now_it_has_a_partial_analyzer(tmp_path: Path):
+    """Java joined the verified gate (sql/command/path/deserialization sinks); it
+    is no longer a file-coverage blind spot. As with Go, the capability-level
+    honesty guarantee still holds -- `source_analysis_support` stays
+    NOT_SUPPORTED for Java (see test_java_verdicts_e2e.py)."""
+    (tmp_path / "Main.java").write_text("class Main {}\n", encoding="utf-8")
+    assert _status(tmp_path, ("Main.java",)) == {"Main.java": "analyzed"}
 
 
 def test_deleted_file_is_missing_not_failed(tmp_path: Path):

--- a/tests/test_java_csharp_analyzers.py
+++ b/tests/test_java_csharp_analyzers.py
@@ -155,7 +155,9 @@ def test_java_genuine_source_still_detected_and_reaches_sink(tmp_path: Path) -> 
     assert _input_nodes(nodes), "genuine getParameter must create an Input source"
     assert any(e.kind == "READS_INPUT" for e in edges)
     assert any(e.kind == "TAINTS" for e in edges)
-    assert any(f.rule_id == "CG-JAVA-SINK-CALL" for f in findings)
+    # executeQuery is now a graded verdict sink (Task 3), not the legacy
+    # CG-JAVA-SINK-CALL inventory finding: a tainted concatenated query is unsafe.
+    assert any(f.rule_id == "CG-SQL-EXEC" for f in findings)
 
 
 def test_java_genuine_source_beside_string_marker_still_detected(tmp_path: Path) -> None:

--- a/tests/test_java_provenance.py
+++ b/tests/test_java_provenance.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from cybergraph.analysis.java_provenance import (
+    assess,
+    assess_command,
+    assess_deserialization,
+    classify,
+)
+from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNKNOWN, VERDICT_UNSAFE
+from cybergraph.security.sinks import lookup_sink
+
+
+def _sql():
+    return lookup_sink("stmt.executeQuery", "java")
+
+
+def test_classify():
+    assert classify('"SELECT 1"') == "literal"
+    assert classify('"SELECT " + id') == "composed"
+    assert classify('String.format("SELECT %s", id)') == "composed"
+    assert (
+        classify("sb.append(id).toString()") == "composed"
+        or classify("sb.append(id)") == "composed"
+    )
+    assert classify("buildQuery()") == "opaque"
+
+
+def test_assess_sql_literal_safe():
+    assert assess(_sql(), '"SELECT 1"', set()) == VERDICT_SAFE
+
+
+def test_assess_sql_concat_tainted_unsafe():
+    assert assess(_sql(), '"SELECT * FROM u WHERE id = " + id', {"id"}) == VERDICT_UNSAFE
+
+
+def test_assess_sql_format_variable_format_unsafe():
+    assert assess(_sql(), "String.format(userFmt, x)", {"userFmt"}) == VERDICT_UNSAFE
+
+
+def test_assess_sql_unresolved_unknown():
+    assert assess(_sql(), '"SELECT " + id', set()) == VERDICT_UNKNOWN
+
+
+def test_assess_command_shell_tainted_unsafe():
+    assert assess_command(['"sh"', '"-c"', "userCmd"], {"userCmd"}) == VERDICT_UNSAFE
+    assert assess_command(['"ls"', '"-la"'], set()) == VERDICT_SAFE
+
+
+def test_deserialization_never_safe():
+    assert assess_deserialization(True) == VERDICT_UNSAFE     # tainted stream
+    assert assess_deserialization(False) == VERDICT_UNKNOWN   # unresolved -> still not safe

--- a/tests/test_java_provenance.py
+++ b/tests/test_java_provenance.py
@@ -109,3 +109,39 @@ def test_assess_append_escaped_quote_swallows_real_call_not_safe():
     assert (
         assess(_sql(), 'sb.append("a\\").append(userInput)', {"userInput"}) == VERDICT_UNKNOWN
     )
+
+
+def test_assess_trailing_call_after_append_chain_tainted_unsafe():
+    # A trailing call this module has no special name for (`.substring(...)`)
+    # after a recognised, all-literal append chain must still be examined --
+    # not silently dropped because the FIRST recognised call's own operands
+    # were all literal.
+    assert assess(_sql(), 'sb.append("a").substring(evil)', {"evil"}) == VERDICT_UNSAFE
+
+
+def test_assess_trailing_call_after_append_chain_unresolved_unknown():
+    # Same shape, but the trailing operand is a plain, unresolved identifier
+    # rather than a taint-confirmed one -- UNKNOWN, never SAFE.
+    assert assess(_sql(), 'sb.append("a").substring(x)', set()) == VERDICT_UNKNOWN
+
+
+def test_assess_trailing_append_after_format_call_tainted_unsafe():
+    # Same class of gap, the other direction: a trailing `.append(...)` after
+    # a recognised, all-literal `String.format(...)` call.
+    assert (
+        assess(_sql(), 'String.format("%s","lit").append(evil)', {"evil"}) == VERDICT_UNSAFE
+    )
+
+
+def test_assess_trailing_substring_after_format_call_tainted_unsafe():
+    # And a trailing call with no special name at all after `String.format(...)`.
+    assert (
+        assess(_sql(), 'String.format("%s","lit").substring(evil)', {"evil"}) == VERDICT_UNSAFE
+    )
+
+
+def test_assess_format_only_all_literal_is_safe():
+    # Regression guard: a `String.format(...)` call with no trailing chain and
+    # every argument a proven literal must still read SAFE -- the coverage
+    # guard closing the trailing-call gap above must not over-correct this.
+    assert assess(_sql(), 'String.format("literal")', set()) == VERDICT_SAFE

--- a/tests/test_java_provenance.py
+++ b/tests/test_java_provenance.py
@@ -49,3 +49,37 @@ def test_assess_command_shell_tainted_unsafe():
 def test_deserialization_never_safe():
     assert assess_deserialization(True) == VERDICT_UNSAFE     # tainted stream
     assert assess_deserialization(False) == VERDICT_UNKNOWN   # unresolved -> still not safe
+
+
+def test_assess_append_text_in_string_literal_does_not_hide_tainted_operand():
+    # ".append(" appearing inside a string literal must not be read as a real
+    # StringBuilder chain -- doing so would hijack the append branch and drop
+    # the tainted `userInput` operand after the `+`, a false SAFE.
+    assert assess(_sql(), '"foo.append(1)" + userInput', {"userInput"}) == VERDICT_UNSAFE
+
+
+def test_assess_format_call_containing_append_text_does_not_hide_tainted_operand():
+    # Same hijack, via a `String.format(...)` call whose own string-literal
+    # argument happens to contain the text ".append(".
+    assert (
+        assess(_sql(), 'String.format("x.append(1)") + userInput', {"userInput"})
+        == VERDICT_UNSAFE
+    )
+
+
+def test_assess_append_text_in_string_literal_untainted_is_unknown_not_safe():
+    # Same shape as above, but the `+` operand is a plain, unresolved
+    # identifier rather than a taint-confirmed one -- UNKNOWN, never SAFE.
+    assert assess(_sql(), '"foo.append(1)" + other', set()) == VERDICT_UNKNOWN
+
+
+def test_assess_stringbuilder_chain_tainted_append_unsafe():
+    # A genuine StringBuilder chain, assessed (not just classified): a
+    # tainted appended operand must read UNSAFE.
+    assert assess(_sql(), 'sb.append("x").append(userInput)', {"userInput"}) == VERDICT_UNSAFE
+
+
+def test_assess_parenthesized_operand_never_safe():
+    # A parenthesized operand is not a proven literal even when it wraps a
+    # tainted name -- it must never read SAFE.
+    assert assess(_sql(), "(userInput)", {"userInput"}) != VERDICT_SAFE

--- a/tests/test_java_provenance.py
+++ b/tests/test_java_provenance.py
@@ -5,6 +5,7 @@ from cybergraph.analysis.java_provenance import (
     assess_command,
     assess_deserialization,
     classify,
+    variable_names,
 )
 from cybergraph.security.predicates import VERDICT_SAFE, VERDICT_UNKNOWN, VERDICT_UNSAFE
 from cybergraph.security.sinks import lookup_sink
@@ -87,11 +88,64 @@ def test_assess_parenthesized_operand_never_safe():
     assert assess(_sql(), "(userInput)", {"userInput"}) == VERDICT_UNKNOWN
 
 
-def test_assess_stringbuilder_all_literal_chain_is_safe():
-    # The one legitimate append-SAFE case: every appended operand is a
-    # proven literal, so the fail-safe fix for the unbalanced-quote bug below
-    # must not over-correct this into UNKNOWN.
-    assert assess(_sql(), 'sb.append("a").append("b")', set()) == VERDICT_SAFE
+def test_assess_stringbuilder_bare_variable_receiver_never_safe():
+    # A bare-variable receiver (`sb`) is a non-literal operand: its prior
+    # state is part of the resulting string, so it can never be proven safe --
+    # even when every *appended* operand is a proven literal. Untainted and
+    # unprovable -> UNKNOWN, never SAFE.
+    assert assess(_sql(), 'sb.append("a").append("b")', set()) == VERDICT_UNKNOWN
+
+
+def test_assess_tainted_receiver_of_append_unsafe():
+    # CRITICAL fail-open: the receiver of a call chain is a non-literal
+    # operand. A tainted bare-variable receiver must read UNSAFE, not SAFE.
+    assert assess(_sql(), 'evil.append("x")', {"evil"}) == VERDICT_UNSAFE
+
+
+def test_assess_tainted_receiver_with_trailing_tostring_unsafe():
+    # Same, with a trailing `.toString()` navigation after the append.
+    assert assess(_sql(), 'sb.append(" LIMIT 10").toString()', {"sb"}) == VERDICT_UNSAFE
+
+
+def test_assess_variable_receiver_untainted_is_unknown_not_safe():
+    # A variable receiver with no confirmed taint is still unprovable ->
+    # UNKNOWN, never SAFE.
+    assert (
+        assess(_sql(), 'query.append(" LIMIT 10").toString()', set()) == VERDICT_UNKNOWN
+    )
+
+
+def test_variable_names_includes_chain_receiver():
+    # Parity with `assess`: the chain receiver is a candidate variable name.
+    assert "evil" in variable_names('evil.append("x")')
+    assert "sb" in variable_names('sb.append(" LIMIT 10").toString()')
+
+
+def test_assess_format_multi_arg_all_literal_numeric_is_safe():
+    # Precision: a multi-arg `String.format` whose args are each a proven
+    # literal is a literal composition -> SAFE. The arg list must be split on
+    # top-level commas and each arg tested individually.
+    assert assess(_sql(), 'String.format("%d", 1)', set()) == VERDICT_SAFE
+
+
+def test_assess_format_multi_arg_all_literal_strings_is_safe():
+    assert assess(_sql(), 'String.format("%s", "a", "b")', set()) == VERDICT_SAFE
+
+
+def test_assess_stringbuilder_all_literal_new_receiver_is_safe():
+    # A literal-construction receiver (`new StringBuilder(...)`) is inert; its
+    # constructor args are examined as a call. Every operand here is a proven
+    # literal, so the whole construction reads SAFE.
+    assert assess(_sql(), 'new StringBuilder("a").append("b")', set()) == VERDICT_SAFE
+
+
+def test_assess_tainted_new_constructor_arg_unsafe():
+    # The `new` receiver is inert, but its constructor args are still examined
+    # as a call -- a tainted constructor arg must read UNSAFE.
+    assert (
+        assess(_sql(), 'new StringBuilder(userInput).append("b")', {"userInput"})
+        == VERDICT_UNSAFE
+    )
 
 
 def test_assess_append_unbalanced_string_swallows_real_call_not_safe():

--- a/tests/test_java_provenance.py
+++ b/tests/test_java_provenance.py
@@ -173,6 +173,38 @@ def test_assess_non_allowlisted_new_receiver_tainted_arg_unsafe():
     )
 
 
+def test_assess_opaque_call_receiver_chain_never_safe():
+    # A leading BARE call whose result is CONSUMED by a further chained call
+    # (`currentQuery().append("lit").toString()`) is an opaque, unmodelled value:
+    # its return is not provably literal, so even with all-literal appended
+    # operands the chain must NOT read SAFE. (Whole-branch review C1: this was
+    # the last fail-open of the "reaches SAFE without proving the whole text is
+    # literal" family -- a bare-call receiver was wrongly treated as inert.)
+    for text in (
+        'currentQuery().append(" LIMIT 1").toString()',
+        'base().append(" LIMIT 1").toString()',
+        'getSql().append("a").append("b")',
+    ):
+        assert assess(_sql(), text, set()) == VERDICT_UNKNOWN, text
+
+
+def test_assess_opaque_call_receiver_chain_tainted_arg_unsafe():
+    # An explicitly tainted appended operand on top of the opaque receiver is
+    # still surfaced as UNSAFE (never swallowed by the opaque seed).
+    assert (
+        assess(_sql(), 'currentQuery().append(evil).toString()', {"evil"})
+        == VERDICT_UNSAFE
+    )
+
+
+def test_assess_terminal_bare_call_still_evaluated():
+    # A TERMINAL bare call (no chained call consuming its result) keeps its
+    # normal evaluation -- the fix must not over-correct every bare call into
+    # UNKNOWN. `String.format(...)` (the allowlisted static form) with all
+    # literal args stays SAFE.
+    assert assess(_sql(), 'String.format("%s", "a")', set()) == VERDICT_SAFE
+
+
 def test_assess_append_unbalanced_string_swallows_real_call_not_safe():
     # `"a` never closes, so the single-pass quote-tracking scan reads the
     # rest of the text -- including the real `.append(userInput)` -- as

--- a/tests/test_java_provenance.py
+++ b/tests/test_java_provenance.py
@@ -81,5 +81,31 @@ def test_assess_stringbuilder_chain_tainted_append_unsafe():
 
 def test_assess_parenthesized_operand_never_safe():
     # A parenthesized operand is not a proven literal even when it wraps a
-    # tainted name -- it must never read SAFE.
-    assert assess(_sql(), "(userInput)", {"userInput"}) != VERDICT_SAFE
+    # tainted name -- it must never read SAFE. The OPAQUE bare-identifier
+    # check does not unwrap parens, so this resolves to UNKNOWN, not UNSAFE --
+    # pinned exactly rather than with a weaker `!= VERDICT_SAFE`.
+    assert assess(_sql(), "(userInput)", {"userInput"}) == VERDICT_UNKNOWN
+
+
+def test_assess_stringbuilder_all_literal_chain_is_safe():
+    # The one legitimate append-SAFE case: every appended operand is a
+    # proven literal, so the fail-safe fix for the unbalanced-quote bug below
+    # must not over-correct this into UNKNOWN.
+    assert assess(_sql(), 'sb.append("a").append("b")', set()) == VERDICT_SAFE
+
+
+def test_assess_append_unbalanced_string_swallows_real_call_not_safe():
+    # `"a` never closes, so the single-pass quote-tracking scan reads the
+    # rest of the text -- including the real `.append(userInput)` -- as
+    # still "inside a string." The detected append site's own argument then
+    # fails to balance too, which must register as unresolved, not as "no
+    # operands found, so every operand is trivially literal."
+    assert assess(_sql(), 'sb.append("a).append(userInput)', {"userInput"}) == VERDICT_UNKNOWN
+
+
+def test_assess_append_escaped_quote_swallows_real_call_not_safe():
+    # Same failure mode via an escaped quote (`\"`) that never terminates the
+    # string instead of a plain missing closing quote.
+    assert (
+        assess(_sql(), 'sb.append("a\\").append(userInput)', {"userInput"}) == VERDICT_UNKNOWN
+    )

--- a/tests/test_java_provenance.py
+++ b/tests/test_java_provenance.py
@@ -157,6 +157,11 @@ def test_assess_non_allowlisted_new_receiver_never_safe():
         'new Foo("lit").append("x")',
         'new File("etc").append("x")',
         'new java.io.File("etc").append("x")',
+        # Package-qualified spoof: an attacker class whose simple name collides
+        # with StringBuilder must NOT be trusted -- the allowlist is the bare
+        # (unqualified) `new StringBuilder`/`new StringBuffer` shape only.
+        'new com.evil.StringBuilder("a").append("b")',
+        'new org.attacker.StringBuffer("a").append("b")',
     ):
         assert assess(_sql(), text, set()) == VERDICT_UNKNOWN, text
 

--- a/tests/test_java_provenance.py
+++ b/tests/test_java_provenance.py
@@ -148,6 +148,26 @@ def test_assess_tainted_new_constructor_arg_unsafe():
     )
 
 
+def test_assess_non_allowlisted_new_receiver_never_safe():
+    # Only `new StringBuilder/StringBuffer(...)` is a modelled, SAFE-eligible
+    # construction receiver. Any other `new X(...)` is an unmodelled construct
+    # whose `.method(...)` semantics are unknown -- even with all-literal args
+    # it must NOT read SAFE, or an unknown builder becomes a fail-open.
+    for text in (
+        'new Foo("lit").append("x")',
+        'new File("etc").append("x")',
+        'new java.io.File("etc").append("x")',
+    ):
+        assert assess(_sql(), text, set()) == VERDICT_UNKNOWN, text
+
+
+def test_assess_non_allowlisted_new_receiver_tainted_arg_unsafe():
+    # A tainted operand in a non-allowlisted construction is still caught.
+    assert (
+        assess(_sql(), 'new File("x").append(evil)', {"evil"}) == VERDICT_UNSAFE
+    )
+
+
 def test_assess_append_unbalanced_string_swallows_real_call_not_safe():
     # `"a` never closes, so the single-pass quote-tracking scan reads the
     # rest of the text -- including the real `.append(userInput)` -- as

--- a/tests/test_java_verdicts_e2e.py
+++ b/tests/test_java_verdicts_e2e.py
@@ -10,6 +10,13 @@ def _rules(tmp_path, src):
     return [f.rule_id for f in findings]
 
 
+def _findings(tmp_path, src):
+    p = tmp_path / "A.java"
+    p.write_text(src, encoding="utf-8")
+    _n, _e, findings = analyze_java_file(p, tmp_path)
+    return findings
+
+
 def test_prepared_statement_is_safe(tmp_path):
     src = ("class A { void h(java.sql.Connection c, String id) throws Exception {\n"
            "  var ps = c.prepareStatement(\"SELECT * FROM u WHERE id = ?\");\n"
@@ -67,6 +74,91 @@ def test_comment_only_parens_read_as_empty_not_unverified(tmp_path):
     rules = _rules(tmp_path, src)
     assert "CG-SQL-EXEC" not in rules
     assert "CG-SQL-EXEC-UNVERIFIED" not in rules
+
+
+def test_text_block_with_odd_quotes_then_commented_sink_is_not_flagged(tmp_path):
+    # Round 2 regression: a text block whose body contains an ODD number of
+    # unescaped `"` desyncs a naive single-quote-parity scanner, so a later
+    # `//` stops being recognised as a comment opener at all and a genuinely
+    # commented-out sink gets graded as live.
+    src = ('class A { void h(javax.servlet.http.HttpServletRequest req) throws Exception {\n'
+           '  String id = req.getParameter("id");\n'
+           '  String block = """\n'
+           '    she said "hi\n'
+           '    """;\n'
+           '  // new java.io.File(id);\n'
+           '} }\n')
+    rules = _rules(tmp_path, src)
+    assert "CG-PATH-TRAVERSAL" not in rules
+    assert "CG-PATH-TRAVERSAL-UNVERIFIED" not in rules
+
+
+def test_text_block_with_odd_quotes_then_real_sink_is_flagged(tmp_path):
+    # Same text block as above, but the sink on the next line is live (not
+    # commented out) -- proves the text-block fix does not over-correct into
+    # dropping a real sink after one.
+    src = ('class A { void h(javax.servlet.http.HttpServletRequest req) throws Exception {\n'
+           '  String id = req.getParameter("id");\n'
+           '  String block = """\n'
+           '    she said "hi\n'
+           '    """;\n'
+           '  new java.io.File(id);\n'
+           '} }\n')
+    assert "CG-PATH-TRAVERSAL" in _rules(tmp_path, src)
+
+
+def test_slash_slash_inside_string_literal_still_flags_concat(tmp_path):
+    # A `//` inside a real string literal must not be mistaken for a comment
+    # opener -- it must not blank the `+ id` that follows it on the same line.
+    src = ('class A { void h(java.sql.Statement st, '
+           'javax.servlet.http.HttpServletRequest req) throws Exception {\n'
+           '  String id = req.getParameter("id");\n'
+           '  st.executeQuery("... \'http://host/\' ..." + id); } }\n')
+    assert "CG-SQL-EXEC" in _rules(tmp_path, src)
+
+
+def test_block_comment_token_inside_string_literal_still_flags_concat(tmp_path):
+    # A `/*` inside a real string literal must not be mistaken for a comment
+    # opener -- it must not swallow the `+ id` that follows it.
+    src = ('class A { void h(java.sql.Statement st, '
+           'javax.servlet.http.HttpServletRequest req) throws Exception {\n'
+           '  String id = req.getParameter("id");\n'
+           '  st.executeQuery("a /* b" + id); } }\n')
+    assert "CG-SQL-EXEC" in _rules(tmp_path, src)
+
+
+def test_trailing_line_comment_after_real_sink_still_flags(tmp_path):
+    # A genuine trailing `// note` must be blanked (it is a real comment), but
+    # the live sink call earlier on the same line must still be graded.
+    src = ('class A { void h(java.sql.Statement st, '
+           'javax.servlet.http.HttpServletRequest req) throws Exception {\n'
+           '  String id = req.getParameter("id");\n'
+           '  st.executeQuery("q" + id); // note\n'
+           '} }\n')
+    assert "CG-SQL-EXEC" in _rules(tmp_path, src)
+
+
+def test_block_comment_spanning_lines_preserves_sink_line_number(tmp_path):
+    # A multi-line `/* ... */` block comment must not shift line numbers: a
+    # real sink several lines later must report ITS OWN line, not one offset
+    # by however many lines the comment blanking touched.
+    src = (
+        'class A { void h(java.sql.Statement st, '
+        'javax.servlet.http.HttpServletRequest req) throws Exception {\n'  # line 1
+        '  String id = req.getParameter("id");\n'                          # line 2
+        '  /* start of a\n'                                                # line 3
+        '     multi-line\n'                                                # line 4
+        '     comment */\n'                                                # line 5
+        '  int x = 1;\n'                                                   # line 6
+        '  int y = 2;\n'                                                   # line 7
+        '  int z = 3;\n'                                                   # line 8
+        '  st.executeQuery("SELECT " + id);\n'                             # line 9
+        '} }\n'                                                           # line 10
+    )
+    findings = _findings(tmp_path, src)
+    sql = [f for f in findings if f.rule_id == "CG-SQL-EXEC"]
+    assert len(sql) == 1
+    assert sql[0].line_start == 9
 
 
 def test_concat_sqli_is_unsafe(tmp_path):

--- a/tests/test_java_verdicts_e2e.py
+++ b/tests/test_java_verdicts_e2e.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import subprocess
+
 from cybergraph.analysis.java import analyze_java_file
+from cybergraph.security.capability import CAPABILITIES, FAIL, NOT_SUPPORTED
+from cybergraph.security.check import check_change
+from cybergraph.security.verdict import STATE_REVIEW
 
 
 def _rules(tmp_path, src):
@@ -190,3 +195,44 @@ def test_readobject_never_safe(tmp_path):
            "  return ois.readObject(); } }\n")
     rules = _rules(tmp_path, src)
     assert "CG-DESERIALIZE" in rules or "CG-DESERIALIZE-UNVERIFIED" in rules
+
+
+def _cap(cid):
+    return next(c for c in CAPABILITIES if c.id == cid)
+
+
+def test_four_capabilities_cover_java():
+    for cid in ("sql_construction", "command_execution", "path_access", "deserialization"):
+        assert "*.java" in _cap(cid).covers, cid
+    assert "*.java" not in _cap("code_execution").covers
+
+
+def _repo(tmp_path):
+    repo = tmp_path / "r"
+    repo.mkdir()
+    for a in (["init", "-q"], ["config", "user.email", "t@e.com"], ["config", "user.name", "t"]):
+        subprocess.run(["git", "-C", str(repo), *a], check=True)
+    (repo / "README.md").write_text("# x\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-q", "-m", "base"], check=True)
+    return repo
+
+
+def test_java_sqli_reviews(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "A.java").write_text(
+        "class A { void h(java.sql.Statement st, javax.servlet.http.HttpServletRequest req) "
+        "throws Exception {\n"
+        "  String id = req.getParameter(\"id\");\n"
+        "  st.executeQuery(\"SELECT * FROM u WHERE id = \" + id); } }\n", encoding="utf-8")
+    v = check_change(repo, mode="worktree")
+    assert v.state == STATE_REVIEW
+    assert any(c.capability_id == "sql_construction" and c.status == FAIL for c in v.checks)
+
+
+def test_java_still_not_supported_overall(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "A.java").write_text("class A { int x = 1; }\n", encoding="utf-8")
+    v = check_change(repo, mode="worktree")
+    assert any(c.capability_id == "source_analysis_support" and c.status == NOT_SUPPORTED
+               for c in v.checks)

--- a/tests/test_java_verdicts_e2e.py
+++ b/tests/test_java_verdicts_e2e.py
@@ -37,6 +37,19 @@ def test_prepared_statement_is_safe(tmp_path):
     assert "CG-SQL-EXEC-UNVERIFIED" not in rules
 
 
+def test_opaque_call_receiver_chain_is_not_reported_clean(tmp_path):
+    # Whole-branch review C1: an opaque bare-call receiver seeding an append
+    # chain (`currentQuery().append(" LIMIT 1").toString()`) must not read a
+    # confirmed-SAFE verdict end-to-end. It now surfaces as UNVERIFIED (UNKNOWN)
+    # rather than being silently dropped as clean.
+    src = ("class A { void h(java.sql.Statement st) throws Exception {\n"
+           "  st.executeQuery(currentQuery().append(\" LIMIT 1\").toString());\n"
+           "} }\n")
+    rules = _rules(tmp_path, src)
+    assert "CG-SQL-EXEC" not in rules  # not falsely confirmed
+    assert "CG-SQL-EXEC-UNVERIFIED" in rules  # surfaced as UNKNOWN, not absent
+
+
 def test_prepared_statement_concat_is_unsafe(tmp_path):
     src = ("class A { void h(java.sql.Connection c, "
            "javax.servlet.http.HttpServletRequest req) throws Exception {\n"

--- a/tests/test_java_verdicts_e2e.py
+++ b/tests/test_java_verdicts_e2e.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from cybergraph.analysis.java import analyze_java_file
+
+
+def _rules(tmp_path, src):
+    p = tmp_path / "A.java"
+    p.write_text(src, encoding="utf-8")
+    _n, _e, findings = analyze_java_file(p, tmp_path)
+    return [f.rule_id for f in findings]
+
+
+def test_prepared_statement_is_safe(tmp_path):
+    src = ("class A { void h(java.sql.Connection c, String id) throws Exception {\n"
+           "  var ps = c.prepareStatement(\"SELECT * FROM u WHERE id = ?\");\n"
+           "  ps.setString(1, id); ps.executeQuery(); } }\n")
+    rules = _rules(tmp_path, src)
+    assert "CG-SQL-EXEC" not in rules  # executeQuery() has no string arg -> not a string-SQL sink
+
+
+def test_concat_sqli_is_unsafe(tmp_path):
+    src = ("class A { void h(java.sql.Statement st, "
+           "javax.servlet.http.HttpServletRequest req) throws Exception {\n"
+           "  String id = req.getParameter(\"id\");\n"
+           "  st.executeQuery(\"SELECT * FROM u WHERE id = \" + id); } }\n")
+    assert "CG-SQL-EXEC" in _rules(tmp_path, src)
+
+
+def test_new_file_user_path_is_flagged(tmp_path):
+    src = ("class A { void h(javax.servlet.http.HttpServletRequest req) throws Exception {\n"
+           "  String p = req.getParameter(\"p\");\n"
+           "  new java.io.File(p); } }\n")
+    rules = _rules(tmp_path, src)
+    assert "CG-PATH-TRAVERSAL" in rules  # new File(...) constructor sink, CALL_RE would miss it
+
+
+def test_runtime_exec_chained_is_flagged(tmp_path):
+    src = ("class A { void h(javax.servlet.http.HttpServletRequest req) throws Exception {\n"
+           "  String c = req.getParameter(\"c\");\n"
+           "  Runtime.getRuntime().exec(new String[]{\"sh\", \"-c\", c}); } }\n")
+    assert "CG-CMD-EXEC" in _rules(tmp_path, src)  # chained .exec(...) after )
+
+
+def test_readobject_never_safe(tmp_path):
+    src = ("class A { Object h(javax.servlet.http.HttpServletRequest req) throws Exception {\n"
+           "  var ois = new java.io.ObjectInputStream(req.getInputStream());\n"
+           "  return ois.readObject(); } }\n")
+    rules = _rules(tmp_path, src)
+    assert "CG-DESERIALIZE" in rules or "CG-DESERIALIZE-UNVERIFIED" in rules

--- a/tests/test_java_verdicts_e2e.py
+++ b/tests/test_java_verdicts_e2e.py
@@ -15,7 +15,58 @@ def test_prepared_statement_is_safe(tmp_path):
            "  var ps = c.prepareStatement(\"SELECT * FROM u WHERE id = ?\");\n"
            "  ps.setString(1, id); ps.executeQuery(); } }\n")
     rules = _rules(tmp_path, src)
-    assert "CG-SQL-EXEC" not in rules  # executeQuery() has no string arg -> not a string-SQL sink
+    # `prepareStatement` is itself a graded sql sink (Task 3 round 1): its
+    # argument is an all-literal string (the `?` placeholder lives inside the
+    # literal), so it must read the confirmed SAFE verdict -- no finding at
+    # all, and specifically neither the confirmed nor the -UNVERIFIED rule id
+    # (ruling out a silent UNKNOWN masquerading as "no finding"). The trailing
+    # `executeQuery()` is separately zero-arg-guarded.
+    assert "CG-SQL-EXEC" not in rules
+    assert "CG-SQL-EXEC-UNVERIFIED" not in rules
+
+
+def test_prepared_statement_concat_is_unsafe(tmp_path):
+    src = ("class A { void h(java.sql.Connection c, "
+           "javax.servlet.http.HttpServletRequest req) throws Exception {\n"
+           "  String id = req.getParameter(\"id\");\n"
+           "  var ps = c.prepareStatement(\"SELECT * FROM u WHERE id = \" + id);\n"
+           "  ps.executeQuery(); } }\n")
+    # A concatenated PreparedStatement is exactly as unsafe as a concatenated
+    # Statement.executeQuery -- this is the case that previously produced ZERO
+    # findings because `prepareStatement` was not a registered sink at all.
+    assert "CG-SQL-EXEC" in _rules(tmp_path, src)
+
+
+def test_commented_out_new_file_sink_is_not_flagged(tmp_path):
+    src = ("class A { void h(javax.servlet.http.HttpServletRequest req) throws Exception {\n"
+           "  String p = req.getParameter(\"p\");\n"
+           "  // new java.io.File(p);\n"
+           "} }\n")
+    rules = _rules(tmp_path, src)
+    assert "CG-PATH-TRAVERSAL" not in rules
+    assert "CG-PATH-TRAVERSAL-UNVERIFIED" not in rules
+
+
+def test_block_commented_out_sqli_is_not_flagged(tmp_path):
+    src = ("class A { void h(java.sql.Statement st, "
+           "javax.servlet.http.HttpServletRequest req) throws Exception {\n"
+           "  String id = req.getParameter(\"id\");\n"
+           "  /* st.executeQuery(\"SELECT * FROM u WHERE id = \" + id); */\n"
+           "} }\n")
+    rules = _rules(tmp_path, src)
+    assert "CG-SQL-EXEC" not in rules
+    assert "CG-SQL-EXEC-UNVERIFIED" not in rules
+
+
+def test_comment_only_parens_read_as_empty_not_unverified(tmp_path):
+    # A sink call whose parens hold only a comment (`/* n/a */`) must be read
+    # as the zero-arg guard's genuinely-empty case, not as an opaque,
+    # unreadable argument that would otherwise surface as -UNVERIFIED noise.
+    src = ("class A { void h(java.sql.Statement st) throws Exception {\n"
+           "  st.executeQuery(/* n/a */); } }\n")
+    rules = _rules(tmp_path, src)
+    assert "CG-SQL-EXEC" not in rules
+    assert "CG-SQL-EXEC-UNVERIFIED" not in rules
 
 
 def test_concat_sqli_is_unsafe(tmp_path):

--- a/tests/test_sinks_java.py
+++ b/tests/test_sinks_java.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import pytest
+
+from cybergraph.security.sinks import lookup_sink
+
+
+@pytest.mark.parametrize("call_name,rule_id,vuln", [
+    ("stmt.executeQuery", "CG-SQL-EXEC", "sql"),
+    ("stmt.executeUpdate", "CG-SQL-EXEC", "sql"),
+    ("em.createNativeQuery", "CG-SQL-EXEC", "sql"),
+    ("jdbcTemplate.query", "CG-SQL-EXEC", "sql"),
+    ("Runtime.exec", "CG-CMD-EXEC", "command"),
+    ("pb.start", "CG-CMD-EXEC", "command"),
+    ("File", "CG-PATH-TRAVERSAL", "path"),
+    ("Files.readAllBytes", "CG-PATH-TRAVERSAL", "path"),
+    ("ois.readObject", "CG-DESERIALIZE", "deserialize"),
+    ("ois.readUnshared", "CG-DESERIALIZE", "deserialize"),
+])
+def test_java_sinks_resolve(call_name, rule_id, vuln):
+    sink = lookup_sink(call_name, "java")
+    assert sink is not None, call_name
+    assert sink.rule_id == rule_id
+    assert sink.vuln_class == vuln
+
+
+def test_java_non_sink_is_none():
+    assert lookup_sink("logger.info", "java") is None
+    assert lookup_sink("list.add", "java") is None
+
+
+def test_other_languages_unchanged():
+    assert lookup_sink("os.system", "python").rule_id == "CG-CMD-EXEC"
+    assert lookup_sink("pickle.loads", "python").rule_id == "CG-DESERIALIZE"
+    assert lookup_sink("stmt.executeQuery", "python") is None
+    assert lookup_sink("db.query", "javascript").rule_id == "CG-SQL-EXEC"

--- a/tests/test_sinks_java.py
+++ b/tests/test_sinks_java.py
@@ -10,6 +10,8 @@ from cybergraph.security.sinks import lookup_sink
     ("stmt.executeUpdate", "CG-SQL-EXEC", "sql"),
     ("em.createNativeQuery", "CG-SQL-EXEC", "sql"),
     ("jdbcTemplate.query", "CG-SQL-EXEC", "sql"),
+    ("conn.prepareStatement", "CG-SQL-EXEC", "sql"),
+    ("conn.prepareCall", "CG-SQL-EXEC", "sql"),
     ("Runtime.exec", "CG-CMD-EXEC", "command"),
     ("pb.start", "CG-CMD-EXEC", "command"),
     ("File", "CG-PATH-TRAVERSAL", "path"),


### PR DESCRIPTION
## What

Graduates the Java analyzer from inventory-only `CG-JAVA-SINK-CALL` findings to **real ACCEPT/REVIEW verdicts** for four injection classes: SQL, command, path, and **deserialization** (a new vuln class this slice introduces). Mirrors the JS core-four upgrade, plus Java-specific handling.

## How

- **Sink registry** (`sinks.py` `_JAVA`): SQL (`executeQuery`/`executeUpdate`/`execute`/`query`/`update`/`createNativeQuery`/`createQuery`/`prepareStatement`/`prepareCall`), command (`exec`/`ProcessBuilder`/`start`, `SHELL_CONDITIONAL`), path (`File`/`FileReader`/`FileWriter`/`FileInputStream`/`readAllBytes`/`write`), deserialization (`readObject`/`readUnshared`). Reuses Python's rule ids (`CG-SQL-EXEC`/`CG-CMD-EXEC`/`CG-PATH-TRAVERSAL`/`CG-DESERIALIZE`).
- **Fail-safe classifier** (`java_provenance.py`): positive-literal-proof `assess`/`assess_command`/`assess_deserialization`, ported from the Go classifier + `String.format`/`StringBuilder` COMPOSED handling. **Cardinal rule:** only an all-literal/constant construction reads SAFE; any variable/non-literal/unknown/unreadable operand → UNSAFE (taint-confirmed) or UNKNOWN, never SAFE. Deserialization is never SAFE.
- **Routing** (`java.py`): a dedicated `_JAVA_SINK_CALL_RE` catches constructors (`new File(p)`) and chained calls (`Runtime.getRuntime().exec(...)`, `ois.readObject()`) that the existing `CALL_RE` misses; a zero-arg guard skips empty-parens sink calls (exempting deserialization); comment-blanking reuses the shared `_source_text` tokenizer (text-block/quote aware, offset-preserving).
- **Capability/coverage**: `JAVA_GLOBS = ("*.java",)`; the four injection capabilities + the coverage verified-gate broaden to `*.java`. `code_execution` is **not** claimed (no Java eval sink in scope). **`VERIFIED_GLOBS` is unchanged** — Java stays honestly `NOT_SUPPORTED` for whole-file `source_analysis_support`.
- **Mutation harness**: 3 D9-java fail-open mutations (tainted-sink / unresolved-var / deserialization reads-safe), each red under an existing test.

## Verification

- Full suite: **1354 passed, 1 skipped**.
- Mutation harness: **44/44 caught** (incl. the 3 new Java fail-opens).
- `run_precision.py`: **GATE PASSED** — precision=1.0, recall=1.0, safe_fp_rate=0.0.
- `run_eval.py`: precision/recall unchanged; Python/existing corpora byte-identical (registry is language-keyed). `results.json` not committed.
- ruff clean on all touched files.

## Review provenance

Built via subagent-driven development with adversarial per-task review + a whole-branch review on the most capable model. The classifier's SAFE surface went through **seven** hardening rounds closing fail-opens of one family ("a branch reads SAFE without proving the *entire* argument text is literal"): string-literal `.append(` hijack, unbalanced-quote swallow, trailing chained-call coverage, tainted/variable call-chain receivers, non-allowlisted `new X(...)`, package-qualified builder spoof, and finally an opaque bare-call receiver consumed by a chain. Each is pinned by a red-under-mutation regression test.

## Follow-ups (non-blocking, fail-safe — over-flag/UNKNOWN, never a missed vuln)

- Bare `write` sink over-matches (`response.getWriter().write(x)` mislabeled `CG-PATH-TRAVERSAL`, wrong CWE) — narrow to `Files.write` or drop.
- Recall gaps that read UNKNOWN not UNSAFE (never SAFE): `INPUT_MARKERS` `request.getInputStream` doesn't substring-match `req.getInputStream()`; a fully unqualified `executeQuery(...)` (no receiver); `String.join`/`.concat`/`MessageFormat.format` with a tainted var.

## Merge order

Independent of, but shares four files with, the Go re-land (#52) — `sinks.py`, `capability.py`, `coverage.py`, `mutation_harness.py`. Whichever merges second should rebase onto the new `main` and re-resolve those additive overlaps. `docs/CRITICAL_AUDIT.md` §4.5 marked resolved for JS + Java (still OPEN for C#/others).