### PR TITLE
chore: gitignore internal/ (non-public notes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ build/
 # be checked against a committed artifact is the failure this project exists to
 # avoid. Regenerate with `python benchmark/run_eval.py` and
 # `python benchmark/run_precision.py`.
+
+# Internal, non-public notes (strategy, GTM) — never commit
+internal/


### PR DESCRIPTION
Adds `internal/` to `.gitignore` so a local, non-public notes directory (strategy / GTM working docs) is never committed or pushed. One-line ignore rule; touches only `.gitignore`.