### PR TITLE
docs: reposition README ("AI writes. CyberGraph verifies.") + detailed features reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
 # CyberGraph
 
-**Verify and monitor your code's security on every change — deterministic ACCEPT/REVIEW verdicts, fully offline, zero tokens.**
+## AI writes. CyberGraph verifies.
 
-AI agents now write a large and growing share of code, and every change is a chance to introduce a vulnerability. The reflexive fix — spending more model tokens asking an LLM *"is this safe?"* — is slow, nondeterministic, and expensive. CyberGraph replaces that with a deterministic verifier: it decides whether a change is safe to ship and returns an **ACCEPT** or **REVIEW** verdict with cited evidence, computed entirely offline with no API keys and no tokens. Install it as a hook and it runs the moment a change is made — so security review stops burning tokens and becomes free, repeatable, and instant.
+Your AI coding agent wrote the change. Should the same AI be the only thing that reviews it?
 
-Under the hood it maps your repository into a cybersecurity knowledge graph — reachability, taint, trust boundaries, construction-provenance — which is what makes the verdicts precise enough to trust: a query built from a variable is UNSAFE, an all-literal one is SAFE, and anything it cannot prove it marks UNKNOWN rather than guessing. **The graph is the engine; the verdict is the product.**
+CyberGraph is an **independent, offline security verifier for code changes**. It checks each change against your application's security rules and returns an **ACCEPT** or **REVIEW** verdict with cited evidence — computed deterministically on your machine, with **no cloud upload, no mandatory LLM, and no per-check token cost**.
 
-> **🔒 No API keys. Fully offline. Zero tokens. Your code never leaves your machine.**
-> `pip install cybergraph` and you get the complete toolkit — the change verifier, git/agent hooks, the interactive HTML report, attack-path graphs, cited findings, and SARIF export — with **zero API keys, zero signup, and zero network calls**. There are no runtime dependencies. An LLM is entirely optional and only rephrases answers the graph has already grounded in evidence; nothing about the analysis requires one.
+- **ACCEPT** — the supported checks ran and found nothing.
+- **REVIEW** — something changed, or a relevant check couldn't be verified.
+
+It never turns *"didn't look"* into a pass: every capability reports `PASS`, `UNKNOWN`, `NOT_SUPPORTED`, or `NOT_APPLICABLE` explicitly, so a blind spot is visible, not silent. **Uncertainty never becomes safety** — if CyberGraph cannot prove a check passed, it tells you, rather than issue a false ACCEPT.
+
+Install it as a hook and it runs the moment an agent finishes a turn or a commit is made — verification that doesn't depend on the agent choosing to check itself:
+
+```text
+AI writes  →  CyberGraph checks  →  ACCEPT / REVIEW  →  shows why (cited evidence)
+```
+
+> **No cloud upload · No mandatory LLM · No per-check token cost · No silent blind spots**
+> `pip install cybergraph` — zero API keys, zero signup, zero network calls, zero runtime dependencies. Under the hood CyberGraph maps your repository into a cybersecurity knowledge graph (reachability, taint, trust boundaries, construction-provenance) — the engine that makes each verdict precise. An LLM is optional and only rephrases evidence the graph has already grounded; nothing about the analysis or the verdict requires one.
 
 ## See it in action
 
@@ -36,9 +47,9 @@ Two problems collide. Security scanners are noisy and flat — a file, a line, a
 - Did this pull request affect a security boundary?
 - Which scanner findings matter first?
 
-And now AI agents generate code faster than anyone can review it, so those questions arrive on every change — and answering them by spending more LLM tokens is slow, nondeterministic, and doesn't scale.
+And now AI agents generate code faster than anyone can review it, so those questions arrive on every change — and having the same class of model that wrote the code also review it is nondeterministic, spends tokens on every turn, and doesn't scale.
 
-CyberGraph connects the dots and turns the answer into a **decision**. It **verifies** each change against the security guarantees it can check and returns a single ACCEPT/REVIEW verdict, and it **monitors** the codebase over time — what regressed, what was fixed, what a change moved across a trust boundary. Because it is deterministic and offline, that verification is effectively free: no tokens, no keys, no network — a gate you can run on every commit and every agent turn without thinking about cost.
+CyberGraph connects the dots and turns the answer into a **decision** made *independently* of the coding model. It **verifies** each change against the security guarantees it can check and returns a single ACCEPT/REVIEW verdict, and it **monitors** the codebase over time — what regressed, what was fixed, what a change moved across a trust boundary. The security decision is deterministic and local, with **no per-check LLM or API cost** — cheap enough to run on every commit and every agent turn.
 
 ## Current capabilities
 
@@ -231,25 +242,33 @@ cybergraph policy --repo .            # show the declared policy and which entit
 cybergraph policy --repo . --baseline # print a proposed baseline without writing anything
 ```
 
-**Which languages are verdict-grade today:** Python, JavaScript/TypeScript, Go, and Java each
-have verdict-grade injection detection — an exact-match sink registry plus a construction
-classifier and intra-function taint that grade a sink's argument **SAFE / UNSAFE / UNKNOWN**
-from how the value was built, never a bare keyword match. Their findings (`CG-SQL-EXEC`,
-`CG-CMD-EXEC`, `CG-PATH-TRAVERSAL`, `CG-CODE-EXEC`, `CG-DESERIALIZE`, plus `CG-TEMPLATE-INJECT`
-for Python) are confirmed or explicitly abstain (`-UNVERIFIED`) — never a guess — and the
-graded set is held to a labelled precision/recall/abstention benchmark
-(`benchmark/run_precision.py`). C# verdicts (adding a code-execution class, and handling C#
-string interpolation) land in the same shape. Any language or sink class not yet upgraded stays
-**inventory-grade**: a `*-SINK-CALL` row that marks "a sensitive sink is used here" from a
-regex analyzer with no parse tree and no taint requirement — a map of where sensitive calls
-live, not a verdict. CI's SARIF export deliberately filters the inventory rules out of code
-scanning uploads until each graduates; graded verdict rules are never filtered and always reach
-code scanning.
+**Language coverage — and how far each is validated.** CyberGraph runs five-language security
+analysis, but assurance is not yet uniform across them, and it says so rather than implying
+parity:
 
-The cardinal rule across every language is the same: **only an all-literal / constant
-construction can read SAFE.** A value built from a variable is UNSAFE when taint confirms it and
-UNKNOWN otherwise; native deserialization is never SAFE. Uncertainty never becomes safety — the
-tool abstains (`-UNVERIFIED`, which drives REVIEW) rather than issue a false ACCEPT.
+| Language | Injection verdicts | Validation |
+|---|---|---|
+| Python | SQL · command · path · code-exec · deserialization · template | **Labelled precision/recall/abstention benchmark ✓** |
+| JavaScript / TypeScript | SQL · command · code-exec · path | Beta |
+| Go | SQL · command · path | Beta |
+| Java | SQL · command · path · deserialization | Beta |
+| C# | SQL · command · path · deserialization · code-exec | Beta |
+
+Python currently carries the strongest validated coverage: it is the language held to a labelled
+benchmark (`benchmark/run_precision.py`) that gates every change. The other four grade a sink's
+argument the same way — **SAFE / UNSAFE / UNKNOWN** from how the value was constructed and
+intra-function taint, never a bare keyword match — and are **Beta** until each earns its own
+labelled benchmark. Whole-file source-analysis support (`source_analysis_support`) is Python-only
+by design; the others are structural, line-based classifiers, so they stay `NOT_SUPPORTED` at
+that capability level even while their injection verdicts are graded. Any sink class not yet
+upgraded stays **inventory-grade** — a `*-SINK-CALL` map of where sensitive calls live, not a
+verdict — and is filtered from code-scanning uploads until it graduates; graded verdict rules are
+never filtered.
+
+The cardinal rule is the same in every language: **only an all-literal / constant construction
+can read SAFE.** A value built from a variable is UNSAFE when taint confirms it and UNKNOWN
+otherwise; native deserialization is never SAFE. **Uncertainty never becomes safety** — the tool
+abstains (`-UNVERIFIED`, which drives REVIEW) rather than issue a false ACCEPT.
 
 ### Run the check automatically — `cybergraph hook`
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # CyberGraph
 
-Security review for codebases, powered by knowledge graphs.
+**Verify and monitor your code's security on every change — deterministic ACCEPT/REVIEW verdicts, fully offline, zero tokens.**
 
-CyberGraph maps a repository into a cybersecurity knowledge graph so developers can inspect security layers, risky code paths, scanner findings, and evidence-backed answers without reading the whole codebase by hand.
+AI agents now write a large and growing share of code, and every change is a chance to introduce a vulnerability. The reflexive fix — spending more model tokens asking an LLM *"is this safe?"* — is slow, nondeterministic, and expensive. CyberGraph replaces that with a deterministic verifier: it decides whether a change is safe to ship and returns an **ACCEPT** or **REVIEW** verdict with cited evidence, computed entirely offline with no API keys and no tokens. Install it as a hook and it runs the moment a change is made — so security review stops burning tokens and becomes free, repeatable, and instant.
 
-> **🔒 No API keys. Fully offline. Your code never leaves your machine.**
-> `pip install cybergraph` and you get the complete toolkit — the interactive HTML report, attack-path graphs, cited findings, and SARIF export — with **zero API keys, zero signup, and zero network calls**. There are no runtime dependencies. An LLM is entirely optional and only rephrases answers the graph has already grounded in evidence; nothing about the analysis requires one.
+Under the hood it maps your repository into a cybersecurity knowledge graph — reachability, taint, trust boundaries, construction-provenance — which is what makes the verdicts precise enough to trust: a query built from a variable is UNSAFE, an all-literal one is SAFE, and anything it cannot prove it marks UNKNOWN rather than guessing. **The graph is the engine; the verdict is the product.**
+
+> **🔒 No API keys. Fully offline. Zero tokens. Your code never leaves your machine.**
+> `pip install cybergraph` and you get the complete toolkit — the change verifier, git/agent hooks, the interactive HTML report, attack-path graphs, cited findings, and SARIF export — with **zero API keys, zero signup, and zero network calls**. There are no runtime dependencies. An LLM is entirely optional and only rephrases answers the graph has already grounded in evidence; nothing about the analysis requires one.
 
 ## See it in action
 
@@ -27,14 +29,16 @@ Generate this for any repo with `cybergraph visualize path/to/repo` (dark theme 
 
 ## Why this exists
 
-Security scanners are useful, but their output is usually flat: a file, a line, a rule, and a warning. Developers still have to answer the hard questions:
+Two problems collide. Security scanners are noisy and flat — a file, a line, a rule, a warning — leaving developers to answer the hard questions themselves:
 
 - Is this issue reachable from production code?
 - Is there authentication before this sensitive action?
 - Did this pull request affect a security boundary?
 - Which scanner findings matter first?
 
-CyberGraph is designed to connect those dots.
+And now AI agents generate code faster than anyone can review it, so those questions arrive on every change — and answering them by spending more LLM tokens is slow, nondeterministic, and doesn't scale.
+
+CyberGraph connects the dots and turns the answer into a **decision**. It **verifies** each change against the security guarantees it can check and returns a single ACCEPT/REVIEW verdict, and it **monitors** the codebase over time — what regressed, what was fixed, what a change moved across a trust boundary. Because it is deterministic and offline, that verification is effectively free: no tokens, no keys, no network — a gate you can run on every commit and every agent turn without thinking about cost.
 
 ## Current capabilities
 
@@ -195,7 +199,7 @@ Suppressions hide findings, but the graph still keeps edges such as `REACHES_SIN
 
 **Phase 1 contract — the sentence this work is judged against:**
 
-> Given a supported AI-generated Python change, CyberGraph can tell whether the specific security guarantees it understands were preserved — and explicitly admit what it could not verify.
+> Given a supported AI-generated code change, CyberGraph can tell whether the specific security guarantees it understands were preserved — and explicitly admit what it could not verify.
 
 `cybergraph check` is the command that evaluates a change against that contract. It compares
 the current state of a repository against a base ref (`--mode merge-base|worktree|range`) and
@@ -227,18 +231,25 @@ cybergraph policy --repo .            # show the declared policy and which entit
 cybergraph policy --repo . --baseline # print a proposed baseline without writing anything
 ```
 
-**Which languages are verified today:** Python is the only language with verdict-grade
-detection — an exact-match sink registry with per-sink taint predicates, gated by a labelled
-precision/recall/abstention benchmark (`benchmark/run_precision.py`). Its findings (`CG-SQL-EXEC`,
-`CG-CMD-EXEC`, `CG-PATH-TRAVERSAL`, `CG-TEMPLATE-INJECT`, `CG-CODE-EXEC`, `CG-DESERIALIZE`) are
-confirmed or explicitly abstain (`-UNVERIFIED`) — never a bare guess. Go, JavaScript/TypeScript,
-Java, and C# are still **inventory-grade**: their sink findings (`CG-GO-SINK-CALL`,
-`CG-JS-SINK-CALL`, `CG-JAVA-SINK-CALL`, `CG-CSHARP-SINK-CALL`) mark "a sensitive sink is used
-here" from a regex-based analyzer with no parse tree and no taint requirement, useful as a map
-of where sensitive calls live but not as a confirmed verdict. CI's SARIF export deliberately
-filters those four inventory rules out of code scanning uploads until each language gets the
-same exact-match-plus-predicate treatment Python already has; Python's verdict rules are never
-filtered and always reach code scanning.
+**Which languages are verdict-grade today:** Python, JavaScript/TypeScript, Go, and Java each
+have verdict-grade injection detection — an exact-match sink registry plus a construction
+classifier and intra-function taint that grade a sink's argument **SAFE / UNSAFE / UNKNOWN**
+from how the value was built, never a bare keyword match. Their findings (`CG-SQL-EXEC`,
+`CG-CMD-EXEC`, `CG-PATH-TRAVERSAL`, `CG-CODE-EXEC`, `CG-DESERIALIZE`, plus `CG-TEMPLATE-INJECT`
+for Python) are confirmed or explicitly abstain (`-UNVERIFIED`) — never a guess — and the
+graded set is held to a labelled precision/recall/abstention benchmark
+(`benchmark/run_precision.py`). C# verdicts (adding a code-execution class, and handling C#
+string interpolation) land in the same shape. Any language or sink class not yet upgraded stays
+**inventory-grade**: a `*-SINK-CALL` row that marks "a sensitive sink is used here" from a
+regex analyzer with no parse tree and no taint requirement — a map of where sensitive calls
+live, not a verdict. CI's SARIF export deliberately filters the inventory rules out of code
+scanning uploads until each graduates; graded verdict rules are never filtered and always reach
+code scanning.
+
+The cardinal rule across every language is the same: **only an all-literal / constant
+construction can read SAFE.** A value built from a variable is UNSAFE when taint confirms it and
+UNKNOWN otherwise; native deserialization is never SAFE. Uncertainty never becomes safety — the
+tool abstains (`-UNVERIFIED`, which drives REVIEW) rather than issue a false ACCEPT.
 
 ### Run the check automatically — `cybergraph hook`
 
@@ -301,9 +312,10 @@ Available tools:
 
 The MCP surface is an **interoperability surface, not automatic verification**: nothing forces
 a connected agent to call `check_change_tool` before or after making a change, and an agent may
-decline to call it entirely. Reliable, always-invoked checking needs a client-side hook, which
-is future work — treat these tools as available context an agent can pull, not a gate it must
-pass.
+decline to call it entirely. For reliable, always-invoked checking, install a client-side hook
+(`cybergraph hook install claude-code|pre-commit`, above) so the verdict fires on every agent
+turn or commit regardless of whether the agent opts in. Treat these MCP tools as context an
+agent can pull, and the hook as the gate it cannot skip.
 
 ## Project direction
 
@@ -311,6 +323,7 @@ CyberGraph is intentionally security-first. It is not trying to be a general cod
 
 See:
 
+- [Features & capabilities](docs/features.md) — the detailed reference to everything CyberGraph does
 - [Architecture](docs/architecture.md)
 - [Getting started](docs/getting-started.md)
 - [Five-minute tutorial](docs/tutorial.md)

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,10 +8,13 @@ short pitch see the [README](../README.md); for architecture internals see
 
 ## 1. What CyberGraph is
 
-CyberGraph is an **offline security verifier and monitor for code changes**. Its headline job is
-simple: given a change to a repository, decide whether it is safe to ship and return a single
-verdict — **ACCEPT** (the checks that ran found nothing) or **REVIEW** (a human should look) —
-with cited evidence and an explicit list of what could not be checked.
+CyberGraph is an **offline security verifier and monitor for code changes**, run *independently*
+of the model that wrote the code. Its headline job: given a change to a repository, check it
+against the security guarantees CyberGraph can verify and return a single verdict — **ACCEPT**
+(the supported checks ran and found nothing) or **REVIEW** (something changed, or a relevant
+check could not be verified) — with cited evidence and an explicit list of what could not be
+checked. ACCEPT is not a certification that the change is secure; it is the narrower, honest
+claim that the guarantees CyberGraph understands were preserved.
 
 It does this **deterministically and entirely offline**: no API keys, no signup, no network
 calls, no runtime dependencies, and — critically — **no LLM tokens**. A large language model is
@@ -23,23 +26,26 @@ routes, guards, sinks, secrets, cloud resources, and the edges between them (cal
 flow, reaches-sink, uses/exposes-secret). That graph is the engine that makes the verdicts
 precise. It is not the pitch; the verdict is.
 
-### Why it saves tokens
+### Zero-token verification, independent of the coding model
 
 AI coding agents now write a large and growing share of code, and each change can introduce a
-vulnerability. The common way to guard that — asking an LLM to re-review every change — spends
-tokens on every turn, is nondeterministic, and gets slower and costlier as the codebase and the
-change rate grow. CyberGraph moves that verification **off the token meter**:
+vulnerability. The common way to guard that — having the same class of model that wrote the code
+also review it — is nondeterministic, spends tokens on every turn, and gets slower and costlier
+as the codebase and change rate grow. CyberGraph moves that verification **off the token meter**:
 
-- **The verdict is free and instant.** A deterministic graph-and-rules check costs no tokens and
-  runs in seconds, so you can gate every commit and every agent turn without weighing the cost.
-- **It catches regressions at the cheapest moment** — as the change is made — instead of after
-  tokens have been spent building on top of an insecure change, or after it reaches production.
-- **It keeps the LLM on the work only an LLM can do.** When a model *is* in the loop, CyberGraph
-  narrows it to grounded evidence (cited findings, reachable paths), so you are not paying for a
-  model to re-derive what a graph already knows.
+- **No per-check LLM or API cost.** The security decision is a deterministic graph-and-rules
+  check, so verifying a change consumes no tokens — you can run it on every commit and every
+  agent turn without a per-check cost to weigh. (Wall-clock varies with repo size and which
+  analyses run — a graph rebuild, SCA, or history pass is not instantaneous — but none of it
+  bills against a model.)
+- **An independent reviewer.** The verdict does not come from the model under review, so it is
+  not vulnerable to the same blind spot that produced the code.
+- **It keeps the LLM on the work only an LLM can do.** When a model *is* in the loop (optional
+  phrasing/triage), CyberGraph narrows it to grounded evidence, so you are not paying a model to
+  re-derive what the graph already knows.
 
-The net effect is indirect but real: security review shifts from a recurring per-change token
-cost to a free, repeatable, local gate.
+The claim here is a *property* — zero-token, deterministic verification — not a measured savings
+figure; any "X% fewer tokens" number would need an end-to-end benchmark, which is future work.
 
 ---
 
@@ -106,13 +112,19 @@ a variable hole is UNSAFE, an all-literal `"SELECT 1"` is SAFE — not from a ke
 CyberGraph analyzes **five languages** through a shared analyzer contract, with graceful
 fallback for the rest.
 
-| Language | Frameworks understood | Verdict grade |
-|---|---|---|
-| Python | FastAPI, Flask, Django | **Verdict-grade** — exact-match sink registry + per-sink taint predicates; the only language in the labelled precision/recall benchmark |
-| JavaScript / TypeScript | Express, Next.js | **Verdict-grade** — SQL / command / code-exec / path |
-| Go | net/http, Gin, Echo | **Verdict-grade** — SQL / command / path (no code-exec sink in Go) |
-| Java | Spring, JDBC | **Verdict-grade** — SQL / command / path / deserialization |
-| C# | ASP.NET Core, ADO.NET | **Verdict-grade** — SQL / command / path / deserialization / code-execution (incl. string interpolation) |
+| Language | Frameworks understood | Injection verdicts | Validation |
+|---|---|---|---|
+| Python | FastAPI, Flask, Django | SQL · command · path · code-exec · deserialization · template | **Labelled precision/recall/abstention benchmark ✓** |
+| JavaScript / TypeScript | Express, Next.js | SQL · command · code-exec · path | Beta |
+| Go | net/http, Gin, Echo | SQL · command · path (no code-exec sink in Go) | Beta |
+| Java | Spring, JDBC | SQL · command · path · deserialization | Beta |
+| C# | ASP.NET Core, ADO.NET | SQL · command · path · deserialization · code-execution (incl. string interpolation) | Beta |
+
+Assurance is **not** uniform across the five. Python carries the strongest validated coverage —
+it is the only language held to a labelled precision/recall/abstention benchmark
+(`benchmark/run_precision.py`) that gates every change. The other four grade sink arguments in
+the same shape (below) and are **Beta** until each earns its own labelled benchmark; the docs and
+UI say so rather than implying identical assurance.
 
 **Verdict-grade vs inventory-grade.** A verdict-grade class grades the sink argument
 SAFE/UNSAFE/UNKNOWN. Any language or sink class not yet upgraded is **inventory-grade**: a

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,333 @@
+# CyberGraph — Features & Capabilities
+
+A detailed reference to what CyberGraph is, what it does, and how each piece works. For the
+short pitch see the [README](../README.md); for architecture internals see
+[architecture.md](architecture.md).
+
+---
+
+## 1. What CyberGraph is
+
+CyberGraph is an **offline security verifier and monitor for code changes**. Its headline job is
+simple: given a change to a repository, decide whether it is safe to ship and return a single
+verdict — **ACCEPT** (the checks that ran found nothing) or **REVIEW** (a human should look) —
+with cited evidence and an explicit list of what could not be checked.
+
+It does this **deterministically and entirely offline**: no API keys, no signup, no network
+calls, no runtime dependencies, and — critically — **no LLM tokens**. A large language model is
+optional and only ever rephrases answers the graph has already grounded in evidence; nothing
+about the analysis or the verdict requires one.
+
+Underneath, CyberGraph parses a repository into a **cybersecurity knowledge graph** — functions,
+routes, guards, sinks, secrets, cloud resources, and the edges between them (calls, user-input
+flow, reaches-sink, uses/exposes-secret). That graph is the engine that makes the verdicts
+precise. It is not the pitch; the verdict is.
+
+### Why it saves tokens
+
+AI coding agents now write a large and growing share of code, and each change can introduce a
+vulnerability. The common way to guard that — asking an LLM to re-review every change — spends
+tokens on every turn, is nondeterministic, and gets slower and costlier as the codebase and the
+change rate grow. CyberGraph moves that verification **off the token meter**:
+
+- **The verdict is free and instant.** A deterministic graph-and-rules check costs no tokens and
+  runs in seconds, so you can gate every commit and every agent turn without weighing the cost.
+- **It catches regressions at the cheapest moment** — as the change is made — instead of after
+  tokens have been spent building on top of an insecure change, or after it reaches production.
+- **It keeps the LLM on the work only an LLM can do.** When a model *is* in the loop, CyberGraph
+  narrows it to grounded evidence (cited findings, reachable paths), so you are not paying for a
+  model to re-derive what a graph already knows.
+
+The net effect is indirect but real: security review shifts from a recurring per-change token
+cost to a free, repeatable, local gate.
+
+---
+
+## 2. The verdict engine
+
+### ACCEPT / REVIEW, and the honesty gate
+
+`cybergraph check` compares the current state of a repo against a base ref
+(`--mode merge-base|worktree|range`) and reports:
+
+- **`accept`** — every capability that was in scope ran and found nothing.
+- **`review`** — a check failed, or a relevant capability could not run (a blind spot), or a
+  change touched a declared security boundary.
+- **`not_evaluated`** — an explicit list of what CyberGraph could *not* check on this change.
+
+It never turns "did not look" into a pass. A capability passes only when there is **positive
+evidence** it was analyzed. This is the product's core credibility claim: for a verification
+tool, a false ACCEPT is worse than a false positive.
+
+### The five capability states
+
+Every capability reports one of five states — the distinctions between the last three carry the
+product's credibility:
+
+| State | Meaning |
+|---|---|
+| `PASS` | the check ran on this change and found nothing |
+| `FAIL` | the check ran and found something |
+| `NOT_APPLICABLE` | supported, but nothing in this change is in its scope |
+| `UNKNOWN` | supported, but it could not run here (a blind spot) |
+| `NOT_SUPPORTED` | the capability does not exist yet for this language/surface |
+
+`NOT_APPLICABLE` and `NOT_SUPPORTED` look alike and are not: a README-only change is
+NOT_APPLICABLE everywhere and can honestly ACCEPT, while a change to a language with no analyzer
+is NOT_SUPPORTED and forces REVIEW — accepting there would be false assurance. Coverage is
+*declared*, never inferred: each capability states the file globs it claims, so the tool cannot
+silently imply coverage it does not have.
+
+### The cardinal rule: only literals are SAFE
+
+The injection verdicts (SQL, command, path, code-execution, deserialization) are decided by a
+per-language **construction classifier** working with intra-function **taint**:
+
+- A sink argument that is a **provably all-literal / constant** construction reads **SAFE**.
+- A construction containing a **variable** reads **UNSAFE** when taint confirms the variable is
+  attacker-influenced, and **UNKNOWN** otherwise.
+- Native **deserialization** is never provably SAFE from construction alone.
+- Anything the classifier cannot read (an unbalanced string, an opaque call, an unmodelled
+  construct) is **UNKNOWN**, never SAFE.
+
+**Uncertainty never becomes safety.** When the tool is unsure it emits a `-UNVERIFIED` finding
+(which drives REVIEW) rather than a false ACCEPT. The classifier is a positive-literal-proof: it
+must *prove* the whole argument is literal to say SAFE; absent that proof, the value is treated
+as non-literal.
+
+This precision is why a verdict is trustworthy enough to gate on. It is computed from
+construction provenance — `"SELECT ... " + userId` is UNSAFE, `String.format`/interpolation with
+a variable hole is UNSAFE, an all-literal `"SELECT 1"` is SAFE — not from a keyword match.
+
+---
+
+## 3. Languages & coverage
+
+CyberGraph analyzes **five languages** through a shared analyzer contract, with graceful
+fallback for the rest.
+
+| Language | Frameworks understood | Verdict grade |
+|---|---|---|
+| Python | FastAPI, Flask, Django | **Verdict-grade** — exact-match sink registry + per-sink taint predicates; the only language in the labelled precision/recall benchmark |
+| JavaScript / TypeScript | Express, Next.js | **Verdict-grade** — SQL / command / code-exec / path |
+| Go | net/http, Gin, Echo | **Verdict-grade** — SQL / command / path (no code-exec sink in Go) |
+| Java | Spring, JDBC | **Verdict-grade** — SQL / command / path / deserialization |
+| C# | ASP.NET Core, ADO.NET | **Verdict-grade** — SQL / command / path / deserialization / code-execution (incl. string interpolation) |
+
+**Verdict-grade vs inventory-grade.** A verdict-grade class grades the sink argument
+SAFE/UNSAFE/UNKNOWN. Any language or sink class not yet upgraded is **inventory-grade**: a
+`*-SINK-CALL` row that marks "a sensitive sink is used here" — a map of where sensitive calls
+live, not a confirmed verdict. CI's SARIF export filters inventory rules out of code-scanning
+uploads (so they don't manufacture alert fatigue); graded verdict rules are never filtered.
+
+**The honesty invariant.** Verdict-grade detection is a structural, line-based classifier — not
+a full parse tree. So each non-Python language stays `NOT_SUPPORTED` for the
+`source_analysis_support` capability (whole-file "CyberGraph can fully read this language")
+even while its injection capabilities are graded. `VERIFIED_GLOBS` (the set that claims full
+source analysis) remains Python-only by design. An unreadable or unparseable file always reads
+UNKNOWN/FAILED, never PASS.
+
+---
+
+## 4. Automatic verification — hooks
+
+`cybergraph check` verifies a change, but something has to invoke it. Hooks make it fire on its
+own at the moment code is accepted:
+
+```bash
+cybergraph hook install claude-code    # runs when an AI agent turn ends (Stop hook)
+cybergraph hook install pre-commit      # runs before each commit (the staged index)
+cybergraph hook status                  # what's installed
+cybergraph hook uninstall pre-commit
+```
+
+- **Advisory by default:** a REVIEW is *surfaced, not blocking* — the commit proceeds, the agent
+  continues, and the verdict is reported.
+- **`--strict` opts into blocking:** a REVIEW becomes a non-zero pre-commit exit, or a Claude
+  Code stop-block the agent must resolve before finishing.
+- Installing over an existing pre-commit hook is refused unless you pass `--force` (which backs
+  up the old hook first).
+
+The hook is what closes the loop for AI-generated code: the verdict runs on **every** agent turn
+or commit regardless of whether the agent chooses to check itself.
+
+---
+
+## 5. The knowledge graph
+
+CyberGraph builds a local SQLite graph in `.cybergraph/graph.db` typed with security semantics.
+
+- **Nodes:** functions, routes/entrypoints, auth/authz guards, validators, sensitive sinks,
+  secrets, cloud resources, dependencies.
+- **Edges:** `CALLS` → `CALLS_RESOLVED` (cross-file, confidence-tagged), user-input/data-flow,
+  `REACHES_SINK`, `USES_SECRET` → `EXPOSES_SECRET`, and IaC-to-code references.
+- **Attack paths:** a BFS from entrypoints to sinks over resolved calls produces
+  interprocedural, route → service → repository → sink paths, each with confidence,
+  sanitizer-barrier flags, taint/data-reachability, a risk score, and fix guidance. A
+  `--shallow` mode reproduces intra-function traversal for comparison.
+- **Resolution honesty:** cross-file call resolution degrades to `low` confidence with
+  `ambiguous: true` rather than asserting certainty.
+
+This is what lets CyberGraph answer *reachability* — not "a dangerous call exists" but "user
+input can reach this dangerous call from this route with no guard in between."
+
+---
+
+## 6. Security policy
+
+CyberGraph verifies against a **declared security policy** — the routes/functions expected to
+require authentication, ownership checks, or other guards — kept as a committed
+`cybergraph.policy.toml`.
+
+```bash
+cybergraph check . --init-policy    # bootstrap the policy from routes that already require login
+cybergraph policy --repo .          # show the declared policy and what it protects
+cybergraph policy --repo . --baseline
+```
+
+Because the policy is a plain committed TOML file, any human or agent working in the repo can
+read what CyberGraph expects to be protected without running the tool. A change that silently
+drops a guard the policy declares is what turns an ACCEPT into a REVIEW.
+
+---
+
+## 7. Findings, suppressions & honesty
+
+- **`-UNVERIFIED` variants:** when CyberGraph can see a value reach a sink but cannot confirm how
+  it was built, it reports the `-UNVERIFIED` variant (e.g. `CG-SQL-EXEC-UNVERIFIED`) — an
+  explicit abstention that drives REVIEW, never a confident claim.
+- **Inline suppressions:** `# cybergraph: ignore CG-SQL-EXEC <reason>` on the sink line. Naming a
+  rule also accepts its `-UNVERIFIED` variant; the reverse is deliberately not true.
+- **Repository suppressions:** `[suppressions] rules = [...]` / `paths = [...]` in config.
+- **Suppressed ≠ fixed:** suppressions hide findings, but the graph keeps the edges
+  (`REACHES_SINK`) so reviewers can still inspect the path. A finding that disappears because a
+  suppression now covers it is counted as *hidden by config (hidden, not fixed)* in history, the
+  delta strip, and the report — its history row stays open, so dropping the suppression later
+  reads as persisting, not as a regression. A finding that disappears because the code changed is
+  counted as fixed. Suppressed attack paths never consume a slot a real one needs on any capped
+  surface (report, export, LLM evidence).
+
+---
+
+## 8. Interoperability
+
+CyberGraph positions as a hub, not just another scanner:
+
+- **Imports:** OSV Scanner, npm audit, Semgrep JSON, SARIF, Gitleaks — all into the same graph.
+- **Exports:** SARIF out (for GitHub code scanning), JSON graph export, BloodHound OpenGraph.
+- **Enrichment:** offline EPSS / KEV / CVSS / advisory JSON.
+- **AI pentester bridge (Strix):** `cybergraph strix-plan` turns reachable paths into a focused
+  scope brief; Strix validates what's actually exploitable with a working PoC;
+  `cybergraph import-strix` feeds PoC-validated findings back so they rank at the top. Strix is
+  never a dependency — the bridge only activates when the `strix` binary and Docker are both
+  present, so the offline-by-default workflow is unchanged.
+- **MCP tools:** an interoperability surface for AI assistants (see §12). Not a gate — the hook
+  (§4) is the gate.
+
+---
+
+## 9. Dependency reachability (SCA)
+
+`cybergraph sca` prioritizes dependency CVEs by **reachability** — is the vulnerable code
+actually reachable from production routes, or merely present in a lockfile? It maps dependency
+manifests and lockfiles across npm, Python, Go, Maven/Gradle, and .NET ecosystems, and connects
+a CVE to the routes and sinks that can reach it, so the ranking reflects real risk rather than
+raw CVE counts.
+
+---
+
+## 10. Cloud & IaC correlation
+
+`cybergraph cloud-code` / `iac-paths` correlate Terraform resources to the application code that
+references them, so **public cloud exposure can be connected to reachable routes, sinks, and
+dependency risk** — e.g. a public bucket or an over-privileged IAM role reachable from an
+internet-facing route. Config posture is checked too: open Firebase security rules, Supabase
+tables with row-level security off, and public S3/GCS bucket policies — a change that weakens one
+is a REVIEW.
+
+---
+
+## 11. Reporting
+
+`cybergraph visualize` produces a single self-contained, offline HTML file (Cytoscape.js, fully
+inlined — no CDN, no network):
+
+- **Dark-mode-first neon graph explorer** with a light/dark toggle and security-typed, glowing
+  nodes.
+- **Guided first view** that opens on the top attack path with a plain-language narrative.
+- **Security-zones view:** Attack Surface → Guards → Logic → Sensitive Sinks.
+- **Exec-first posture:** an A–F security grade, a one-line verdict, a severity-distribution bar,
+  a since-last-scan delta strip (new / regressed / fixed), findings grouped into expandable rule
+  cards, an honest findings-cap footer, and a print stylesheet for clean PDF export.
+- Search, layer/severity filters, a details panel with source drill-down, and entrypoint→sink
+  path highlighting.
+
+---
+
+## 12. Evidence & answers
+
+- **Grounded answers** (`cybergraph explain`): file/line/rule/path citations, attack-path
+  narratives, remediation guidance, and a high/medium/low/insufficient confidence level. It never
+  claims a vulnerability without supporting evidence and **abstains** (returns
+  `CONFIDENCE_INSUFFICIENT`) rather than fabricate — and works with no LLM at all.
+- **Faithfulness-checked triage:** `cybergraph triage --llm` can suppress a finding only on a
+  false-positive verdict whose cited evidence appears verbatim in the supplied code slice — a
+  faithfulness check, not a trust-the-model check.
+- **Optional, local-only LLM phrasing** via configurable providers (Anthropic Claude, OpenAI,
+  Kimi), constrained to retrieved evidence.
+- **MCP tools** for AI coding assistants: `build_security_graph_tool`,
+  `query_security_graph_tool`, `explain_attack_path_tool`, `grounded_security_answer_tool`,
+  `analyze_repo_tool`, `top_risks_tool`, `secret_exposures_tool`,
+  `prioritize_dependencies_tool`, `iac_attack_paths_tool`, `import_scanner_report_tool`,
+  `import_vulnerabilities_tool`, and `check_change_tool` (mirrors `cybergraph check --json`).
+
+---
+
+## 13. Trust & deployment
+
+- **Zero runtime dependencies** (`dependencies = []`) and fully offline — installable in
+  regulated environments (finance, defence, health) where network-reaching tooling cannot go.
+- **Your code never leaves your machine.**
+- **CI is fork-safe and least-privilege:** untrusted PR code runs with `contents: read` only; the
+  PR comment is posted by a separate `workflow_run` job from the default branch. The
+  `cybergraph check` step runs on every PR as a non-gating notification until the field
+  false-positive rate is measured.
+- Python 3.10 – 3.13; ruff-linted; a labelled precision/recall/abstention benchmark and a
+  mutation harness that proves the verdicts can actually fail (every seeded fail-open is caught).
+
+---
+
+## 14. Command reference (selected)
+
+```text
+cybergraph quickstart .        # zero-to-report: init, build, analyze, open report
+cybergraph check .             # ACCEPT/REVIEW verdict for a change (the core command)
+cybergraph hook install ...    # run check automatically on commit / agent turn
+cybergraph policy --repo .     # show the declared security policy
+cybergraph analyze .           # build + run every analysis, print top risks
+cybergraph history .           # what's new / fixed / regressed / hidden-by-config since last scan
+cybergraph visualize .         # interactive offline HTML report
+cybergraph explain "..."       # evidence-cited, confidence-scored answer
+cybergraph paths / layers / secrets / cloud-code / top-risks
+cybergraph scan / triage / sca / iac-paths / infer-specs
+cybergraph review --base main  # PR-style diff verdict
+cybergraph sarif / export-json / opengraph      # exports
+cybergraph import-report / import-vulns / enrich-vulns / import-strix   # imports
+```
+
+---
+
+## 15. Status & roadmap
+
+**Beta.** Stable: the graph store, the five-language analyzers, evidence retrieval, and the HTML
+report. The verdict layer is verdict-grade for Python, JavaScript/TypeScript, Go, and Java, with
+C# landing in the same shape. The public API and finding rules may still change before 1.0.
+
+Known, documented follow-ups (all fail-safe — they under-claim, never issue a false ACCEPT):
+
+- Sinks configured via property assignment rather than call arguments (e.g. a command or query
+  string assigned to a property, then executed) are not yet traced across the assignment.
+- Some broad bare-name matches over-flag to `-UNVERIFIED` (REVIEW) rather than resolving
+  precisely — conservative noise, never a missed vulnerability.
+- Verdict coverage continues to widen: more sink classes per language, and receiver-type
+  precision for cases currently handled conservatively.


### PR DESCRIPTION
Repositions the README around the product's real wedge — **independent, offline verification of AI-written code** — and adds a detailed `docs/features.md` capability reference. Docs only; no code changes.

## README
- **New hero: "AI writes. CyberGraph verifies."** Opens on the tension (should the same AI be the only thing reviewing its own change?) and the independence angle. The knowledge graph is framed as the engine, not the pitch.
- **Differentiation:** *No cloud upload · No mandatory LLM · No per-check token cost · No silent blind spots*, plus the `AI writes → CyberGraph checks → ACCEPT/REVIEW → shows why` flow.
- **"Uncertainty never becomes safety"** stated as a principle.
- **Language-coverage table** — Python (labelled benchmark ✓) vs JS/TS, Go, Java, C# (Beta) — so the docs never imply uniform assurance.
- Fixed stale content the rewrite surfaced: languages section (was "Python only"), MCP section (hooks now exist, not "future work"), Phase-1 contract ("Python change" → "code change").

## Claims tightened (epistemic contract)
- **Removed "safe to ship"** — ACCEPT is preservation of the guarantees CyberGraph can verify, **not** a security certification.
- **"free and instant" → "no per-check LLM/API cost"** (wall-clock varies with repo size / graph rebuild / SCA — explicitly noted).
- **Zero-token stated as a property, not a measured savings figure** — any "X% fewer tokens" needs an end-to-end benchmark (called out as future work).

## docs/features.md
15-section reference: verdict engine (ACCEPT/REVIEW, five capability states, the cardinal "only literals are SAFE" rule), zero-token/independence rationale, per-language coverage + validation status, hooks, the graph + attack paths, policy, findings/suppressions (hidden≠fixed), interoperability, SCA reachability, IaC correlation, the HTML report, evidence/grounded answers, trust/deployment, command reference, status/roadmap. Kept as a *reference* (the README top is the ~10%); no unbuilt/aspirational features asserted as shipped.

## Stacking
Based on `feat/csharp-verdicts` (#54), because the coverage claims include C# verdicts which live there, not yet on `main`. After #54 merges, rebase onto `main` and retarget this PR to `main`.